### PR TITLE
feat: interactive agents, activity feed, persistence & zero-config watcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@tailwindcss/vite": "^4.2.1",
         "@vitejs/plugin-react": "^4.7.0",
         "tailwindcss": "^4.2.1",
-        "vite": "^6.4.1"
+        "vite": "^6.4.1",
+        "vitest": "^3.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1471,6 +1472,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1497,6 +1516,131 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1546,6 +1690,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001779",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz",
@@ -1566,6 +1720,33 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1590,6 +1771,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -1622,6 +1813,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1673,6 +1871,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2029,6 +2247,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2081,6 +2306,23 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2223,6 +2465,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2232,6 +2481,40 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
@@ -2254,6 +2537,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2269,6 +2566,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tslib": {
@@ -2383,6 +2710,119 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -186,7 +186,7 @@ function processEvent(event) {
       task = tool
       // Detect errors from tool result
       const toolResult = event.tool_result || ''
-      const isError = event.is_error || (typeof toolResult === 'string' && /error|failed|exception|ENOENT/i.test(toolResult.slice(0, 200)))
+      const isError = event.is_error || (typeof toolResult === 'string' && /^(Error:|Exit code [1-9]|ENOENT|EPERM|EACCES|Command failed|fatal:)/im.test(toolResult.slice(0, 300)))
       status = isError ? 'blocked' : 'done'
       hint = isError ? 'error' : null
       const ctx = extractContext(tool, toolInput)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useEffect } from 'react'
 import PixelOffice from './components/PixelOffice'
 import ControlPanel from './components/ControlPanel'
+import ActivityFeed from './components/ActivityFeed'
 import ErrorBoundary from './components/ErrorBoundary'
 import { detectPlatform, getPlatformConfig } from './systems/platformDetect'
 import { useOfficeStore } from './systems/store'
@@ -50,7 +51,9 @@ export default function App() {
       <div className="w-screen h-screen bg-[#F5F2EB] dark:bg-[#1a1814] flex flex-col items-center justify-center overflow-hidden">
         <PixelOffice animationQuality={config.animationQuality} />
         {config.showControlPanel && <ControlPanel platform={platform} />}
+        <ActivityFeed mode={mode} />
       </div>
     </ErrorBoundary>
   )
 }
+

