### PR TITLE
fix: address all audit findings (HIGH/MEDIUM/LOW)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
   "dependencies": {
     "framer-motion": "^12.37.0",
     "react": "^19.2.4",

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -744,8 +744,11 @@ export default function AgentCharacter({ agent }) {
           store.addHandoff(id, targetId)
           setTimeout(() => {
             const s = useOfficeStore.getState()
-            s.setAgentBehavior(targetId, 'reading-screen', 'normal', '收到!')
-            setTimeout(() => s.clearBubble(targetId), 3000)
+            // Only set behavior if target is not locked in a group event
+            if (!s.agents[targetId]?.inGroupEvent) {
+              s.setAgentBehavior(targetId, 'reading-screen', 'normal', '收到!')
+              setTimeout(() => s.clearBubble(targetId), 3000)
+            }
           }, 1500)
         }
       }

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import { useOfficeStore } from '../systems/store'
 import { startOfficeLife } from '../systems/officeLife'
+import { inferFromParams, listenForVibeUpdates } from '../inference/inferStatus'
 import AgentCharacter from './AgentCharacter'
 import {
   Desk, Bookshelf, Plant, Couch, RoundTable, MeetingTable,
@@ -206,6 +207,27 @@ export default function PixelOffice({ animationQuality = 'full' }) {
   useEffect(() => {
     const cleanup = startOfficeLife(useOfficeStore)
     return cleanup
+  }, [])
+
+  // Wire AgentCortex status inference (URL params + postMessage)
+  useEffect(() => {
+    const applyInference = (info) => {
+      if (!info) return
+      if (info.activeAgent) {
+        useOfficeStore.setState((s) => {
+          if (!s.agents[info.activeAgent]) return s
+          return {
+            agents: {
+              ...s.agents,
+              [info.activeAgent]: { ...s.agents[info.activeAgent], status: 'working' },
+            },
+          }
+        })
+      }
+    }
+    applyInference(inferFromParams())
+    const unlisten = listenForVibeUpdates(applyInference)
+    return unlisten
   }, [])
 
   const agentList = sortByY(Object.values(agents))
@@ -431,8 +453,8 @@ export default function PixelOffice({ animationQuality = 'full' }) {
         <AgentCharacter key={agent.id} agent={agent} />
       ))}
 
