### PR TITLE
fix: hooks crash + auto port, i18n, onboarding

### DIFF
--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -38,8 +38,10 @@ function toolToRole(tool) {
     Edit: 'dev', Write: 'dev', NotebookEdit: 'dev',
     Bash: 'ops',
     Read: 'res', Glob: 'res', Grep: 'res',
-    Agent: 'pm',
+    Agent: 'pm', TodoWrite: 'pm',
     WebFetch: 'res', WebSearch: 'res',
+    EnterPlanMode: 'arch', ExitPlanMode: 'arch',
+    AskUserQuestion: 'gate',
   }
   return map[tool] || 'dev'
 }
@@ -94,6 +96,13 @@ function extractContext(tool, toolInput) {
       case 'WebFetch':
       case 'WebSearch':
         return input.query || input.url?.replace(/^https?:\/\//, '').slice(0, 25) || null
+      case 'TodoWrite':
+        return input.todos?.length ? `${input.todos.length} tasks` : null
+      case 'EnterPlanMode':
+      case 'ExitPlanMode':
+        return null
+      case 'AskUserQuestion':
+        return input.questions?.[0]?.question?.slice(0, 25) || null
       default:
         return null
     }
@@ -120,7 +129,9 @@ function toolLabel(tool, context, isDone) {
       case 'Bash':   return `⚡ ${context}`
       case 'Grep':   return `🔎 搜 ${context}`
       case 'Glob':   return `🔍 找 ${context}`
-      case 'Agent':  return `📋 ${context}`
+      case 'Agent':
+      case 'TodoWrite':  return `📋 ${context}`
+      case 'AskUserQuestion':  return `🚪 確認：${context}`
       case 'WebFetch':
       case 'WebSearch': return `🌐 ${context}`
       default:       return `💻 ${context}`
@@ -139,6 +150,10 @@ function toolLabel(tool, context, isDone) {
     WebFetch:     ['🌐 查資料中', '🌐 上網看看'],
     WebSearch:    ['🌐 搜尋中', '🌐 找答案中'],
     NotebookEdit: ['📓 改 notebook', '📓 跑實驗中'],
+    TodoWrite:       ['📋 整理任務中', '📋 排工作'],
+    EnterPlanMode:   ['🏗️ 規劃架構中', '🏗️ 想想怎麼做'],
+    ExitPlanMode:    ['🏗️ 架構定案！', '🏗️ 計劃好了'],
+    AskUserQuestion: ['🚪 問問看', '🚪 確認一下'],
   }
   return pick(fallback[tool] || ['💻 處理中', '💻 忙著呢'])
 }

--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -241,6 +241,7 @@ function processEvent(event) {
 
   const output = {
     _seq: String(Date.now()),
+    _cwd: process.cwd(),
     type: 'office-status',
     agents: newAgents,
     activeCount,

--- a/src/components/AgentInspector.jsx
+++ b/src/components/AgentInspector.jsx
@@ -26,6 +26,15 @@ export default function AgentInspector() {
     return () => window.removeEventListener('keydown', handler)
   }, [selectedAgent, clearSelectedAgent])
 
+  // Hooks must be called unconditionally (React Rules of Hooks),
+  // so this must appear before the early-return guard.
+  const recentActivities = useMemo(() => {
+    if (!selectedAgent) return []
+    return activityLog
+      .filter(a => a.agentId === selectedAgent)
+      .slice(0, 5)
+  }, [activityLog, selectedAgent])
+
   if (!selectedAgent || !agent) return null
 
   const name = charName(selectedAgent)
@@ -34,14 +43,6 @@ export default function AgentInspector() {
   const currentBehavior = behaviorLabel(agent.behavior)
   const task = ext?.label || ext?.task || null
   const color = agent.color || '#888'
-
-  // Recent activities for this agent (last 5)
-  const recentActivities = useMemo(() =>
-    activityLog
-      .filter(a => a.agentId === selectedAgent)
-      .slice(0, 5),
-    [activityLog, selectedAgent]
-  )
 
   const pos = agent.position || { x: 300, y: 250 }
 

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -4,16 +4,6 @@ import { behaviorLabel, charName, t, setLocale, availableLocales, useLocale, eve
 
 const statusOptions = ['idle', 'working', 'blocked', 'done']
 
-const platformLabels = {
-  browser: 'Browser',
-  'claude-cli': 'Claude CLI',
-  'claude-desktop': 'Claude Desktop',
-  'codex-app': 'Codex App',
-  'codex-cli': 'Codex CLI',
-  antigravity: 'Antigravity',
-  embedded: 'Embedded',
-}
-
 export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const agents = useOfficeStore((s) => s.agents)
   const isPaused = useOfficeStore((s) => s.isPaused)
@@ -26,6 +16,10 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const statusSource = useOfficeStore((s) => s.statusSource)
 
   const [showTest, setShowTest] = useState(false)
+  const [showInfo, setShowInfo] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return !localStorage.getItem('office-onboarded')
+  })
   const lang = useLocale()
   const agentList = Object.values(agents)
   const isPanel = mode === 'panel'
@@ -55,6 +49,11 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
     return labels[next] || next.toUpperCase()
   })()
 
