### PR TITLE
feat: map arch and gate roles to Claude Code tools

### DIFF
--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -38,8 +38,10 @@ function toolToRole(tool) {
     Edit: 'dev', Write: 'dev', NotebookEdit: 'dev',
     Bash: 'ops',
     Read: 'res', Glob: 'res', Grep: 'res',
-    Agent: 'pm',
+    Agent: 'pm', TodoWrite: 'pm',
     WebFetch: 'res', WebSearch: 'res',
+    EnterPlanMode: 'arch', ExitPlanMode: 'arch',
+    AskUserQuestion: 'gate',
   }
   return map[tool] || 'dev'
 }
@@ -94,6 +96,13 @@ function extractContext(tool, toolInput) {
       case 'WebFetch':
       case 'WebSearch':
         return input.query || input.url?.replace(/^https?:\/\//, '').slice(0, 25) || null
+      case 'TodoWrite':
+        return input.todos?.length ? `${input.todos.length} tasks` : null
+      case 'EnterPlanMode':
+      case 'ExitPlanMode':
+        return null
+      case 'AskUserQuestion':
+        return input.questions?.[0]?.question?.slice(0, 25) || null
       default:
         return null
     }
@@ -120,7 +129,9 @@ function toolLabel(tool, context, isDone) {
       case 'Bash':   return `⚡ ${context}`
       case 'Grep':   return `🔎 搜 ${context}`
       case 'Glob':   return `🔍 找 ${context}`
-      case 'Agent':  return `📋 ${context}`
+      case 'Agent':
+      case 'TodoWrite':  return `📋 ${context}`
+      case 'AskUserQuestion':  return `🚪 確認：${context}`
       case 'WebFetch':
       case 'WebSearch': return `🌐 ${context}`
       default:       return `💻 ${context}`
@@ -139,6 +150,10 @@ function toolLabel(tool, context, isDone) {
     WebFetch:     ['🌐 查資料中', '🌐 上網看看'],
     WebSearch:    ['🌐 搜尋中', '🌐 找答案中'],
     NotebookEdit: ['📓 改 notebook', '📓 跑實驗中'],
+    TodoWrite:       ['📋 整理任務中', '📋 排工作'],
+    EnterPlanMode:   ['🏗️ 規劃架構中', '🏗️ 想想怎麼做'],
+    ExitPlanMode:    ['🏗️ 架構定案！', '🏗️ 計劃好了'],
+    AskUserQuestion: ['🚪 問問看', '🚪 確認一下'],
   }
   return pick(fallback[tool] || ['💻 處理中', '💻 忙著呢'])
 }

--- a/tests/officeStatusHook.test.js
+++ b/tests/officeStatusHook.test.js
@@ -29,9 +29,21 @@ describe('toolToRole', () => {
     expect(toolToRole('WebSearch')).toBe('res')
   })
 
+  it('maps TodoWrite to pm', () => {
+    expect(toolToRole('TodoWrite')).toBe('pm')
+  })
+
+  it('maps EnterPlanMode/ExitPlanMode to arch', () => {
+    expect(toolToRole('EnterPlanMode')).toBe('arch')
+    expect(toolToRole('ExitPlanMode')).toBe('arch')
+  })
+
+  it('maps AskUserQuestion to gate', () => {
+    expect(toolToRole('AskUserQuestion')).toBe('gate')
+  })
+
   it('defaults unknown tools to dev', () => {
     expect(toolToRole('UnknownTool')).toBe('dev')
-    expect(toolToRole('TodoWrite')).toBe('dev')
   })
 })
 
@@ -158,5 +170,24 @@ describe('extractContext (hook)', () => {
 
   it('returns null for unknown tool', () => {
     expect(extractContext('UnknownTool', { anything: 'here' })).toBeNull()
+  })
+
+  it('extracts task count from TodoWrite input', () => {
+    const result = extractContext('TodoWrite', { todos: [{ content: 'a' }, { content: 'b' }] })
+    expect(result).toBe('2 tasks')
+  })
+
+  it('returns null for TodoWrite with no todos', () => {
+    expect(extractContext('TodoWrite', {})).toBeNull()
+  })
+
+  it('extracts question from AskUserQuestion input', () => {
+    const result = extractContext('AskUserQuestion', { questions: [{ question: 'Which approach should we use for auth?' }] })
+    expect(result).toBe('Which approach should we ')
+  })
+
+  it('returns null for EnterPlanMode/ExitPlanMode', () => {
+    expect(extractContext('EnterPlanMode', {})).toBeNull()
+    expect(extractContext('ExitPlanMode', {})).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- **Architect** (`arch`) now activates on `EnterPlanMode`/`ExitPlanMode` — lights up when Claude plans before multi-step tasks
- **Gatekeeper** (`gate`) now activates on `AskUserQuestion` — lights up when Claude asks for human confirmation (quality gate)
- **PM** gets `TodoWrite` mapping — lights up when Claude manages task lists
- Context extraction + labels for all new tool mappings
- 8 new test assertions (92 total, all passing)

## Why
Previously `arch` and `gate` characters were permanently idle during real Claude Code usage because `toolToRole()` had no tool mapped to them. Only `skillToRole()` (SubagentStart/Stop) could trigger them, which fires rarely.

## Test plan
- [x] `npm test` — 92 tests pass
- [x] curl-verified arch + gate + dev all light up via `/api/status`
- [x] Simulated 5 real-world scenarios (bug fix, feature planning, consecutive failures, rapid operations, task management) — all roles activate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)