### PR TITLE
fix: RAF race condition, agent null guards, README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Agent Virtual Office
+
+> AI Agent 團隊的辦公室模擬器 — 他們不只在跑 code，他們在**上班**。
+
+## 專案結構
+
+```
+virtual-office/    # 主要應用程式（React + Vite）
+deploy_brain.*     # AgentCortex 部署腳本（sh / ps1 / cmd）
+```
+
+## 快速開始
+
+```bash
+cd virtual-office
+npm install
+npm run dev
+```
+
+詳細說明請見 [virtual-office/README.md](virtual-office/README.md)。

--- a/virtual-office/README.md
+++ b/virtual-office/README.md
@@ -97,7 +97,6 @@ virtual-office/
 │   └── config/
 │       ├── characters.json       # 角色定義
 │       └── officeEvents.json     # 事件池 + 對話訊息庫
-├── CLAUDE.md                     # Claude Code 專案指引
 ├── DESIGN_SPEC.md                # 視覺 + 行為完整規格
 └── ARCHITECTURE.md               # 技術架構文檔
 ```

--- a/virtual-office/src/components/AgentCharacter.jsx
+++ b/virtual-office/src/components/AgentCharacter.jsx
@@ -572,6 +572,7 @@ export default function AgentCharacter({ agent }) {
   const targetPosRef = useRef(null)
   const rafRef = useRef(null)
   const lastTimeRef = useRef(null)
+  const isUnmountedRef = useRef(false)
   const [renderPos, setRenderPos] = useState(null)
   const [isWalking, setIsWalking] = useState(false)
   // Use refs for callbacks accessed inside RAF to avoid stale closures
@@ -601,7 +602,7 @@ export default function AgentCharacter({ agent }) {
     lastTimeRef.current = null
 
     const animate = (timestamp) => {
-      if (!visualPosRef.current || !targetPosRef.current) {
+      if (isUnmountedRef.current || !visualPosRef.current || !targetPosRef.current) {
         rafRef.current = null
         return
       }
@@ -645,8 +646,13 @@ export default function AgentCharacter({ agent }) {
 
   // Cleanup RAF on unmount
   useEffect(() => {
+    isUnmountedRef.current = false
     return () => {
-      if (rafRef.current) cancelAnimationFrame(rafRef.current)
+      isUnmountedRef.current = true
+      if (rafRef.current) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
     }
   }, [])
 

--- a/virtual-office/src/systems/officeLife.js
+++ b/virtual-office/src/systems/officeLife.js
@@ -130,7 +130,9 @@ const EVENT_HANDLERS = {
 
   'eureka': (store, participants) => {
     // Architect has a eureka moment, runs to whiteboard
-    store.getState().setAgentGroupEvent('arch', {
+    const s = store.getState()
+    if (!s.agents['arch']) return
+    s.setAgentGroupEvent('arch', {
       behavior: 'whiteboard',
       expression: 'surprised',
       bubble: '有了！💡',
@@ -140,17 +142,19 @@ const EVENT_HANDLERS = {
 
   'review-debate': (store, participants) => {
     // Dev and QA face off
+    const s = store.getState()
+    if (!s.agents['dev'] || !s.agents['qa']) return
     const devPos = HOME_POSITIONS.dev || { x: 340, y: 364 }
     const qaPos = HOME_POSITIONS.qa || { x: 400, y: 244 }
     const meetPoint = { x: (devPos.x + qaPos.x) / 2, y: (devPos.y + qaPos.y) / 2 }
 
-    store.getState().setAgentGroupEvent('dev', {
+    s.setAgentGroupEvent('dev', {
       behavior: 'chat',
       expression: 'focused',
       bubble: '這沒bug啊！',
       groupTarget: jitter({ x: meetPoint.x - 20, y: meetPoint.y }, 8),
     })
-    store.getState().setAgentGroupEvent('qa', {
+    s.setAgentGroupEvent('qa', {
       behavior: 'chat',
       expression: 'confused',
       bubble: '明明就有！',
@@ -171,7 +175,9 @@ const EVENT_HANDLERS = {
 
   'deploy-success': (store, participants) => {
     // Ops presses the button, everyone celebrates
-    store.getState().setAgentGroupEvent('ops', {
+    const s = store.getState()
+    if (!s.agents['ops']) return
+    s.setAgentGroupEvent('ops', {
       behavior: 'deploy-button',
       expression: 'happy',
       bubble: '部署成功！🚀',


### PR DESCRIPTION
## Summary
- **AgentCharacter.jsx**: Fix RAF cleanup race condition — added `isUnmountedRef` to prevent dangling animation loops after component unmount
- **officeLife.js**: Add null checks for hardcoded agent IDs (`arch`, `dev`, `qa`, `ops`) in group event handlers (`eureka`, `review-debate`, `deploy-success`), preventing silent failures if agents are missing
- **README.md** (root): Add root-level README so GitHub repo page isn't blank
- **virtual-office/README.md**: Remove reference to non-existent `CLAUDE.md` in architecture tree

## Test plan
- [ ] `npm run dev` still launches without errors
- [ ] Agents walk and animate normally (RAF fix doesn't break movement)
- [ ] Group events (`eureka`, `review-debate`, `deploy-success`) still trigger correctly
- [ ] Rapidly switching views or unmounting components doesn't cause frame rate degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)