-      {/* ═══ FLYING DOCUMENTS (handoff animation) ═══ */}
-      <FlyingDocuments />
+      {/* ═══ FLYING DOCUMENTS (handoff animation) — skip on light quality ═══ */}
+      {animationQuality !== 'light' && <FlyingDocuments />}
 
       {/* ═══ LIGHTING ═══ */}
       {lightOverlay.opacity > 0 && (
@@ -440,8 +462,8 @@ export default function PixelOffice({ animationQuality = 'full' }) {
           fill={lightOverlay.fill} opacity={lightOverlay.opacity} pointerEvents="none" />
       )}
 
-      {/* Night screen glow */}
-      {hour >= 19 && deskData.map((d) => (
+      {/* Night screen glow — only on full quality (radialGradient is GPU-heavy) */}
+      {animationQuality === 'full' && hour >= 19 && deskData.map((d) => (
         <g key={`glow-${d.id}`}>
           <radialGradient id={`glow-${d.id}`} cx="50%" cy="50%" r="50%">
             <stop offset="0%" stopColor="#4af" stopOpacity="0.08" />

--- a/src/systems/officeLife.js
+++ b/src/systems/officeLife.js
@@ -4,9 +4,6 @@ import { WAYPOINTS, MEETING_CHAIRS, HOME_POSITIONS } from './movementSystem'
 const DAILY_INTERVAL = [60000, 180000]   // 1-3 min (group events happen often enough to see)
 const RARE_INTERVAL = [300000, 600000]   // 5-10 min
 
-let dailyTimer = null
-let rareTimer = null
-
 function randomInterval(range) {
   return range[0] + Math.random() * (range[1] - range[0])
 }
@@ -39,8 +36,9 @@ function pickParticipants(event, agents) {
 
 // ─── Event handlers: each sets visual states for participants ────────
 
+// All handlers receive (store, participants, cancelled) where cancelled = { value: bool }
 const EVENT_HANDLERS = {
-  'tea-break': (store, participants) => {
+  'tea-break': (store, participants, _cancelled) => {
     // 2-3 people walk to coffee area and chat
     const coffeeSpots = [
       { x: 80, y: 475 }, { x: 110, y: 485 }, { x: 140, y: 470 },
@@ -56,7 +54,7 @@ const EVENT_HANDLERS = {
     })
   },
 
-  'standup': (store, participants) => {
+  'standup': (store, participants, cancelled) => {
     // Everyone gathers at whiteboard area
     const whiteboardSpots = [
       { x: 530, y: 355 }, { x: 550, y: 370 }, { x: 570, y: 355 },
@@ -74,6 +72,7 @@ const EVENT_HANDLERS = {
     })
     // After a few seconds, more bubbles appear
     setTimeout(() => {
+      if (cancelled.value) return
       const s = store.getState()
       const ids = participants.filter(id => s.agents[id]?.inGroupEvent)
       if (ids.length >= 2) {
@@ -82,7 +81,7 @@ const EVENT_HANDLERS = {
     }, 8000)
   },
 
-  'food-delivery': (store, participants) => {
+  'food-delivery': (store, participants, cancelled) => {
     // Everyone gets happy, one person "brings food"
     const bringer = participants[0]
     store.getState().setAgentGroupEvent(bringer, {
@@ -93,17 +92,18 @@ const EVENT_HANDLERS = {
     })
     // Others react with happy expressions at their desks
     setTimeout(() => {
+      if (cancelled.value) return
       participants.slice(1).forEach((id) => {
         const s = store.getState()
         if (s.agents[id]) {
           s.setAgentBehavior(id, 'eat-snack', 'happy', '讚！吃飯！')
-          setTimeout(() => s.clearBubble(id), 4000)
+          setTimeout(() => { if (!cancelled.value) s.clearBubble(id) }, 4000)
         }
       })
     }, 2000)
   },
 
-  'coffee-spill': (store, participants) => {
+  'coffee-spill': (store, participants, cancelled) => {
     // One person spills, neighbor helps
     const spiller = participants[0]
     store.getState().setAgentGroupEvent(spiller, {
@@ -114,6 +114,7 @@ const EVENT_HANDLERS = {
     })
     if (participants[1]) {
       setTimeout(() => {
+        if (cancelled.value) return
         const s = store.getState()
         const spillerPos = s.agents[spiller]?.position
         if (spillerPos) {
@@ -128,7 +129,7 @@ const EVENT_HANDLERS = {
     }
   },
 
-  'eureka': (store, participants) => {
+  'eureka': (store, participants, _cancelled) => {
     // Architect has a eureka moment, runs to whiteboard
     const s = store.getState()
     if (!s.agents['arch']) return
@@ -140,7 +141,7 @@ const EVENT_HANDLERS = {
     })
   },
 
-  'review-debate': (store, participants) => {
+  'review-debate': (store, participants, cancelled) => {
     // Dev and QA face off
     const s = store.getState()
     if (!s.agents['dev'] || !s.agents['qa']) return
@@ -162,18 +163,20 @@ const EVENT_HANDLERS = {
     })
     // Back and forth
     setTimeout(() => {
+      if (cancelled.value) return
       const s = store.getState()
       if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'chat', 'confused', '...讓我看看')
       if (s.agents.qa?.inGroupEvent) s.setAgentBehavior('qa', 'magnifier', 'focused', '你看這裡')
     }, 6000)
     setTimeout(() => {
+      if (cancelled.value) return
       const s = store.getState()
       if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'typing', 'normal', '好吧修了')
       if (s.agents.qa?.inGroupEvent) s.setAgentBehavior('qa', 'thumbs-up', 'happy', '讚')
     }, 12000)
   },
 
-  'deploy-success': (store, participants) => {
+  'deploy-success': (store, participants, cancelled) => {
     // Ops presses the button, everyone celebrates
     const s = store.getState()
     if (!s.agents['ops']) return
@@ -184,31 +187,33 @@ const EVENT_HANDLERS = {
       groupTarget: null,
     })
     setTimeout(() => {
+      if (cancelled.value) return
       participants.filter(id => id !== 'ops').forEach((id, i) => {
         const s = store.getState()
         if (s.agents[id]) {
           const celebBubbles = ['🎉 耶！', '太好了！', '終於...', '慶祝！', '下班！', '完美~']
           s.setAgentBehavior(id, 'thumbs-up', 'happy', celebBubbles[i % celebBubbles.length])
-          setTimeout(() => s.clearBubble(id), 5000)
+          setTimeout(() => { if (!cancelled.value) s.clearBubble(id) }, 5000)
         }
       })
     }, 2000)
   },
 
   // Group meeting — 3 people go to meeting room
-  'group-meeting': (store, participants) => {
+  'group-meeting': (store, participants, cancelled) => {
     const chairs = [...MEETING_CHAIRS].sort(() => Math.random() - 0.5)
     const bubbles = ['開會囉', '來了來了', '又開會...']
     participants.forEach((id, i) => {
       store.getState().setAgentGroupEvent(id, {
         behavior: 'meeting',
-        expression: i === 0 ? 'normal' : 'normal',
+        expression: 'normal',
         bubble: bubbles[i % bubbles.length],
         groupTarget: jitter(chairs[i % chairs.length], 6),
       })
     })
     // Discussion bubbles mid-meeting
     setTimeout(() => {
+      if (cancelled.value) return
       const s = store.getState()
       const active = participants.filter(id => s.agents[id]?.inGroupEvent)
       if (active.length > 0) s.setAgentBehavior(active[0], 'meeting', 'focused', '所以方向是...')
@@ -217,13 +222,14 @@ const EVENT_HANDLERS = {
   },
 }
 
-function executeEvent(store, event, participants) {
+function executeEvent(store, event, participants, cancelled) {
   const handler = EVENT_HANDLERS[event.id]
   if (handler) {
-    handler(store, participants)
+    handler(store, participants, cancelled)
 
     // Clean up after event duration — release all participants
     setTimeout(() => {
+      if (cancelled.value) return
       const s = store.getState()
       participants.forEach((id) => {
         if (s.agents[id]?.inGroupEvent) {
@@ -237,8 +243,15 @@ function executeEvent(store, event, participants) {
 }
 
 export function startOfficeLife(store) {
+  // Keep timer refs local to this invocation so cleanup is exact
+  let dailyTimer = null
+  let rareTimer = null
+  // Shared cancellation flag — prevents stale event-cleanup callbacks from firing after stop()
+  const cancelled = { value: false }
+
   const scheduleDaily = () => {
     dailyTimer = setTimeout(() => {
+      if (cancelled.value) return
       const state = store.getState()
       if (!state.isPaused && !state.activeEvent) {
         const pool = eventsData.daily
@@ -246,7 +259,7 @@ export function startOfficeLife(store) {
         const participants = pickParticipants(event, state.agents)
 
         store.getState().setActiveEvent(event)
-        executeEvent(store, event, participants)
+        executeEvent(store, event, participants, cancelled)
       }
       scheduleDaily()
     }, randomInterval(DAILY_INTERVAL))
@@ -254,6 +267,7 @@ export function startOfficeLife(store) {
 
   const scheduleRare = () => {
     rareTimer = setTimeout(() => {
+      if (cancelled.value) return
       const state = store.getState()
       if (!state.isPaused && !state.activeEvent) {
         const pool = eventsData.rare
@@ -261,7 +275,7 @@ export function startOfficeLife(store) {
         const participants = pickParticipants(event, state.agents)
 
         store.getState().setActiveEvent(event)
-        executeEvent(store, event, participants)
+        executeEvent(store, event, participants, cancelled)
       }
       scheduleRare()
     }, randomInterval(RARE_INTERVAL))
@@ -276,6 +290,7 @@ export function startOfficeLife(store) {
   }, 60000)
 
   return () => {
+    cancelled.value = true
     clearTimeout(dailyTimer)
     clearTimeout(rareTimer)
     clearInterval(timeInterval)

--- a/src/systems/platformDetect.js
+++ b/src/systems/platformDetect.js
@@ -27,7 +27,8 @@ export function detectPlatform() {
     // Check if we're in an iframe (artifact mode)
     try {
       if (window.parent !== window && window.parent.document) {
-        // Same-origin iframe — likely dev
+        // Same-origin iframe (e.g. dev preview) — treat as embedded
+        return 'embedded'
       }
     } catch {
       // Cross-origin iframe — likely artifact or embedded

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -1,8 +1,12 @@
 import { create } from 'zustand'
 import characters from '../config/characters.json'
 import { HOME_POSITIONS } from './movementSystem'
+import { detectProjectMode } from './platformDetect'
 
-const detectMode = () => 'agentcortex'
+const detectMode = () => {
+  if (typeof window === 'undefined') return 'agentcortex'
+  return detectProjectMode()
+}
 
 const initAgents = (mode) => {
   const roster = characters[mode] || characters.agentcortex


### PR DESCRIPTION
## Summary

Fixes all issues identified in `/review` audit pass.

### 🔴 HIGH
- **`platformDetect.js`** — same-origin iframe try-success path now explicitly returns `'embedded'` instead of silently falling through to `'browser'`
- **`officeLife.js`** — move `dailyTimer`/`rareTimer` refs inside `startOfficeLife()` so React StrictMode double-mount / HMR don't create duplicate running timers
- **`officeLife.js`** — add `cancelled` flag threaded through all nested `setTimeout` callbacks; stale closures from stopped office sessions can no longer write to the store

### 🟡 MEDIUM
- **`AgentCharacter.jsx`** — handoff `setAgentBehavior` now guards against `inGroupEvent` so `officeLife`-controlled agent state isn't overwritten mid-event
- **`store.js`** — replace hardcoded `detectMode = () => 'agentcortex'` with real `detectProjectMode()` from platformDetect (with `window` undefined guard)
- **`PixelOffice.jsx`** — wire `inferFromParams` + `listenForVibeUpdates` so AgentCortex URL params and postMessage actually reach agent status; gate `FlyingDocuments` behind `animationQuality !== 'light'` and night glow behind `animationQuality === 'full'`

### 🟢 LOW
- **`package.json`** — remove `"type": "commonjs"` which conflicts with the ESM-only source

## Test plan
- [ ] `npm run dev` — office loads, agents walk and animate
- [ ] Visit `?platform=embedded` — ControlPanel hidden, `embedded` config applied
- [ ] Visit `?command=/implement` — Dev agent status turns `working`
- [ ] Open in iframe (same-origin) — platform detected as `embedded` not `browser`
- [ ] StrictMode double-mount produces exactly one set of office timers
- [ ] Trigger a group event, navigate away and back — no stale store mutations in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)