### PR TITLE
refactor: simplify + harden mood engine, status polling, and rendering

### DIFF
--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -1,0 +1,14 @@
+﻿# Claude Bootstrap Template
+
+Use this prompt when starting a new task in Claude:
+
+```text
+Please follow AGENTS.md.
+Run /bootstrap behavior now.
+Task: <describe requirement>
+Target files: <file1>, <file2>
+Constraints: <constraints>
+Acceptance Criteria:
+1) <ac1>
+2) <ac2>
+```

--- a/.claude/commands/decide.md
+++ b/.claude/commands/decide.md
@@ -1,0 +1,8 @@
+# Claude Decide Template
+
+```text
+Please run /decide behavior.
+Record the key decision with reasoning, alternatives considered, and impact.
+Follow the D-[N] format defined in .agent/workflows/decide.md.
+Append to the Work Log under ## Decisions.
+```

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,12 @@
+﻿# Claude Handoff Template
+
+```text
+Please run /handoff behavior.
+Output a resumable summary including:
+- Done
+- In Progress
+- Blockers
+- Next Steps
+- Risks
+- References
+```

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,7 @@
+﻿# Claude Implement Template
+
+```text
+Please run /implement behavior for the approved plan.
+Do minimal and reversible edits only.
+After changes, provide diff summary and evidence.
+```

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,10 @@
+﻿# Claude Plan Template
+
+```text
+Please run /plan behavior for the active task.
+Include:
+1. Target files
+2. Step-by-step execution
+3. Risks and rollback
+4. Verification commands
+```

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -1,0 +1,7 @@
+﻿# Claude Review Template
+
+```text
+Please run /review behavior.
+Focus on regressions, compatibility risks, and scope creep.
+List findings by severity with file references.
+```

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,8 @@
+﻿# Claude Ship Template
+
+```text
+Please run /ship behavior.
+Before shipping, verify handoff references:
+ship:[doc=<path>][code=<path>][log=<path>]
+If any field is missing, fail the gate and list missing fields.
+```

--- a/.claude/commands/spec-intake.md
+++ b/.claude/commands/spec-intake.md
@@ -1,0 +1,44 @@
+# Claude Spec Intake Template
+
+Use this when you have an existing spec (from another LLM, a document, or your own notes) and want to bring it into the project workflow.
+
+```text
+Please run /spec-intake behavior.
+Spec source: <paste spec here, or give a file path, or describe in natural language>
+```
+
+## Examples
+
+**Pasting a spec directly:**
+```text
+Please run /spec-intake behavior.
+Spec source:
+  # User Authentication
+  Goal: Allow users to sign in with Google OAuth and email/password.
+  AC:
+  1. User can sign in with Google
+  2. User can sign in with email + password
+  3. Session persists across page reloads
+```
+
+**Referencing a file:**
+```text
+Please run /spec-intake behavior.
+Spec source: docs/specs/draft-product-spec.md
+```
+
+**Natural language (product early stage):**
+```text
+Please run /spec-intake behavior.
+Spec source: 我要做一個任務管理系統，有用戶系統、任務 CRUD、標籤分類、還有通知功能
+```
+
+## What the AI will do
+
+1. Read and parse the spec in whatever format you gave it
+2. If it's a large product spec → extract all features, show you a list, ask which to start with
+3. Generate a proper `docs/specs/<feature>.md` with quality assessment
+4. Flag anything it inferred (you confirm or correct)
+5. Freeze the spec and run bootstrap automatically
+
+No reformatting required from you.

--- a/.claude/commands/test-classify.md
+++ b/.claude/commands/test-classify.md
@@ -1,0 +1,8 @@
+# Claude Test-Classify Template
+
+```text
+Please run /test-classify behavior.
+Determine the task classification and auto-select the appropriate test depth and evidence format.
+Follow the matrix defined in .agent/workflows/test-classify.md.
+Report: classification tier, required test depth, and evidence template to use.
+```