--- a/src/components/ActivityFeed.jsx
+++ b/src/components/ActivityFeed.jsx
@@ -1,0 +1,111 @@
+import React, { useState, useMemo } from 'react'
+import { useOfficeStore } from '../systems/store'
+import { charName, eventName, useLocale, t } from '../i18n'
+import { formatTimeAgo } from '../utils/formatTime'
+
+const typeIcons = {
+  event: '🎪',
+  status: '⚡',
+  behavior: '📝',
+}
+
+export default function ActivityFeed({ mode = 'full' }) {
+  useLocale()
+  const [collapsed, setCollapsed] = useState(true)
+  const activityLog = useOfficeStore((s) => s.activityLog)
+  const activeEvent = useOfficeStore((s) => s.activeEvent)
+
+  // Inject live event into feed
+  const entries = useMemo(() => {
+    const items = [...activityLog]
+    if (activeEvent) {
+      items.unshift({
+        id: 'live-event',
+        timestamp: Date.now(),
+        type: 'event',
+        agentId: null,
+        message: activeEvent.id ? eventName(activeEvent.id) : activeEvent.name,
+      })
+    }
+    return items.slice(0, 20)
+  }, [activityLog, activeEvent])
+
+  if (mode === 'panel') return null // too compact for panel mode
+
+  const hasEntries = entries.length > 0
+  const unreadCount = entries.filter(e => Date.now() - e.timestamp < 30000).length
+
+  return (
+    <div className={`fixed top-3 right-3 z-50 select-none transition-all duration-200 ${collapsed ? 'w-10' : 'w-64'}`}>
+      {/* Toggle button */}
+      <button
+        onClick={() => setCollapsed(!collapsed)}
+        className="w-10 h-10 rounded-full bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-200 dark:border-gray-700 shadow-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors relative"
+        title={collapsed ? t('activityFeed.expand', 'Activity Feed') : t('activityFeed.collapse', 'Collapse')}
+      >
+        <span className="text-sm">📋</span>
+        {collapsed && unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 w-4 h-4 rounded-full bg-blue-500 text-white text-[9px] flex items-center justify-center font-bold">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {/* Feed panel */}
+      {!collapsed && (
+        <div className="mt-2 bg-white/95 dark:bg-gray-900/95 backdrop-blur rounded-lg border border-gray-200 dark:border-gray-700 shadow-xl overflow-hidden">
+          <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-800 flex items-center justify-between">
+            <span className="text-xs font-bold text-gray-700 dark:text-gray-200">
+              {t('activityFeed.title', 'Activity')}
+            </span>
+            {hasEntries && (
+              <span className="text-[10px] text-gray-400 dark:text-gray-500">
+                {entries.length} {t('activityFeed.items', 'items')}
+              </span>
+            )}
+          </div>
+          <div className="max-h-64 overflow-y-auto">
+            {!hasEntries ? (
+              <div className="px-3 py-4 text-center text-xs text-gray-400 dark:text-gray-500">
+                {t('activityFeed.empty', 'No activity yet')}
+              </div>
+            ) : (
+              entries.map((entry) => (
+                <ActivityEntry key={entry.id} entry={entry} />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ActivityEntry({ entry }) {
+  // Use hook selectors instead of getState() to stay reactive
+  const agentColor = useOfficeStore((s) => entry.agentId ? s.agents[entry.agentId]?.color : null)
+  const isRecent = Date.now() - entry.timestamp < 30000
+  const icon = typeIcons[entry.type] || '📝'
+  const name = entry.agentId ? charName(entry.agentId) : null
+  const ago = formatTimeAgo(entry.timestamp)
+
+  return (
+    <div className={`px-3 py-1.5 border-b border-gray-50 dark:border-gray-800 last:border-0 flex items-start gap-2 ${isRecent ? 'bg-blue-50/50 dark:bg-blue-900/10' : ''}`}>
+      <span className="text-[10px] mt-0.5 shrink-0">{icon}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1">
+          {name && (
+            <>
+              <span className="inline-block w-1.5 h-1.5 rounded-full shrink-0" style={{ backgroundColor: agentColor }} />
+              <span className="text-[10px] font-bold text-gray-600 dark:text-gray-300 shrink-0">{name}</span>
+            </>
+          )}
+          <span className="text-[10px] text-gray-400 dark:text-gray-500 ml-auto shrink-0">{ago}</span>
+        </div>
+        <div className="text-[10px] text-gray-500 dark:text-gray-400 truncate">
+          {entry.message}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
-import { useOfficeStore } from '../systems/store'
+import { useOfficeStore, STATUS_COLORS } from '../systems/store'
 import { getNextBehavior } from '../systems/behaviorEngine'
 import { getTargetForBehavior, calcFacing, calculatePath, needsLocationChange } from '../systems/movementSystem'
 import { eventBubble, charName, useLocale } from '../i18n'
@@ -562,6 +562,16 @@ function BehaviorIndicator({ behavior }) {
   }
 }
 
+// ─── Unicode-aware text width for monospace SVG ──────────────────────
+// CJK chars ~10 units, ASCII ~7 units at fontSize 12 monospace
+function estimateTextWidth(str) {
+  let w = 0
+  for (const ch of str) {
+    w += ch.codePointAt(0) > 0x2E7F ? 10 : 7
+  }
+  return w
+}
+
 // ═══ AGENT CHARACTER WITH RAF-BASED MOVEMENT ═══
 
 function AgentCharacter({ agent }) {
@@ -870,20 +880,35 @@ function AgentCharacter({ agent }) {
     }
   }, [doSchedule, id])
 
+  const setSelectedAgent = useOfficeStore((s) => s.setSelectedAgent)
+
+  const handleClick = useCallback((e) => {
+    e.stopPropagation()
+    setSelectedAgent(id)
+  }, [id, setSelectedAgent])
+
   const state = agentState || {}
   const pos = renderPos || state.position || { x: 0, y: 0 }
 
+  // Name tag dimensions (lifted from render for clarity)
+  const tagW = estimateTextWidth(name) + 16
+  const tagHalfW = tagW / 2
+  const tagFill = state.status !== 'idle' ? (STATUS_COLORS[state.status] || color) : color
+  const statusIcon = state.status === 'working' ? '⚡' : state.status === 'blocked' ? '✕' : state.status === 'done' ? '✓' : null
+  const glowColor = STATUS_COLORS[state.status]
+
   return (
-    <g transform={`translate(${pos.x}, ${pos.y}) scale(1.35)`}>
+    <g transform={`translate(${pos.x}, ${pos.y}) scale(1.35)`}
+      style={{ cursor: 'pointer' }} onClick={handleClick}>
       {/* Working glow ring */}
       {state.status === 'working' && (
-        <circle cx={0} cy={-18} r={22} fill="none" stroke="#EF9F27" strokeWidth="2" opacity="0.5">
+        <circle cx={0} cy={-18} r={22} fill="none" stroke={glowColor} strokeWidth="2" opacity="0.5">
           <animate attributeName="opacity" values="0.2;0.6;0.2" dur="1.5s" repeatCount="indefinite" />
           <animate attributeName="r" values="20;24;20" dur="1.5s" repeatCount="indefinite" />
         </circle>
       )}
       {state.status === 'blocked' && (
-        <circle cx={0} cy={-18} r={22} fill="none" stroke="#E24B4A" strokeWidth="2" opacity="0.4">
+        <circle cx={0} cy={-18} r={22} fill="none" stroke={glowColor} strokeWidth="2" opacity="0.4">
           <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1s" repeatCount="indefinite" />
         </circle>
       )}
@@ -902,40 +927,16 @@ function AgentCharacter({ agent }) {
       {/* Name tag + bubble: inverse-scale to keep text at original size despite character scale */}
       <g transform={`scale(${1/1.35})`}>
         <g transform="translate(0, -48)">
-          <rect
-            x={-name.length * 5 - 10}
-            y={-11}
-            width={name.length * 10 + 20}
-            height={20}
-            rx={10}
-            fill={
-              state.status === 'working' ? '#EF9F27' :
-              state.status === 'done' ? '#5CB88A' :
-              state.status === 'blocked' ? '#E24B4A' : color
-            }
-            opacity="0.92"
-          />
+          <rect x={-tagHalfW} y={-11} width={tagW} height={20} rx={10}
+            fill={tagFill} opacity="0.92" />
           <text x={0} y={1} textAnchor="middle" dominantBaseline="middle"
-            fontSize="12" fontFamily="monospace" fontWeight="bold" fill="white"
-          >
+            fontSize="12" fontFamily="monospace" fontWeight="bold" fill="white">
             {name}
           </text>
-          {state.status === 'working' && (
-            <g transform={`translate(${name.length * 5 + 6}, -2)`}>
+          {statusIcon && (
+            <g transform={`translate(${tagHalfW - 2}, -2)`}>
               <rect x={-4} y={-4} width={8} height={8} rx={2} fill="white" opacity="0.9" />
-              <text x={0} y={1} textAnchor="middle" dominantBaseline="middle" fontSize="7" fill="#EF9F27">⚡</text>
-            </g>
-          )}
-          {state.status === 'blocked' && (
-            <g transform={`translate(${name.length * 5 + 6}, -2)`}>
-              <rect x={-4} y={-4} width={8} height={8} rx={2} fill="white" opacity="0.9" />
-              <text x={0} y={1} textAnchor="middle" dominantBaseline="middle" fontSize="7" fill="#E24B4A">✕</text>
-            </g>
-          )}
-          {state.status === 'done' && (
-            <g transform={`translate(${name.length * 5 + 6}, -2)`}>
-              <rect x={-4} y={-4} width={8} height={8} rx={2} fill="white" opacity="0.9" />
-              <text x={0} y={1} textAnchor="middle" dominantBaseline="middle" fontSize="7" fill="#5CB88A">✓</text>
+              <text x={0} y={1} textAnchor="middle" dominantBaseline="middle" fontSize="7" fill={tagFill}>{statusIcon}</text>
             </g>
           )}
         </g>

--- a/src/components/AgentInspector.jsx
+++ b/src/components/AgentInspector.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useMemo } from 'react'
+import { useOfficeStore, STATUS_COLORS } from '../systems/store'
+import { charName, behaviorLabel, t, useLocale } from '../i18n'
+import { formatTimeAgo } from '../utils/formatTime'
+
+const statusEmoji = {
+  idle: '💤',
+  working: '⚡',
+  done: '✅',
+  blocked: '🚫',
+}
+
+export default function AgentInspector() {
+  useLocale()
+  const selectedAgent = useOfficeStore((s) => s.selectedAgent)
+  const agent = useOfficeStore((s) => s.selectedAgent ? s.agents[s.selectedAgent] : null)
+  const ext = useOfficeStore((s) => s.selectedAgent ? s.externalStatus[s.selectedAgent] : null)
+  const activityLog = useOfficeStore((s) => s.activityLog)
+  const clearSelectedAgent = useOfficeStore((s) => s.clearSelectedAgent)
+
+  // Close on Escape
+  useEffect(() => {
+    if (!selectedAgent) return
+    const handler = (e) => { if (e.key === 'Escape') clearSelectedAgent() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [selectedAgent, clearSelectedAgent])
+
+  if (!selectedAgent || !agent) return null
+
+  const name = charName(selectedAgent)
+  const status = agent.status || 'idle'
+  const statusLabel = t(`statusLabels.${status}`, status)
+  const currentBehavior = behaviorLabel(agent.behavior)
+  const task = ext?.label || ext?.task || null
+  const color = agent.color || '#888'
+
+  // Recent activities for this agent (last 5)
+  const recentActivities = useMemo(() =>
+    activityLog
+      .filter(a => a.agentId === selectedAgent)
+      .slice(0, 5),
+    [activityLog, selectedAgent]
+  )
+
+  const pos = agent.position || { x: 300, y: 250 }
+
+  // Panel dimensions — expand for activity rows
+  const activityRows = Math.min(recentActivities.length, 3)
+  const baseH = task ? 90 : 74
+  const W = 200, H = baseH + (activityRows > 0 ? 14 + activityRows * 13 : 0)
+  // Position panel above agent, clamped to viewport (SVG 800x560)
+  let px = pos.x - W / 2
+  let py = pos.y - H - 80
+  if (px < 10) px = 10
+  if (px + W > 790) px = 790 - W
+  if (py < 10) py = 10
+
+  return (
+    <g
+      style={{ opacity: 1, transition: 'opacity 0.2s' }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Backdrop click to close */}
+      <rect x={0} y={0} width={800} height={560} fill="transparent" onClick={clearSelectedAgent} />
+
+      {/* Connection line from panel to agent */}
+      <line x1={pos.x} y1={py + H} x2={pos.x} y2={pos.y - 40}
+        stroke={color} strokeWidth="1" strokeDasharray="3,3" opacity="0.5" />
+
+      {/* Panel background */}
+      <rect x={px} y={py} width={W} height={H} rx={8}
+        fill="white" stroke={color} strokeWidth="1.5"
+        filter="url(#bubble-shadow)" />
+
+      {/* Header bar */}
+      <rect x={px} y={py} width={W} height={28} rx={8} fill={color} />
+      <rect x={px} y={py + 20} width={W} height={8} fill={color} />
+
+      {/* Name + close button */}
+      <text x={px + 10} y={py + 18} fontSize="12" fontFamily="monospace" fontWeight="bold" fill="white">
+        {name}
+      </text>
+      <text x={px + W - 14} y={py + 18} fontSize="12" fontFamily="monospace" fill="white"
+        style={{ cursor: 'pointer' }} onClick={clearSelectedAgent}>
+        ✕
+      </text>
+
+      {/* Status badge */}
+      <circle cx={px + 12} cy={py + 42} r={5} fill={STATUS_COLORS[status]} />
+      <text x={px + 22} y={py + 45} fontSize="10" fontFamily="monospace" fill={STATUS_COLORS[status]} fontWeight="bold">
+        {statusEmoji[status]} {statusLabel}
+      </text>
+
+      {/* Current behavior */}
+      <text x={px + 10} y={py + 62} fontSize="9" fontFamily="monospace" fill="#666">
+        {currentBehavior}
+      </text>
+
+      {/* External task label (if any) */}
+      {task && (
+        <text x={px + 10} y={py + 78} fontSize="9" fontFamily="'Segoe UI', system-ui, sans-serif" fill="#378ADD">
+          {truncate(task, 30)}
+        </text>
+      )}
+
+      {/* Recent activities */}
+      {recentActivities.length > 0 && (
+        <g>
+          <line x1={px + 10} y1={py + (task ? 86 : 70)} x2={px + W - 10} y2={py + (task ? 86 : 70)}
+            stroke="#eee" strokeWidth="0.5" />
+          {recentActivities.slice(0, 3).map((a, i) => {
+            const baseY = py + (task ? 98 : 82) + i * 13
+            const ago = formatTimeAgo(a.timestamp, { compact: true })
+            return (
+              <g key={a.id}>
+                <text x={px + 10} y={baseY} fontSize="8" fontFamily="monospace" fill="#999">
+                  {ago}
+                </text>
+                <text x={px + 50} y={baseY} fontSize="8" fontFamily="'Segoe UI', system-ui, sans-serif" fill="#555">
+                  {truncate(a.message, 22)}
+                </text>
+              </g>
+            )
+          })}
+        </g>
+      )}
+    </g>
+  )
+}
+
+function truncate(str, max) {
+  if (!str) return ''
+  const chars = Array.from(str)
+  return chars.length > max ? chars.slice(0, max).join('') + '…' : str
+}

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,13 +1,6 @@
 import React, { useState } from 'react'
-import { useOfficeStore } from '../systems/store'
+import { useOfficeStore, STATUS_COLORS } from '../systems/store'
 import { behaviorLabel, charName, t, setLocale, availableLocales, useLocale, eventName } from '../i18n'
-
-const statusColors = {
-  idle: '#888',
-  working: '#EF9F27',
-  done: '#5CB88A',
-  blocked: '#E24B4A',
-}
 
 const statusOptions = ['idle', 'working', 'blocked', 'done']
 
@@ -73,7 +66,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
               return (
                 <div key={agent.id} className="flex items-center gap-0.5 shrink-0" title={`${charName(agent.id)}: ${ext ? (ext.task || ext.status) : agent.behavior}`}>
                   <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: agent.color }} />
-                  <span className="inline-block w-1 h-1 rounded-full" style={{ backgroundColor: statusColors[agent.status] || '#888' }} />
+                  <span className="inline-block w-1 h-1 rounded-full" style={{ backgroundColor: STATUS_COLORS[agent.status] || '#888' }} />
                 </div>
               )
             })}
@@ -113,7 +106,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
                 <span className="text-gray-700 dark:text-gray-200 font-medium">{name}</span>
                 <span className="text-gray-400 dark:text-gray-500">·</span>
                 <span className={ext ? 'text-emerald-600 dark:text-emerald-400 font-medium' : 'text-gray-500 dark:text-gray-400'}>{label}</span>
-                <span className="inline-block w-1.5 h-1.5 rounded-full ml-0.5" style={{ backgroundColor: statusColors[agent.status] || '#888' }} />
+                <span className="inline-block w-1.5 h-1.5 rounded-full ml-0.5" style={{ backgroundColor: STATUS_COLORS[agent.status] || '#888' }} />
               </div>
             )
           })}
@@ -180,7 +173,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
                         ? 'text-white font-bold'
                         : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 bg-gray-200 dark:bg-gray-700'
                     }`}
-                    style={agent.status === st ? { backgroundColor: statusColors[st] } : {}}
+                    style={agent.status === st ? { backgroundColor: STATUS_COLORS[st] } : {}}
                   >
                     {st}
                   </button>

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -4,6 +4,7 @@ import { startOfficeLife } from '../systems/officeLife'
 import { startStatusIntegration } from '../inference/inferStatus'
 import { eventName } from '../i18n'
 import AgentCharacter from './AgentCharacter'
+import AgentInspector from './AgentInspector'
 import {
   Bookshelf, Plant, Couch, RoundTable, MeetingTable,
   CoffeeMachine, WaterCooler, GateBooth, WallWindow, Whiteboard,
@@ -658,6 +659,9 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
 
       {/* ═══ FLYING DOCUMENTS (handoff animation) ═══ */}
       <FlyingDocuments />
+
+      {/* ═══ AGENT INSPECTOR (click-to-inspect popover) ═══ */}
+      <AgentInspector />
 
       {/* ═══ LIGHTING ═══ */}
       {lightOverlay.opacity > 0 && (

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -78,8 +78,16 @@ export function behaviorLabel(behaviorId) {
   return t(`behaviorLabels.${behaviorId}`, behaviorId)
 }
 
-// Convenience: get character name
+// ─── Custom name resolver (set by store to avoid circular dep) ───
+let _nameResolver = null
+export function setNameResolver(fn) { _nameResolver = fn }
+
+// Convenience: get character name (custom profile overrides i18n)
 export function charName(charId) {
+  if (_nameResolver) {
+    const custom = _nameResolver(charId)
+    if (custom) return custom
+  }
   return t(`characters.${charId}.name`, charId)
 }
 

--- a/src/inference/inferStatus.js
+++ b/src/inference/inferStatus.js
@@ -119,10 +119,13 @@ function startPolling(callback, intervalMs = 2000) {
 // ─── File polling via /api/status (CLI hook writes ~/.claude/office-status.json)
 // This is the primary channel for real CLI integration
 
-function startFilePolling(callback, intervalMs = 2000) {
+function startFilePolling(callback, intervalMs = 1000) {
   let lastEtag = null
+  let lastSeq = null    // prevent re-applying same data even if ETag is invalidated
   let consecutive404 = 0
   const timer = setInterval(async () => {
+    // Back off when server is unreachable (skip every other poll after 10 failures)
+    if (consecutive404 > 10 && consecutive404 % 3 !== 0) return
     try {
       const headers = {}
       if (lastEtag) headers['If-None-Match'] = lastEtag
@@ -132,15 +135,18 @@ function startFilePolling(callback, intervalMs = 2000) {
       consecutive404 = 0
       lastEtag = resp.headers.get('ETag')
       let data
-      try { data = await resp.json() } catch { return } // malformed JSON — skip without counting as 404
+      try { data = await resp.json() } catch { return }
       if (!data) return
+      // Same _seq means same data — don't re-apply (prevents expiresAt reset)
+      if (data._seq && data._seq === lastSeq) return
+      lastSeq = data._seq || null
       const msg = normalizeStatusMessage(data)
       if (msg) callback(msg)
     } catch {
       consecutive404++
     }
-    // Stop polling if server seems down
-    if (consecutive404 > 15) clearInterval(timer)
+    // Back off if server seems down (skip polls but don't kill the interval)
+    // Polling resumes automatically when server comes back (consecutive404 resets on success)
   }, intervalMs)
   return () => clearInterval(timer)
 }
@@ -233,7 +239,7 @@ function listenTitleChanges(callback) {
 // ─── Master integration orchestrator ───────────────────────────────────
 
 const STALENESS_TIMEOUT = 120000 // 2 minutes
-const DEBOUNCE_MS = 500
+const DEBOUNCE_MS = 150  // keep low — tool calls are 1-2s apart, debounce must not eat them
 
 /**
  * Start all status integration channels

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -187,6 +187,17 @@
       "anyone want to order delivery together"
     ]
   },
+  "activityFeed": {
+    "title": "Activity",
+    "expand": "Activity Feed",
+    "collapse": "Collapse",
+    "items": "items",
+    "empty": "No activity yet"
+  },
+  "inspector": {
+    "recentActivity": "Recent",
+    "noActivity": "No recent activity"
+  },
   "moodLabels": {
     "normal": "Normal",
     "rushing": "Rushing",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -187,6 +187,17 @@
       "有人要一起叫外送嗎"
     ]
   },
+  "activityFeed": {
+    "title": "動態",
+    "expand": "活動記錄",
+    "collapse": "收合",
+    "items": "筆",
+    "empty": "尚無動態"
+  },
+  "inspector": {
+    "recentActivity": "近期動態",
+    "noActivity": "尚無近期動態"
+  },
   "moodLabels": {
     "normal": "正常",
     "rushing": "趕工中",

--- a/src/systems/constants.js
+++ b/src/systems/constants.js
@@ -17,8 +17,8 @@ export const CORRIDOR_JITTER = 30       // px jitter for corridor waypoints
 export const DOOR_JITTER = 20           // px jitter for door waypoints
 
 // Office life events
-export const DAILY_EVENT_INTERVAL = [60000, 180000]    // 1-3 min
-export const RARE_EVENT_INTERVAL = [300000, 600000]    // 5-10 min
+export const DAILY_EVENT_INTERVAL = [60000, 180000]    // 1–3 min
+export const RARE_EVENT_INTERVAL = [300000, 600000]    // 5–10 min
 export const TIME_CHECK_INTERVAL = 60000               // 1 min
 
 // API

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -1,32 +1,140 @@
 import { create } from 'zustand'
 import characters from '../config/characters.json'
 import { HOME_POSITIONS } from './movementSystem'
-import { randomBubble } from '../i18n'
+import { randomBubble, setNameResolver, behaviorLabel } from '../i18n'
 import { generateContextBubble } from './contextBubble'
 import { detectProjectMode } from './platformDetect'
 
-const detectMode = () => {
+// ─── Shared constants ───
+export const STATUS_COLORS = {
+  idle: '#888',
+  working: '#EF9F27',
+  done: '#5CB88A',
+  blocked: '#E24B4A',
+}
+
+// ─── Persistence helpers ───
+const PERSIST_KEY = 'office-state'
+
+function loadPersistedState() {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = localStorage.getItem(PERSIST_KEY)
+    if (!raw) return null
+    const data = JSON.parse(raw)
+    // Discard stale data (older than 4 hours)
+    if (Date.now() - (data._savedAt || 0) > 4 * 60 * 60 * 1000) return null
+    return data
+  } catch { return null }
+}
+
+function savePersistedState(state) {
+  if (typeof window === 'undefined') return
+  try {
+    const data = {
+      _savedAt: Date.now(),
+      agents: {},
+      // Don't persist transient state (mood, externalStatus, statusSource, activeWorkflow)
+    }
+    for (const [id, a] of Object.entries(state.agents)) {
+      data.agents[id] = {
+        // Don't persist status — it's transient, driven only by external hooks
+        behavior: a.behavior,
+        expression: a.expression,
+        deskItemCount: a.deskItemCount,
+        position: a.position,
+        facing: a.facing,
+      }
+    }
+    localStorage.setItem(PERSIST_KEY, JSON.stringify(data))
+  } catch { /* quota exceeded — ignore */ }
+}
+
+// ─── Validation for persisted data ───
+const VALID_FACINGS = new Set(['up', 'down', 'left', 'right'])
+
+function isValidPosition(pos) {
+  return pos && typeof pos.x === 'number' && typeof pos.y === 'number'
+    && isFinite(pos.x) && isFinite(pos.y)
+}
+
+function validatePersistedAgent(saved) {
+  if (!saved) return null
+  return {
+    // status is NOT persisted — always starts as 'idle', driven by external hooks
+    behavior: typeof saved.behavior === 'string' ? saved.behavior : undefined,
+    expression: typeof saved.expression === 'string' ? saved.expression : undefined,
+    deskItemCount: saved.deskItemCount && typeof saved.deskItemCount === 'object' ? saved.deskItemCount : undefined,
+    position: isValidPosition(saved.position) ? saved.position : undefined,
+    facing: VALID_FACINGS.has(saved.facing) ? saved.facing : undefined,
+  }
+}
+
+// ─── Cached init-time computations (avoid redundant calls) ───
+const _persisted = loadPersistedState()
+
+const _mode = (() => {
   if (typeof window === 'undefined') return 'agentcortex'
   return detectProjectMode()
+})()
+
+// ─── Custom agent profiles (cached — URL params don't change) ───
+// Supported via: ?agents=Alice:dev,Bob:qa  OR  window.__office_config__.agents
+const _customProfiles = (() => {
+  if (typeof window === 'undefined') return {}
+  const profiles = {}
+  const cfg = window.__office_config__?.agents
+  if (cfg && typeof cfg === 'object') {
+    for (const [id, override] of Object.entries(cfg)) {
+      profiles[id] = { name: override.name, color: override.color }
+    }
+  }
+  const params = new URLSearchParams(window.location.search)
+  const agentsParam = params.get('agents')
+  if (agentsParam) {
+    for (const entry of agentsParam.split(',')) {
+      const [name, role] = entry.split(':').map(s => s.trim())
+      if (name && role) profiles[role] = { name, ...(profiles[role] || {}) }
+    }
+  }
+  return profiles
+})()
+
+// ─── Activity log helpers ───
+let _activityId = 0
+function mkActivity(entry) {
+  return { id: ++_activityId, timestamp: Date.now(), ...entry }
 }
+
+// Behaviors worth logging to the activity feed (skip mundane ones like idle)
+const LOGGABLE_BEHAVIORS = new Set([
+  'typing', 'reading-screen', 'writing-notes', 'whiteboard', 'research',
+  'deploy-button', 'shield-verify', 'meeting', 'chat', 'pass-document',
+  'goto-coffee-machine', 'nap', 'scratch-head', 'desk-slam',
+])
+
 
 const initAgents = (mode) => {
   const roster = characters[mode] || characters.agentcortex
   const agents = {}
   for (const c of roster) {
     const home = HOME_POSITIONS[c.id] || { x: 300, y: 250 }
+    const saved = validatePersistedAgent(_persisted?.agents?.[c.id])
+    const custom = _customProfiles[c.id]
     agents[c.id] = {
       ...c,
-      behavior: 'idle',
-      expression: 'normal',
+      name: custom?.name || c.name,
+      color: custom?.color || c.color,
+      behavior: saved?.behavior || 'idle',
+      expression: saved?.expression || 'normal',
       bubble: null,
-      status: 'idle',
+      status: 'idle',  // always start idle — external hooks drive status
       weightOverride: null,
-      deskItemCount: { coffee: 0, sticky: 0, books: 0 },
-      position: { ...home },
-      targetPosition: { ...home },
+      deskItemCount: saved?.deskItemCount || { coffee: 0, sticky: 0, books: 0 },
+      position: saved?.position || { ...home },
+      targetPosition: saved?.position || { ...home },
       isMoving: false,
-      facing: 'down',
+      facing: saved?.facing || 'down',
       inGroupEvent: false,
       groupTarget: null,
     }
@@ -35,8 +143,8 @@ const initAgents = (mode) => {
 }
 
 export const useOfficeStore = create((set) => ({
-  mode: detectMode(),
-  agents: initAgents(detectMode()),
+  mode: _mode,
+  agents: initAgents(_mode),
   hour: new Date().getHours(),
   minute: new Date().getMinutes(),
   activeEvent: null,
@@ -46,12 +154,19 @@ export const useOfficeStore = create((set) => ({
   setAgentBehavior: (id, behavior, expression, bubble) =>
     set((s) => {
       if (!s.agents[id]) return s
-      return {
-        agents: {
-          ...s.agents,
-          [id]: { ...s.agents[id], behavior, expression: expression || s.agents[id].expression, bubble: bubble || null },
-        },
+      const prev = s.agents[id].behavior
+      // Status is driven only by external integration (hooks), not by organic behaviors
+      const agents = {
+        ...s.agents,
+        [id]: { ...s.agents[id], behavior, expression: expression || s.agents[id].expression, bubble: bubble || null },
       }
+      // Log notable behavior changes to activity feed
+      if (behavior !== prev && LOGGABLE_BEHAVIORS.has(behavior)) {
+        const msg = bubble || behaviorLabel(behavior)
+        const entry = mkActivity({ type: 'behavior', agentId: id, message: msg })
+        return { agents, activityLog: [entry, ...s.activityLog].slice(0, 50) }
+      }
+      return { agents }
     }),
 
   // Group event: lock agent into event behavior + set movement target
@@ -126,7 +241,11 @@ export const useOfficeStore = create((set) => ({
     set({ hour: now.getHours(), minute: now.getMinutes() })
   },
 
-  setActiveEvent: (event) => set({ activeEvent: event }),
+  setActiveEvent: (event) => set((s) => {
+    if (!event) return { activeEvent: event }
+    const entry = mkActivity({ type: 'event', agentId: null, message: event.id || event.name || 'event' })
+    return { activeEvent: event, activityLog: [entry, ...s.activityLog].slice(0, 50) }
+  }),
   clearActiveEvent: () => set({ activeEvent: null }),
   togglePause: () => set((s) => {
     const next = !s.isPaused
@@ -146,6 +265,7 @@ export const useOfficeStore = create((set) => ({
       const now = Date.now()
       const ext = { ...s.externalStatus }
       const agents = { ...s.agents }
+      const activities = []
       for (const u of updates) {
         if (!agents[u.agentId]) continue
         ext[u.agentId] = {
@@ -153,7 +273,9 @@ export const useOfficeStore = create((set) => ({
           task: u.task,
           label: u.label,
           hint: u.hint || null,
-          expiresAt: u.status === 'done' ? now + 15000 : now + 120000,
+          // working/blocked: 15s expiry (hook re-sends on each tool call to keep alive)
+          // done: 10s expiry (brief celebration then back to idle)
+          expiresAt: u.status === 'done' ? now + 10000 : now + 15000,
         }
         // Immediately set behavior + expression to match work status
         const behaviorMap = {
@@ -162,18 +284,27 @@ export const useOfficeStore = create((set) => ({
           done:    { behavior: 'thumbs-up', expression: 'happy' },
         }
         const bm = behaviorMap[u.status] || {}
+        // Don't overwrite behavior/expression during group events (officeLife controls those)
+        const inGroup = agents[u.agentId].inGroupEvent
         agents[u.agentId] = {
           ...agents[u.agentId],
           status: u.status,
-          behavior: bm.behavior || agents[u.agentId].behavior,
-          expression: bm.expression || agents[u.agentId].expression,
+          behavior: inGroup ? agents[u.agentId].behavior : (bm.behavior || agents[u.agentId].behavior),
+          expression: inGroup ? agents[u.agentId].expression : (bm.expression || agents[u.agentId].expression),
         }
         // Context-aware bubble > status pool fallback
         const bubble = generateContextBubble(u.agentId, u, ext)
           || randomBubble(u.status === 'blocked' ? 'blocked-status' : u.status === 'done' ? 'done-status' : 'working-status')
         if (bubble) agents[u.agentId] = { ...agents[u.agentId], bubble }
+        // Log activity inline (single loop instead of two)
+        if (u.status === 'done' || u.status === 'blocked' || (u.status === 'working' && u.label)) {
+          activities.push(mkActivity({ type: 'status', agentId: u.agentId, message: u.label || u.status }))
+        }
       }
-      return { externalStatus: ext, agents }
+      const log = activities.length > 0
+        ? [...activities, ...s.activityLog].slice(0, 50)
+        : s.activityLog
+      return { externalStatus: ext, agents, activityLog: log }
     }),
 
   clearExternalStatus: (agentId) =>
@@ -194,7 +325,7 @@ export const useOfficeStore = create((set) => ({
     }),
 
   // ─── Mood system ───
-  mood: 'normal',                // normal | rushing | frustrated | stuck | smooth | intense | idle
+  mood: 'normal',  // normal | rushing | frustrated | stuck | smooth | intense | idle (transient, not persisted)
   setMood: (mood) => set({ mood }),
 
   setStatusSource: (source) => set({ statusSource: source }),
@@ -210,4 +341,25 @@ export const useOfficeStore = create((set) => ({
     set((s) => ({
       handoffs: s.handoffs.filter(h => h.id !== id),
     })),
+
+  // ─── Activity Log (for Activity Feed) ───
+  activityLog: [],  // [{ id, timestamp, type, agentId, message }]
+
+  // ─── Selected agent for inspect popover ───
+  selectedAgent: null,
+  setSelectedAgent: (id) => set((s) => ({ selectedAgent: s.selectedAgent === id ? null : id })),
+  clearSelectedAgent: () => set({ selectedAgent: null }),
 }))
+
+// ─── Register custom name resolver for i18n ───
+setNameResolver((charId) => _customProfiles[charId]?.name || null)
+
+// ─── Auto-persist on state changes (throttled) ───
+let _persistTimer = null
+useOfficeStore.subscribe(() => {
+  if (_persistTimer) return
+  _persistTimer = setTimeout(() => {
+    _persistTimer = null
+    savePersistedState(useOfficeStore.getState())
+  }, 2000)
+})

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -1,0 +1,10 @@
+// Shared time formatting utility
+// compact: "5s", "3m", "1h"
+// descriptive: "now", "5s ago", "3m ago"
+export function formatTimeAgo(ts, { compact = false } = {}) {
+  const diff = Math.floor((Date.now() - ts) / 1000)
+  if (!compact && diff < 5) return 'now'
+  if (diff < 60) return compact ? `${diff}s` : `${diff}s ago`
+  if (diff < 3600) return compact ? `${Math.floor(diff / 60)}m` : `${Math.floor(diff / 60)}m ago`
+  return compact ? `${Math.floor(diff / 3600)}h` : `${Math.floor(diff / 3600)}h ago`
+}

--- a/src/utils/normalizePost.js
+++ b/src/utils/normalizePost.js
@@ -16,6 +16,8 @@ export function normalizePost(body) {
     }
     if (body.mood) body.mood = VALID_MOODS.includes(body.mood) ? body.mood : null
     if (body.moodDuration) body.moodDuration = Math.min(Number(body.moodDuration) || 60000, MAX_MOOD_DURATION)
+    // Ensure _seq is always set (used for dedup + staleness)
+    if (!body._seq) body._seq = String(Date.now())
     return body
   }
   const agents = []

--- a/vite.config.js
+++ b/vite.config.js
@@ -19,8 +19,12 @@ import { normalizePost, VALID_ROLES } from './src/utils/normalizePost.js'
 // Shorthand format: { "dev": "working", "qa": "blocked", "workflow": "name" }
 // Full format:      { "type": "office-status", "agents": [...], "workflow": "name" }
 
+// Shared status file path and ETag cache (shared between plugins)
+const STATUS_PATH = path.join(os.homedir(), '.claude', 'office-status.json')
+const etagCache = { lastEtag: null, lastData: null }
+
 function officeStatusPlugin() {
-  const statusPath = path.join(os.homedir(), '.claude', 'office-status.json')
+  const statusPath = STATUS_PATH
 
   // Simple rate limiter: max 30 POST requests per 10 seconds per IP
   const postCounts = new Map()
@@ -40,9 +44,7 @@ function officeStatusPlugin() {
     return entry.count <= RATE_LIMIT
   }
 
-  // ETag tracking for GET 304 responses
-  let lastEtag = null
-  let lastData = null
+  // ETag tracking uses shared etagCache (so file watcher can invalidate)
 
   return {
     name: 'office-status-api',
@@ -66,22 +68,41 @@ function officeStatusPlugin() {
           return
         }
 
-        // GET → read current status (with ETag support)
+        // GET → read current status (ETag cache + server-side staleness)
         if (req.method === 'GET') {
           try {
+            // Fast path: check cached ETag before reading file
+            const clientEtag = req.headers['if-none-match']
+            if (clientEtag && etagCache.lastEtag === clientEtag) {
+              res.statusCode = 304
+              res.end()
+              return
+            }
+
             const data = fs.readFileSync(statusPath, 'utf-8')
+
+            // Server-side staleness: if _seq is older than 60s, return empty
+            try {
+              const parsed = JSON.parse(data)
+              const seq = parseInt(parsed._seq, 10)
+              if (seq && Date.now() - seq > 60000) {
+                res.end('null')
+                return
+              }
+            } catch {}
+
             const etag = '"' + createHash('md5').update(data).digest('hex').slice(0, 12) + '"'
 
-            // 304 Not Modified if ETag matches
-            if (req.headers['if-none-match'] === etag) {
+            // 304 if ETag matches (for clients with stale cache ref)
+            if (clientEtag === etag) {
               res.statusCode = 304
               res.end()
               return
             }
 
             res.setHeader('ETag', etag)
-            lastEtag = etag
-            lastData = data
+            etagCache.lastEtag = etag
+            etagCache.lastData = data
             res.end(data)
           } catch {
             res.end('null')
@@ -115,8 +136,8 @@ function officeStatusPlugin() {
               const json = JSON.stringify(normalized, null, 2)
               fs.writeFileSync(statusPath, json)
               // Invalidate ETag cache
-              lastEtag = null
-              lastData = null
+              etagCache.lastEtag = null
+              etagCache.lastData = null
               res.end(JSON.stringify({ ok: true, agents: normalized.agents?.length ?? 0 }))
             } catch (err) {
               res.statusCode = 400
@@ -133,8 +154,88 @@ function officeStatusPlugin() {
   }
 }
 
+// ─── Zero-config fallback: watch ~/.claude/office-status.json + project files ───
+// When hooks aren't installed (e.g. worktree, new setup), the office can still
+// detect development activity by watching file changes via Vite's built-in watcher.
+
+function fileWatcherFallbackPlugin() {
+  const statusPath = STATUS_PATH
+  const DEBOUNCE_MS = 1500
+  const recentEdits = new Map()  // role → { file, time }
+
+  // Map file path/extension to agent roles (test/spec checked first)
+  function fileToRole(file) {
+    if (/\.(test|spec)\./i.test(file)) return 'qa'
+    if (/tests?[/\\]/i.test(file)) return 'qa'
+    if (/\.(jsx?|tsx?|vue|svelte)$/i.test(file)) return 'dev'
+    if (/\.(css|scss|less|tailwind)/i.test(file)) return 'dev'
+    if (/\.(json|ya?ml|toml|env)/i.test(file)) return 'ops'
+    if (/\.(md|txt|doc)/i.test(file)) return 'res'
+    return 'dev'
+  }
+
+  function shortName(filePath) {
+    return path.basename(filePath)
+  }
+
+  function writeStatus(role, file) {
+    const now = Date.now()
+    // Per-role debounce (so editing test + src simultaneously both register)
+    const last = recentEdits.get(role)
+    if (last && now - last.time < DEBOUNCE_MS) return
+
+    // Don't overwrite richer hook-generated status — skip if hooks recently wrote
+    try {
+      const existing = JSON.parse(fs.readFileSync(statusPath, 'utf-8'))
+      if (existing.source === 'claude-cli' && existing._seq && now - parseInt(existing._seq, 10) < 10000) return
+    } catch {}
+
+    recentEdits.set(role, { file, time: now })
+
+    // Build agents list from all recent edits (within 15s)
+    const agents = []
+    for (const [r, entry] of recentEdits) {
+      if (now - entry.time < 15000) {
+        agents.push({ role: r, task: 'Edit', status: 'working', label: `✏️ ${shortName(entry.file)}` })
+      } else {
+        recentEdits.delete(r)
+      }
+    }
+
+    const output = {
+      _seq: String(now),
+      type: 'office-status',
+      agents,
+      activeCount: agents.length,
+      source: 'file-watcher',
+    }
+
+    try {
+      const dir = path.dirname(statusPath)
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+      fs.writeFileSync(statusPath, JSON.stringify(output, null, 2))
+      etagCache.lastEtag = null
+      etagCache.lastData = null
+    } catch {}
+  }
+
+  return {
+    name: 'office-file-watcher-fallback',
+    configureServer(server) {
+      // Watch project source files for changes (Vite's watcher covers src/)
+      server.watcher.on('change', (file) => {
+        // Skip node_modules, dist, .git, and the status file itself
+        if (/node_modules|dist|\.git/.test(file)) return
+        if (file.includes('office-status')) return
+        const role = fileToRole(file)
+        writeStatus(role, file)
+      })
+    }
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss(), officeStatusPlugin()],
+  plugins: [react(), tailwindcss(), officeStatusPlugin(), fileWatcherFallbackPlugin()],
   build: {
     rollupOptions: {
       output: { inlineDynamicImports: true }


### PR DESCRIPTION
## Summary
- **Click-to-inspect**: Click any agent → SVG popover with status, behavior, task, recent activities
- **Activity Feed**: Floating 📋 panel logging behavior changes and office events with unread badge
- **State persistence**: Agent positions/behaviors saved to localStorage (4hr TTL)
- **Custom agent profiles**: URL params (`?agents=Alice:dev`) or `window.__office_config__`
- **Zero-config file watcher**: Vite plugin auto-detects file changes and maps to agent roles (`.test` → QA, `.jsx` → Dev, `.json` → Ops) — works without hook installation
- **Status lifecycle fixes**: 15s working expiry, 10s done expiry, polling dedup via `_seq`, server-side 60s staleness check, hook/watcher conflict guard
- **Unicode-aware name tags**: Proper width for CJK vs ASCII characters
- **Code quality**: Shared `STATUS_COLORS`, `formatTimeAgo` utility, removed dead code, validated persisted state

## Test plan
- [x] `npm test` — 85 tests pass
- [x] `npm run build` — clean production build (321KB / 101KB gzip)
- [x] POST working/blocked/done status → UI updates correctly
- [x] Status expires to idle after 15s (working) / 10s (done)
- [x] File watcher: edit .jsx → Developer WORKING, edit .test.js → QA WORKING
- [x] File watcher defers to hook-generated status
- [x] Page reload → no stale status carried over
- [x] HMR → polling survives component remount
- [x] Name tags: proper width for "QA" (30px) vs "Developer" (79px)
- [x] Activity Feed: shows organic behaviors + office events with unread badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)