+  const dismissInfo = () => {
+    setShowInfo(false)
+    localStorage.setItem('office-onboarded', '1')
+  }
+
   // ─── Panel mode: compact single-line status bar ───
   if (isPanel) {
     return (
@@ -74,7 +73,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
           {statusSource === 'external' && (
             <div className="flex items-center gap-0.5 shrink-0">
               <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-              <span className="text-emerald-600 dark:text-emerald-400 font-medium">Live</span>
+              <span className="text-emerald-600 dark:text-emerald-400 font-medium">{t('ui.live')}</span>
             </div>
           )}
           <button onClick={togglePause} className="px-1 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800">
@@ -88,6 +87,28 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   // ─── Full mode: standard control panel ───
   return (
     <div className="fixed bottom-0 left-0 right-0 bg-white/90 dark:bg-gray-900/90 backdrop-blur border-t border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs select-none z-50">
+      {/* Onboarding popover */}
+      {showInfo && (
+        <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 w-72 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-3 text-xs z-50">
+          <p className="text-gray-700 dark:text-gray-200 mb-2">
+            {t('onboarding.description')}
+          </p>
+          <div className="text-gray-400 dark:text-gray-500 space-y-0.5 mb-2">
+            <div>{t('onboarding.shortcutPause')}</div>
+            <div>{t('onboarding.shortcutLang')}</div>
+            <div>{t('onboarding.shortcutClick')}</div>
+          </div>
+          <button
+            onClick={dismissInfo}
+            className="w-full px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors text-[11px] font-medium"
+          >
+            {t('onboarding.gotIt')}
+          </button>
+          {/* Triangle pointer */}
+          <div className="absolute top-full left-1/2 -translate-x-1/2 w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-white dark:border-t-gray-800" />
+        </div>
+      )}
+
       <div className="flex items-center gap-3">
         <div className="text-gray-500 dark:text-gray-400 font-mono min-w-[42px]">
           {String(hour).padStart(2, '0')}:{String(minute).padStart(2, '0')}
@@ -121,20 +142,20 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         {statusSource === 'external' && (
           <div className="flex items-center gap-1 shrink-0">
             <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse" />
-            <span className="text-[10px] text-emerald-600 dark:text-emerald-400 font-medium">Live</span>
+            <span className="text-[10px] text-emerald-600 dark:text-emerald-400 font-medium">{t('ui.live')}</span>
           </div>
         )}
         {statusSource === 'fallback' && (
           <div className="flex items-center gap-1 shrink-0">
             <span className="inline-block w-1.5 h-1.5 rounded-full bg-yellow-500 animate-pulse" />
             <span className="text-[10px] text-yellow-600 dark:text-yellow-400 font-medium">
-              {Object.keys(externalStatus).length} agents
+              {t('ui.fallbackAgents').replace('{0}', Object.keys(externalStatus).length)}
             </span>
           </div>
         )}
 
         <div className="text-[10px] text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 px-1.5 py-0.5 rounded shrink-0">
-          {platformLabels[platform] || platform}
+          {t('ui.platforms.' + platform, platform)}
         </div>
 
         <div className="flex items-center gap-1.5 shrink-0">
@@ -145,14 +166,21 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
             {isPaused ? '▶' : '⏸'}
           </button>
           <button onClick={triggerWorkflow} className="px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors" title="Run workflow animation">
-            Run
+            {t('ui.run')}
           </button>
           <button
             onClick={() => setShowTest(!showTest)}
             className={`px-2 py-1 rounded border transition-colors ${showTest ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900 dark:text-orange-300' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
             title="Toggle test controls"
           >
-            Test
+            {t('ui.test')}
+          </button>
+          <button
+            onClick={() => setShowInfo(!showInfo)}
+            className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-300 text-[10px]"
+            title="Info"
+          >
+            ?
           </button>
         </div>
       </div>
@@ -182,7 +210,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
             ))}
           </div>
           <div className="mt-1 text-[10px] text-gray-400">
-            Set agent status to change behavior weights — working: more typing, blocked: frustrated, done: celebratory
+            {t('ui.testHint')}
           </div>
         </div>
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -206,5 +206,29 @@
     "smooth": "Smooth",
     "intense": "Intense",
     "idle": "Idle"
+  },
+  "ui": {
+    "live": "Live",
+    "fallbackAgents": "{0} agents",
+    "run": "Run",
+    "test": "Test",
+    "testHint": "Set agent status to change behavior weights — working: more typing, blocked: frustrated, done: celebratory",
+    "platforms": {
+      "browser": "Browser",
+      "claude-cli": "Claude CLI",
+      "claude-desktop": "Claude Desktop",
+      "codex-app": "Codex App",
+      "codex-cli": "Codex CLI",
+      "antigravity": "Antigravity",
+      "embedded": "Embedded"
+    }
+  },
+  "onboarding": {
+    "description": "This office visualizes your Claude Code session — each character reacts to your real coding activity.",
+    "shortcuts": "Keyboard shortcuts",
+    "shortcutPause": "Space — Pause / Resume",
+    "shortcutLang": "L — Switch language",
+    "shortcutClick": "Click agent — Inspector",
+    "gotIt": "Got it!"
   }
 }

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -206,5 +206,29 @@
     "smooth": "順風順水",
     "intense": "全力衝刺",
     "idle": "悠哉悠哉"
+  },
+  "ui": {
+    "live": "即時",
+    "fallbackAgents": "{0} 個 agent",
+    "run": "執行",
+    "test": "測試",
+    "testHint": "設定 agent 狀態以改變行為權重 — 工作中：更多打字，卡住：焦躁，完成：慶祝",
+    "platforms": {
+      "browser": "瀏覽器",
+      "claude-cli": "Claude CLI",
+      "claude-desktop": "Claude 桌面版",
+      "codex-app": "Codex App",
+      "codex-cli": "Codex CLI",
+      "antigravity": "Antigravity",
+      "embedded": "嵌入式"
+    }
+  },
+  "onboarding": {
+    "description": "這個辦公室會即時顯示你的 Claude Code 工作狀態 — 每個角色會隨著你的開發活動做出反應。",
+    "shortcuts": "快捷鍵",
+    "shortcutPause": "空白鍵 — 暫停 / 繼續",
+    "shortcutLang": "L — 切換語言",
+    "shortcutClick": "點擊角色 — 查看詳情",
+    "gotIt": "了解！"
   }
 }

--- a/tests/officeStatusHook.test.js
+++ b/tests/officeStatusHook.test.js
@@ -29,9 +29,21 @@ describe('toolToRole', () => {
     expect(toolToRole('WebSearch')).toBe('res')
   })
 
+  it('maps TodoWrite to pm', () => {
+    expect(toolToRole('TodoWrite')).toBe('pm')
+  })
+
+  it('maps EnterPlanMode/ExitPlanMode to arch', () => {
+    expect(toolToRole('EnterPlanMode')).toBe('arch')
+    expect(toolToRole('ExitPlanMode')).toBe('arch')
+  })
+
+  it('maps AskUserQuestion to gate', () => {
+    expect(toolToRole('AskUserQuestion')).toBe('gate')
+  })
+
   it('defaults unknown tools to dev', () => {
     expect(toolToRole('UnknownTool')).toBe('dev')
-    expect(toolToRole('TodoWrite')).toBe('dev')
   })
 })
 
@@ -158,5 +170,24 @@ describe('extractContext (hook)', () => {
 
   it('returns null for unknown tool', () => {
     expect(extractContext('UnknownTool', { anything: 'here' })).toBeNull()
+  })
+
+  it('extracts task count from TodoWrite input', () => {
+    const result = extractContext('TodoWrite', { todos: [{ content: 'a' }, { content: 'b' }] })
+    expect(result).toBe('2 tasks')
+  })
+
+  it('returns null for TodoWrite with no todos', () => {
+    expect(extractContext('TodoWrite', {})).toBeNull()
+  })
+
+  it('extracts question from AskUserQuestion input', () => {
+    const result = extractContext('AskUserQuestion', { questions: [{ question: 'Which approach should we use for auth?' }] })
+    expect(result).toBe('Which approach should we ')
+  })
+
+  it('returns null for EnterPlanMode/ExitPlanMode', () => {
+    expect(extractContext('EnterPlanMode', {})).toBeNull()
+    expect(extractContext('ExitPlanMode', {})).toBeNull()
   })
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -236,6 +236,9 @@ function fileWatcherFallbackPlugin() {
 
 export default defineConfig({
   plugins: [react(), tailwindcss(), officeStatusPlugin(), fileWatcherFallbackPlugin()],
+  server: {
+    strictPort: false,
+  },
   build: {
     rollupOptions: {
       output: { inlineDynamicImports: true }


### PR DESCRIPTION
## Summary

- **Fix hooks crash**: Move `useMemo` before early return in `AgentInspector.jsx` to prevent React "Rendered more hooks than during the previous render" error when clicking agents
- **Auto port**: Add `server.strictPort: false` to Vite config so it auto-increments port instead of crashing
- **i18n completion**: Extract 6 hardcoded English strings from ControlPanel (`Live`, `Run`, `Test`, `Browser`, test hint, fallback agents) to locale files with zh-TW translations
- **Onboarding popover**: First-visit auto-show info popover with app description + keyboard shortcuts, dismissible via "Got it!", re-openable via `?` button, fully bilingual
- **Session context**: Add `_cwd` field to hook status output for debugging multi-session scenarios

## Test plan

- [x] All 177 tests pass (`npx vitest run`)
- [ ] Click any agent character → Inspector opens without crash
- [ ] Switch to 中文 → verify Run→執行, Test→測試, Browser→瀏覽器
- [ ] First visit shows onboarding popover → click 了解 → reload → no popover
- [ ] Click `?` → popover re-appears with correct language
- [ ] Start two `npx agent-virtual-office` → second auto-picks different port

🤖 Generated with [Claude Code](https://claude.com/claude-code)