--- a/.claude/commands/test.md
+++ b/.claude/commands/test.md
@@ -1,0 +1,7 @@
+﻿# Claude Test Template
+
+```text
+Please run /test behavior.
+Execute the minimal relevant test set and report commands + results.
+If tests cannot run, state blockers explicitly.
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,44 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node public/hooks/office-status-hook.js"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node public/hooks/office-status-hook.js"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node public/hooks/office-status-hook.js"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node public/hooks/office-status-hook.js"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ CLAUDE.md
 .agent/
 .agents/
 .antigravity/
-.claude/
+.claude/**
+!.claude/settings.json
+!.claude/commands/
+!.claude/commands/**
 .codex/
 codex/
 agentcortex/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "start": "vite",
-    "build:single": "vite build --outDir dist-single"
+    "build:single": "vite build --outDir dist-single",
+    "test": "vitest run"
   },
   "keywords": [
     "virtual-office",
@@ -45,6 +46,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@vitejs/plugin-react": "^4.7.0",
     "tailwindcss": "^4.2.1",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "^3.2.1"
   }
 }

--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -240,3 +240,8 @@ function processEvent(event) {
   fs.writeFileSync(tmp, JSON.stringify(output, null, 2))
   fs.renameSync(tmp, STATUS_FILE)
 }
+
+// Export helpers for testing (CommonJS — this file runs as a Node.js hook)
+if (typeof module !== 'undefined') {
+  module.exports = { toolToRole, skillToRole, shortFile, shortCommand, extractContext }
+}

--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -190,7 +190,7 @@ function processEvent(event) {
       status = isError ? 'blocked' : 'done'
       hint = isError ? 'error' : null
       const ctx = extractContext(tool, toolInput)
-      label = isError ? `❌ ${ctx || tool} 失敗了` : toolLabel(tool, ctx, true)
+      label = isError ? `❌ ${ctx || tool} failed` : toolLabel(tool, ctx, true)
       break
     }
     case 'SubagentStart':

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -359,7 +359,14 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
     const ids = Object.keys(s.agents)
     return ids.join(',')  // primitive string → stable reference
   })
-  const agents = useOfficeStore((s) => s.agents)
+  // Targeted selector — only re-renders when coffee counts change, not on every agent tick
+  const coffeeCounts = useOfficeStore((s) => {
+    const counts = {}
+    for (const [id, agent] of Object.entries(s.agents)) {
+      counts[id] = agent.deskItemCount?.coffee || 0
+    }
+    return JSON.stringify(counts)
+  })
   const hour = useOfficeStore((s) => s.hour)
   const minute = useOfficeStore((s) => s.minute)
   const activeEvent = useOfficeStore((s) => s.activeEvent)
@@ -376,7 +383,11 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
   }, [])
 
   // Memoize agent list — only re-sort when IDs change (not on every property update)
-  const agentList = useMemo(() => sortByY(Object.values(agents)), [agentIds])
+  const agentList = useMemo(
+    () => sortByY(agentIds ? agentIds.split(',').map(id => useOfficeStore.getState().agents[id]).filter(Boolean) : []),
+    [agentIds]
+  )
+  const coffeeCountMap = useMemo(() => JSON.parse(coffeeCounts), [coffeeCounts])
   const lightOverlay = getLightingOverlay(hour)
 
   // Panel mode: auto-adapt viewBox to container shape
@@ -564,7 +575,7 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
           label={d.label}
           color={d.color}
           variant={d.variant}
-          coffeeCount={agents[d.id]?.deskItemCount?.coffee || 0}
+          coffeeCount={coffeeCountMap[d.id] || 0}
         />
       ))}
 

--- a/src/inference/inferStatus.js
+++ b/src/inference/inferStatus.js
@@ -12,7 +12,7 @@
  */
 
 import { routeExternalAgents, distributeFallbackCount, routeTaskToAgent } from './agentRouter'
-import { pushEvent, setMoodOverride, resetMood } from '../systems/moodEngine'
+import { pushEventBatch, setMoodOverride, resetMood } from '../systems/moodEngine'
 
 // ─── Message normalization ─────────────────────────────────────────────
 
@@ -76,8 +76,12 @@ export function inferFromParams() {
 
 function listenForStatusUpdates(callback) {
   const handler = (event) => {
-    // Only accept messages from same origin or trusted parent frames
-    if (event.origin !== window.location.origin && event.source !== window.parent) return
+    // Accept same-origin messages (any source) or messages from parent frame (for embedded/artifact mode).
+    // Note: cross-origin parent frames CAN send status updates — this is intentional for embedding,
+    // and the impact is limited to visual changes (character animations/mood). No sensitive data exposed.
+    const sameOrigin = event.origin === window.location.origin
+    const fromParent = event.source === window.parent
+    if (!sameOrigin && !fromParent) return
     const msg = normalizeStatusMessage(event.data)
     if (msg) callback(msg)
   }
@@ -127,7 +131,8 @@ function startFilePolling(callback, intervalMs = 2000) {
       if (!resp.ok) { consecutive404++; return }
       consecutive404 = 0
       lastEtag = resp.headers.get('ETag')
-      const data = await resp.json()
+      let data
+      try { data = await resp.json() } catch { return } // malformed JSON — skip without counting as 404
       if (!data) return
       const msg = normalizeStatusMessage(data)
       if (msg) callback(msg)
@@ -236,6 +241,8 @@ const DEBOUNCE_MS = 500
  * @returns {Function} cleanup function
  */
 export function startStatusIntegration(store) {
+  // Reset mood state in case of HMR or React Strict Mode double-invoke
+  resetMood()
   let lastUpdateTime = 0
   let debounceTimer = null
   let stalenessTimer = null
@@ -251,15 +258,8 @@ export function startStatusIntegration(store) {
       s.applyExternalStatus(updates)
       s.setStatusSource('external')
 
-      // Feed mood engine with each agent update
-      for (const u of updates) {
-        pushEvent({
-          role: u.agentId,
-          status: u.status,
-          task: u.task,
-          hint: u.hint || null,
-        })
-      }
+      // Feed mood engine — batch to recompute mood once instead of once per agent
+      pushEventBatch(updates.map(u => ({ role: u.agentId, status: u.status, task: u.task, hint: u.hint || null })))
     } else if (msg.activeCount > 0) {
       const ids = distributeFallbackCount(msg.activeCount)
       s.applyExternalStatus(ids.map(id => ({ agentId: id, status: 'working', task: null, label: null })))

--- a/src/systems/contextBubble.js
+++ b/src/systems/contextBubble.js
@@ -25,7 +25,7 @@ function pick(arr) {
  * "⚡ npm test" → "npm test"
  * "🔎 搜 useLocale" → "useLocale"
  */
-function extractContext(label) {
+export function extractContext(label) {
   if (!label) return null
   // Strip emoji prefix: "✏️ 改 App.jsx" → "改 App.jsx" → "App.jsx"
   // Pattern: optional emoji(s) + optional Chinese verb + space + context
@@ -51,7 +51,7 @@ function fromTemplate(key, ctx) {
 /**
  * Map tool name to action category for template lookup
  */
-function toolToAction(task) {
+export function toolToAction(task) {
   if (!task) return null
   switch (task) {
     case 'Edit': return 'edit'

--- a/src/systems/moodEngine.js
+++ b/src/systems/moodEngine.js
@@ -38,10 +38,8 @@ function pruneStale() {
 
 function computeMood() {
   // Manual override takes priority
-  if (overrideMood && overrideExpiry && Date.now() < overrideExpiry) {
-    return overrideMood
-  }
-  if (overrideMood && overrideExpiry && Date.now() >= overrideExpiry) {
+  if (overrideMood && overrideExpiry) {
+    if (Date.now() < overrideExpiry) return overrideMood
     overrideMood = null
     overrideExpiry = null
   }
@@ -109,11 +107,13 @@ function resetIdleTimer() {
 }
 
 /**
- * Push an event into the sliding window and recompute mood.
- * Called from inferStatus.js on every incoming status update.
+ * Push multiple events at once — only recomputes mood once after all are queued.
  */
-export function pushEvent({ role, status, task, hint }) {
-  events.push({ timestamp: Date.now(), role, status, task: task || null, hint: hint || null })
+export function pushEventBatch(eventList) {
+  const now = Date.now()
+  for (const { role, status, task, hint } of eventList) {
+    events.push({ timestamp: now, role, status, task: task || null, hint: hint || null })
+  }
 
   // Keep window size bounded
   while (events.length > MAX_EVENTS) {

--- a/src/utils/normalizePost.js
+++ b/src/utils/normalizePost.js
@@ -1,0 +1,44 @@
+export const VALID_ROLES = ['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate']
+export const VALID_STATUSES = ['idle', 'working', 'blocked', 'done']
+export const VALID_MOODS = ['normal', 'rushing', 'frustrated', 'stuck', 'smooth', 'intense', 'idle']
+export const MAX_MOOD_DURATION = 3_600_000 // 1 hour
+
+/**
+ * Normalize POST body to the unified office-status format.
+ * Handles both shorthand ({ dev: "working" }) and full format ({ type: "office-status", agents: [...] }).
+ */
+export function normalizePost(body) {
+  if (body.type === 'office-status') {
+    if (Array.isArray(body.agents)) {
+      body.agents = body.agents.filter(a =>
+        VALID_ROLES.includes(a.role) && VALID_STATUSES.includes(a.status)
+      ).map(a => ({ ...a, hint: a.hint || null }))
+    }
+    if (body.mood) body.mood = VALID_MOODS.includes(body.mood) ? body.mood : null
+    if (body.moodDuration) body.moodDuration = Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION)
+    return body
+  }
+  const agents = []
+  for (const key of VALID_ROLES) {
+    const val = body[key]
+    if (val == null) continue
+    const isStatus = VALID_STATUSES.includes(val)
+    agents.push({
+      role: key,
+      task: isStatus ? null : val,
+      status: isStatus ? val : 'working',
+      label: body.label || null,
+      hint: body.hint || null,
+    })
+  }
+  return {
+    _seq: String(Date.now()),
+    type: 'office-status',
+    agents,
+    activeCount: agents.filter(a => a.status !== 'done').length,
+    workflow: body.workflow || null,
+    source: body.source || 'api',
+    mood: VALID_MOODS.includes(body.mood) ? body.mood : null,
+    moodDuration: body.moodDuration ? Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION) : null,
+  }
+}

--- a/tests/contextBubble.test.js
+++ b/tests/contextBubble.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import { extractContext, toolToAction } from '../src/systems/contextBubble.js'
+
+describe('extractContext', () => {
+  it('returns null for null/empty input', () => {
+    expect(extractContext(null)).toBeNull()
+    expect(extractContext('')).toBeNull()
+    expect(extractContext(undefined)).toBeNull()
+  })
+
+  it('strips emoji prefix', () => {
+    expect(extractContext('✏️ App.jsx')).toBe('App.jsx')
+    expect(extractContext('⚡ npm test')).toBe('npm test')
+    expect(extractContext('🔎 useLocale')).toBe('useLocale')
+  })
+
+  it('strips Chinese verb prefix', () => {
+    expect(extractContext('改 App.jsx')).toBe('App.jsx')
+    expect(extractContext('寫 store.js')).toBe('store.js')
+    expect(extractContext('讀 config.json')).toBe('config.json')
+    expect(extractContext('找 pattern')).toBe('pattern')
+    expect(extractContext('搜 useLocale')).toBe('useLocale')
+    expect(extractContext('跑 npm test')).toBe('npm test')
+  })
+
+  it('strips English verb prefix', () => {
+    expect(extractContext('editing App.jsx')).toBe('App.jsx')
+    expect(extractContext('writing store.js')).toBe('store.js')
+    expect(extractContext('reading config.json')).toBe('config.json')
+    expect(extractContext('searching pattern')).toBe('pattern')
+    expect(extractContext('running npm test')).toBe('npm test')
+  })
+
+  it('strips combined emoji + Chinese verb', () => {
+    expect(extractContext('✏️ 改 App.jsx')).toBe('App.jsx')
+    expect(extractContext('⚡ 跑 npm test')).toBe('npm test')
+    expect(extractContext('🔎 搜 useLocale')).toBe('useLocale')
+  })
+
+  it('returns plain text unchanged', () => {
+    expect(extractContext('App.jsx')).toBe('App.jsx')
+    expect(extractContext('npm test')).toBe('npm test')
+  })
+})
+
+describe('toolToAction', () => {
+  it('returns null for null/undefined', () => {
+    expect(toolToAction(null)).toBeNull()
+    expect(toolToAction(undefined)).toBeNull()
+  })
+
+  it('maps known tools correctly', () => {
+    expect(toolToAction('Edit')).toBe('edit')
+    expect(toolToAction('Write')).toBe('write')
+    expect(toolToAction('Read')).toBe('read')
+    expect(toolToAction('Bash')).toBe('bash')
+    expect(toolToAction('Grep')).toBe('search')
+    expect(toolToAction('Glob')).toBe('search')
+    expect(toolToAction('Agent')).toBe('delegate')
+    expect(toolToAction('WebFetch')).toBe('web')
+    expect(toolToAction('WebSearch')).toBe('web')
+  })
+
+  it('returns "generic" for unknown tools', () => {
+    expect(toolToAction('UnknownTool')).toBe('generic')
+    expect(toolToAction('TodoWrite')).toBe('generic')
+  })
+})

--- a/tests/moodEngine.test.js
+++ b/tests/moodEngine.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock zustand store before importing moodEngine
+vi.mock('../src/systems/store', () => {
+  let mood = 'normal'
+  return {
+    useOfficeStore: {
+      getState: () => ({
+        mood,
+        setMood: (m) => { mood = m },
+      }),
+    },
+  }
+})
+
+const { pushEventBatch, setMoodOverride, resetMood } = await import('../src/systems/moodEngine.js')
+const { useOfficeStore } = await import('../src/systems/store')
+
+function getMood() {
+  return useOfficeStore.getState().mood
+}
+
+describe('moodEngine', () => {
+  beforeEach(() => {
+    resetMood()
+    vi.restoreAllMocks()
+  })
+
+  describe('pushEventBatch', () => {
+    it('sets mood based on events', () => {
+      pushEventBatch([{ role: 'dev', status: 'working', task: 'Edit', hint: null }])
+      expect(getMood()).toBe('normal')
+    })
+
+    it('computes mood only once per batch (not N times)', () => {
+      // If pushEventBatch called updateStoreMood N times, the mood
+      // would be recomputed unnecessarily. We just verify it doesn't throw.
+      pushEventBatch([
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+        { role: 'qa', status: 'done', task: 'Bash', hint: null },
+        { role: 'ops', status: 'done', task: 'Bash', hint: null },
+      ])
+      // Should be computed once — not an error
+    })
+  })
+
+  describe('rushing detection', () => {
+    it('detects rushing when 5+ events in 10s window', () => {
+      const events = Array.from({ length: 6 }, (_, i) => ({
+        role: `dev`, status: 'working', task: `task${i}`, hint: null,
+      }))
+      pushEventBatch(events)
+      expect(getMood()).toBe('rushing')
+    })
+  })
+
+  describe('frustrated detection', () => {
+    it('detects frustrated when last 3 events are blocked', () => {
+      // First add some normal events to avoid rushing
+      pushEventBatch([
+        { role: 'dev', status: 'blocked', task: 'Edit', hint: 'error' },
+      ])
+      // Space them out by pushing one at a time
+      pushEventBatch([{ role: 'dev', status: 'blocked', task: 'Bash', hint: 'error' }])
+      pushEventBatch([{ role: 'dev', status: 'blocked', task: 'Read', hint: 'error' }])
+      expect(getMood()).toBe('frustrated')
+    })
+  })
+
+  describe('smooth detection', () => {
+    it('detects smooth when last 5 events are done', () => {
+      vi.useFakeTimers()
+      // Space events 3s apart to avoid rushing threshold (5+ in 10s)
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(3000)
+        pushEventBatch([{ role: 'dev', status: 'done', task: `task${i}`, hint: null }])
+      }
+      expect(getMood()).toBe('smooth')
+      vi.useRealTimers()
+    })
+  })
+
+  describe('stuck detection', () => {
+    it('detects stuck when same task appears 5+ times', () => {
+      vi.useFakeTimers()
+      // Space events 3s apart to avoid rushing threshold
+      for (let i = 0; i < 5; i++) {
+        vi.advanceTimersByTime(3000)
+        pushEventBatch([{ role: 'dev', status: 'working', task: 'Edit', hint: null }])
+      }
+      expect(getMood()).toBe('stuck')
+      vi.useRealTimers()
+    })
+  })
+
+  describe('intense detection', () => {
+    it('detects intense when 3+ distinct roles active in 30s', () => {
+      pushEventBatch([
+        { role: 'dev', status: 'working', task: 'Edit', hint: null },
+        { role: 'qa', status: 'working', task: 'Bash', hint: null },
+        { role: 'ops', status: 'working', task: 'Bash', hint: null },
+      ])
+      // 3 events in batch triggers rushing (>=5 threshold not met with 3),
+      // but 3 distinct roles should trigger intense
+      // Note: rushing check (5+ events in 10s) runs before intense (3+ roles)
+      // With only 3 events, rushing won't trigger, so intense should
+      expect(getMood()).toBe('intense')
+    })
+  })
+
+  describe('idle detection', () => {
+    it('returns idle when no events', () => {
+      resetMood()
+      // pushEventBatch with empty array doesn't add events but still calls computeMood
+      pushEventBatch([])
+      expect(getMood()).toBe('idle')
+    })
+  })
+
+  describe('setMoodOverride', () => {
+    it('overrides computed mood', () => {
+      pushEventBatch([{ role: 'dev', status: 'working', task: 'Edit', hint: null }])
+      setMoodOverride('frustrated', 60000)
+      expect(getMood()).toBe('frustrated')
+    })
+
+    it('expires after duration', () => {
+      vi.useFakeTimers()
+      setMoodOverride('rushing', 1000)
+      expect(getMood()).toBe('rushing')
+
+      vi.advanceTimersByTime(1001)
+      // Need to trigger recomputation
+      pushEventBatch([])
+      expect(getMood()).not.toBe('rushing')
+
+      vi.useRealTimers()
+    })
+  })
+
+  describe('resetMood', () => {
+    it('clears all state', () => {
+      pushEventBatch([
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+        { role: 'dev', status: 'done', task: 'Edit', hint: null },
+      ])
+      resetMood()
+      pushEventBatch([])
+      expect(getMood()).toBe('idle')
+    })
+  })
+})

--- a/tests/normalizePost.test.js
+++ b/tests/normalizePost.test.js
@@ -1,0 +1,166 @@
+import { describe, it, expect } from 'vitest'
+import { normalizePost, VALID_ROLES, VALID_STATUSES, VALID_MOODS, MAX_MOOD_DURATION } from '../src/utils/normalizePost.js'
+
+describe('normalizePost', () => {
+  describe('shorthand format', () => {
+    it('converts dev: "working" to full format', () => {
+      const result = normalizePost({ dev: 'working' })
+      expect(result.type).toBe('office-status')
+      expect(result.agents).toHaveLength(1)
+      expect(result.agents[0]).toMatchObject({ role: 'dev', status: 'working', task: null })
+      expect(result.activeCount).toBe(1)
+    })
+
+    it('treats non-status values as tasks with status "working"', () => {
+      const result = normalizePost({ dev: 'writing tests' })
+      expect(result.agents[0]).toMatchObject({ role: 'dev', status: 'working', task: 'writing tests' })
+    })
+
+    it('handles multiple agents', () => {
+      const result = normalizePost({ dev: 'working', qa: 'blocked', ops: 'done' })
+      expect(result.agents).toHaveLength(3)
+      expect(result.activeCount).toBe(2) // dev + qa, not ops (done)
+    })
+
+    it('ignores unknown roles', () => {
+      const result = normalizePost({ dev: 'working', hacker: 'evil' })
+      expect(result.agents).toHaveLength(1)
+      expect(result.agents[0].role).toBe('dev')
+    })
+
+    it('passes through workflow and source', () => {
+      const result = normalizePost({ dev: 'working', workflow: 'Sprint 1', source: 'curl' })
+      expect(result.workflow).toBe('Sprint 1')
+      expect(result.source).toBe('curl')
+    })
+
+    it('defaults source to "api"', () => {
+      const result = normalizePost({ dev: 'working' })
+      expect(result.source).toBe('api')
+    })
+
+    it('passes label and hint to all agents', () => {
+      const result = normalizePost({ dev: 'working', qa: 'working', label: 'editing App.jsx', hint: 'error' })
+      for (const a of result.agents) {
+        expect(a.label).toBe('editing App.jsx')
+        expect(a.hint).toBe('error')
+      }
+    })
+  })
+
+  describe('full format (type: office-status)', () => {
+    it('passes through valid agents', () => {
+      const body = {
+        type: 'office-status',
+        agents: [{ role: 'dev', status: 'working' }, { role: 'qa', status: 'done' }],
+      }
+      const result = normalizePost(body)
+      expect(result.agents).toHaveLength(2)
+    })
+
+    it('filters out invalid roles', () => {
+      const body = {
+        type: 'office-status',
+        agents: [{ role: 'dev', status: 'working' }, { role: 'hacker', status: 'working' }],
+      }
+      const result = normalizePost(body)
+      expect(result.agents).toHaveLength(1)
+      expect(result.agents[0].role).toBe('dev')
+    })
+
+    it('filters out invalid statuses', () => {
+      const body = {
+        type: 'office-status',
+        agents: [{ role: 'dev', status: 'working' }, { role: 'qa', status: 'sleeping' }],
+      }
+      const result = normalizePost(body)
+      expect(result.agents).toHaveLength(1)
+    })
+
+    it('normalizes hint to null if missing', () => {
+      const body = {
+        type: 'office-status',
+        agents: [{ role: 'dev', status: 'working' }],
+      }
+      const result = normalizePost(body)
+      expect(result.agents[0].hint).toBeNull()
+    })
+  })
+
+  describe('mood validation', () => {
+    it('accepts valid moods', () => {
+      for (const mood of VALID_MOODS) {
+        const result = normalizePost({ dev: 'working', mood })
+        expect(result.mood).toBe(mood)
+      }
+    })
+
+    it('rejects invalid moods', () => {
+      const result = normalizePost({ dev: 'working', mood: 'hacked' })
+      expect(result.mood).toBeNull()
+    })
+
+    it('rejects invalid moods in full format', () => {
+      const result = normalizePost({ type: 'office-status', agents: [], mood: '<script>' })
+      expect(result.mood).toBeNull()
+    })
+  })
+
+  describe('moodDuration capping', () => {
+    it('caps duration at MAX_MOOD_DURATION', () => {
+      const result = normalizePost({
+        type: 'office-status', agents: [],
+        mood: 'rushing', moodDuration: 999_999_999,
+      })
+      expect(result.moodDuration).toBe(MAX_MOOD_DURATION)
+    })
+
+    it('defaults to 60000 for non-numeric duration', () => {
+      const result = normalizePost({
+        type: 'office-status', agents: [],
+        mood: 'rushing', moodDuration: 'forever',
+      })
+      expect(result.moodDuration).toBe(60000)
+    })
+
+    it('passes through valid duration', () => {
+      const result = normalizePost({
+        type: 'office-status', agents: [],
+        mood: 'rushing', moodDuration: 30000,
+      })
+      expect(result.moodDuration).toBe(30000)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('handles empty body', () => {
+      const result = normalizePost({})
+      expect(result.agents).toHaveLength(0)
+      expect(result.activeCount).toBe(0)
+    })
+
+    it('handles null values for roles', () => {
+      const result = normalizePost({ dev: null, qa: 'working' })
+      expect(result.agents).toHaveLength(1)
+      expect(result.agents[0].role).toBe('qa')
+    })
+  })
+})
+
+describe('constants', () => {
+  it('VALID_ROLES has 7 entries', () => {
+    expect(VALID_ROLES).toHaveLength(7)
+  })
+
+  it('VALID_STATUSES has 4 entries', () => {
+    expect(VALID_STATUSES).toHaveLength(4)
+  })
+
+  it('VALID_MOODS has 7 entries', () => {
+    expect(VALID_MOODS).toHaveLength(7)
+  })
+
+  it('MAX_MOOD_DURATION is 1 hour', () => {
+    expect(MAX_MOOD_DURATION).toBe(3_600_000)
+  })
+})

--- a/tests/normalizeStatusMessage.test.js
+++ b/tests/normalizeStatusMessage.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeStatusMessage } from '../src/inference/inferStatus.js'
+
+describe('normalizeStatusMessage', () => {
+  it('returns null for null input', () => {
+    expect(normalizeStatusMessage(null)).toBeNull()
+  })
+
+  it('returns null for non-object input', () => {
+    expect(normalizeStatusMessage('hello')).toBeNull()
+    expect(normalizeStatusMessage(42)).toBeNull()
+    expect(normalizeStatusMessage(undefined)).toBeNull()
+  })
+
+  it('returns null for unknown message types', () => {
+    expect(normalizeStatusMessage({ type: 'unknown' })).toBeNull()
+    expect(normalizeStatusMessage({ foo: 'bar' })).toBeNull()
+  })
+
+  describe('office-status protocol', () => {
+    it('passes through office-status messages as-is', () => {
+      const msg = { type: 'office-status', agents: [{ role: 'dev', status: 'working' }] }
+      expect(normalizeStatusMessage(msg)).toBe(msg) // same reference
+    })
+  })
+
+  describe('legacy office-vibe conversion', () => {
+    it('converts office-vibe to office-status', () => {
+      const result = normalizeStatusMessage({
+        type: 'office-vibe',
+        agent: 'dev',
+        command: 'npm test',
+        phase: 'running',
+      })
+      expect(result.type).toBe('office-status')
+      expect(result.agents).toHaveLength(1)
+      expect(result.agents[0]).toMatchObject({
+        role: 'dev',
+        task: 'npm test',
+        status: 'working',
+      })
+    })
+
+    it('maps "done" phase to done status', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', phase: 'done' })
+      expect(result.agents[0].status).toBe('done')
+    })
+
+    it('maps "complete" phase to done status', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', phase: 'completed' })
+      expect(result.agents[0].status).toBe('done')
+    })
+
+    it('maps "blocked" phase to blocked status', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', phase: 'blocked' })
+      expect(result.agents[0].status).toBe('blocked')
+    })
+
+    it('maps "error" phase to blocked status', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', phase: 'error' })
+      expect(result.agents[0].status).toBe('blocked')
+    })
+
+    it('maps unknown phase to working status', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', phase: 'thinking' })
+      expect(result.agents[0].status).toBe('working')
+    })
+
+    it('defaults to working when no phase', () => {
+      const result = normalizeStatusMessage({ type: 'office-vibe', command: 'test' })
+      expect(result.agents[0].status).toBe('working')
+    })
+
+    it('passes through source and workflow', () => {
+      const result = normalizeStatusMessage({
+        type: 'office-vibe',
+        source: 'gemini',
+        workflow: 'Sprint 1',
+      })
+      expect(result.source).toBe('gemini')
+      expect(result.workflow).toBe('Sprint 1')
+    })
+  })
+})

--- a/tests/officeStatusHook.test.js
+++ b/tests/officeStatusHook.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect } from 'vitest'
+
+// Import CommonJS hook helpers
+const { toolToRole, skillToRole, shortFile, shortCommand, extractContext } = await import('../public/hooks/office-status-hook.js')
+
+describe('toolToRole', () => {
+  it('maps Edit/Write/NotebookEdit to dev', () => {
+    expect(toolToRole('Edit')).toBe('dev')
+    expect(toolToRole('Write')).toBe('dev')
+    expect(toolToRole('NotebookEdit')).toBe('dev')
+  })
+
+  it('maps Bash to ops', () => {
+    expect(toolToRole('Bash')).toBe('ops')
+  })
+
+  it('maps Read/Glob/Grep to res', () => {
+    expect(toolToRole('Read')).toBe('res')
+    expect(toolToRole('Glob')).toBe('res')
+    expect(toolToRole('Grep')).toBe('res')
+  })
+
+  it('maps Agent to pm', () => {
+    expect(toolToRole('Agent')).toBe('pm')
+  })
+
+  it('maps web tools to res', () => {
+    expect(toolToRole('WebFetch')).toBe('res')
+    expect(toolToRole('WebSearch')).toBe('res')
+  })
+
+  it('defaults unknown tools to dev', () => {
+    expect(toolToRole('UnknownTool')).toBe('dev')
+    expect(toolToRole('TodoWrite')).toBe('dev')
+  })
+})
+
+describe('skillToRole', () => {
+  it('maps planning skills to pm', () => {
+    expect(skillToRole('plan')).toBe('pm')
+    expect(skillToRole('spec-intake')).toBe('pm')
+    expect(skillToRole('bootstrap')).toBe('pm')
+    expect(skillToRole('decide')).toBe('pm')
+  })
+
+  it('maps review/test skills to qa', () => {
+    expect(skillToRole('review')).toBe('qa')
+    expect(skillToRole('test')).toBe('qa')
+    expect(skillToRole('test-classify')).toBe('qa')
+  })
+
+  it('maps implementation skills to dev', () => {
+    expect(skillToRole('implement')).toBe('dev')
+    expect(skillToRole('fix-bug')).toBe('dev')
+  })
+
+  it('maps shipping skills to ops', () => {
+    expect(skillToRole('ship')).toBe('ops')
+    expect(skillToRole('deploy')).toBe('ops')
+    expect(skillToRole('handoff')).toBe('ops')
+  })
+
+  it('maps research skills to res', () => {
+    expect(skillToRole('research')).toBe('res')
+    expect(skillToRole('explore')).toBe('res')
+  })
+
+  it('maps architecture skills to arch', () => {
+    expect(skillToRole('architect')).toBe('arch')
+    expect(skillToRole('design')).toBe('arch')
+  })
+
+  it('maps security skills to gate', () => {
+    expect(skillToRole('security')).toBe('gate')
+    expect(skillToRole('audit')).toBe('gate')
+  })
+
+  it('defaults to dev for null/unknown', () => {
+    expect(skillToRole(null)).toBe('dev')
+    expect(skillToRole('random-skill')).toBe('dev')
+  })
+})
+
+describe('shortFile', () => {
+  it('extracts basename from full path', () => {
+    expect(shortFile('/Users/x/project/src/App.jsx')).toBe('App.jsx')
+    expect(shortFile('C:\\Users\\x\\project\\src\\store.js')).toBe('store.js')
+  })
+
+  it('returns null for null input', () => {
+    expect(shortFile(null)).toBeNull()
+  })
+
+  it('handles bare filename', () => {
+    expect(shortFile('App.jsx')).toBe('App.jsx')
+  })
+})
+
+describe('shortCommand', () => {
+  it('extracts last command from chained commands', () => {
+    expect(shortCommand('cd /project && npm test')).toBe('npm test')
+  })
+
+  it('truncates long commands', () => {
+    const long = 'npm run build:production --mode=staging --verbose --output-dir=/tmp'
+    const result = shortCommand(long)
+    expect(result.length).toBeLessThanOrEqual(30)
+    expect(result).toMatch(/\.\.\./)
+  })
+
+  it('returns short commands as-is', () => {
+    expect(shortCommand('git status')).toBe('git status')
+  })
+
+  it('returns null for null input', () => {
+    expect(shortCommand(null)).toBeNull()
+  })
+})
+
+describe('extractContext (hook)', () => {
+  it('extracts file path from Edit input', () => {
+    const result = extractContext('Edit', { file_path: '/project/src/App.jsx' })
+    expect(result).toBe('App.jsx')
+  })
+
+  it('extracts command from Bash input', () => {
+    const result = extractContext('Bash', { command: 'npm test' })
+    expect(result).toBe('npm test')
+  })
+
+  it('extracts pattern from Grep input', () => {
+    const result = extractContext('Grep', { pattern: 'useLocale' })
+    expect(result).toBe('"useLocale"')
+  })
+
+  it('extracts pattern from Glob input', () => {
+    const result = extractContext('Glob', { pattern: '**/*.test.js' })
+    expect(result).toBe('**/*.test.js')
+  })
+
+  it('extracts description from Agent input', () => {
+    const result = extractContext('Agent', { description: 'Search for tests' })
+    expect(result).toBe('Search for tests')
+  })
+
+  it('handles string JSON input', () => {
+    const result = extractContext('Edit', JSON.stringify({ file_path: '/src/App.jsx' }))
+    expect(result).toBe('App.jsx')
+  })
+
+  it('returns null for null input', () => {
+    expect(extractContext('Edit', null)).toBeNull()
+  })
+
+  it('returns null for invalid JSON string', () => {
+    expect(extractContext('Edit', 'not json')).toBeNull()
+  })
+
+  it('returns null for unknown tool', () => {
+    expect(extractContext('UnknownTool', { anything: 'here' })).toBeNull()
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -22,6 +22,8 @@ function officeStatusPlugin() {
   const statusPath = path.join(os.homedir(), '.claude', 'office-status.json')
   const VALID_ROLES = ['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate']
   const VALID_STATUSES = ['idle', 'working', 'blocked', 'done']
+  const VALID_MOODS = ['normal', 'rushing', 'frustrated', 'stuck', 'smooth', 'intense', 'idle']
+  const MAX_MOOD_DURATION = 3_600_000 // 1 hour
 
   // Convert shorthand { dev: "working", qa: "testing" } to full format
   function normalizePost(body) {
@@ -32,9 +34,9 @@ function officeStatusPlugin() {
           VALID_ROLES.includes(a.role) && VALID_STATUSES.includes(a.status)
         ).map(a => ({ ...a, hint: a.hint || null }))
       }
-      // Preserve mood and hint fields
-      if (body.mood) body.mood = String(body.mood)
-      if (body.moodDuration) body.moodDuration = Number(body.moodDuration) || 60000
+      // Validate mood against allowlist; cap duration to prevent permanent overrides
+      if (body.mood) body.mood = VALID_MOODS.includes(body.mood) ? body.mood : null
+      if (body.moodDuration) body.moodDuration = Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION)
       return body
     }
     const agents = []
@@ -57,8 +59,8 @@ function officeStatusPlugin() {
       activeCount: agents.filter(a => a.status !== 'done').length,
       workflow: body.workflow || null,
       source: body.source || 'api',
-      mood: body.mood || null,
-      moodDuration: body.moodDuration || null,
+      mood: VALID_MOODS.includes(body.mood) ? body.mood : null,
+      moodDuration: body.moodDuration ? Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION) : null,
     }
   }
 
@@ -157,7 +159,7 @@ function officeStatusPlugin() {
               // Invalidate ETag cache
               lastEtag = null
               lastData = null
-              res.end(JSON.stringify({ ok: true, agents: normalized.agents.length }))
+              res.end(JSON.stringify({ ok: true, agents: normalized.agents?.length ?? 0 }))
             } catch (err) {
               res.statusCode = 400
               res.end(JSON.stringify({ ok: false, error: err.message }))

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,7 @@ import { createHash } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
+import { normalizePost, VALID_ROLES } from './src/utils/normalizePost.js'
 
 // Middleware: Universal status API
 //   GET  /api/status → read current status (browser polls this)
@@ -20,49 +21,6 @@ import os from 'node:os'
 
 function officeStatusPlugin() {
   const statusPath = path.join(os.homedir(), '.claude', 'office-status.json')
-  const VALID_ROLES = ['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate']
-  const VALID_STATUSES = ['idle', 'working', 'blocked', 'done']
-  const VALID_MOODS = ['normal', 'rushing', 'frustrated', 'stuck', 'smooth', 'intense', 'idle']
-  const MAX_MOOD_DURATION = 3_600_000 // 1 hour
-
-  // Convert shorthand { dev: "working", qa: "testing" } to full format
-  function normalizePost(body) {
-    if (body.type === 'office-status') {
-      // Validate statuses in full format too
-      if (Array.isArray(body.agents)) {
-        body.agents = body.agents.filter(a =>
-          VALID_ROLES.includes(a.role) && VALID_STATUSES.includes(a.status)
-        ).map(a => ({ ...a, hint: a.hint || null }))
-      }
-      // Validate mood against allowlist; cap duration to prevent permanent overrides
-      if (body.mood) body.mood = VALID_MOODS.includes(body.mood) ? body.mood : null
-      if (body.moodDuration) body.moodDuration = Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION)
-      return body
-    }
-    const agents = []
-    for (const key of VALID_ROLES) {
-      const val = body[key]
-      if (val == null) continue
-      const isStatus = VALID_STATUSES.includes(val)
-      agents.push({
-        role: key,
-        task: isStatus ? null : val,
-        status: isStatus ? val : 'working',
-        label: body.label || null,
-        hint: body.hint || null,
-      })
-    }
-    return {
-      _seq: String(Date.now()),
-      type: 'office-status',
-      agents,
-      activeCount: agents.filter(a => a.status !== 'done').length,
-      workflow: body.workflow || null,
-      source: body.source || 'api',
-      mood: VALID_MOODS.includes(body.mood) ? body.mood : null,
-      moodDuration: body.moodDuration ? Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION) : null,
-    }
-  }
 
   // Simple rate limiter: max 30 POST requests per 10 seconds per IP
   const postCounts = new Map()


### PR DESCRIPTION
## Summary
- **Simplify**: batch mood recomputation (N→1), targeted coffeeCounts selector to reduce PixelOffice re-renders, merge redundant override check, guard JSON parse failures
- **Security**: validate mood against allowlist, cap moodDuration to 1hr, document postMessage origin tradeoff, fix hardcoded Chinese label
- **Project setup**: add `.claude/settings.json` with project-level hooks so `office-status-hook.js` fires automatically for developers; commit `.claude/commands/` for custom slash commands; update `.gitignore` to allow these while ignoring session data

## Test plan
- [ ] `npm run dev` starts without errors
- [ ] Agents render correctly in the pixel office
- [ ] `curl -X POST localhost:5174/api/status -H 'Content-Type: application/json' -d '{"dev":"working"}'` updates office
- [ ] Invalid mood values (e.g. `"hacked"`) are rejected by the API
- [ ] `moodDuration` exceeding 1hr is capped
- [ ] New session picks up hooks from `.claude/settings.json` automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)