### PR TITLE
feat: v0.10 office vitality + 5-pass bug hardening

### DIFF
--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -864,6 +864,12 @@ function AgentCharacter({ agent }) {
     const watchdog = setInterval(() => {
       const agent = useOfficeStore.getState().agents[id]
       if (!agent) return
+      // Don't fire during group events — officeLife controls behavior and duration
+      if (agent.inGroupEvent) {
+        lastBehaviorRef.behavior = agent.behavior
+        lastBehaviorRef.since = Date.now()
+        return
+      }
       if (agent.behavior !== lastBehaviorRef.behavior) {
         lastBehaviorRef.behavior = agent.behavior
         lastBehaviorRef.since = Date.now()

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -810,8 +810,8 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
       <text x={40} y={184} textAnchor="middle" fontSize="5.5" fill="#7F77DD" fontFamily="monospace">SHIP IT</text>
       <text x={40} y={193} textAnchor="middle" fontSize="4.5" fill="#888" fontFamily="monospace">everyday</text>
 
-      {/* Sprint Kanban board on north wall */}
-      <SprintKanban x={80} y={163} doneCount={totalDoneToday} />
+      {/* Sprint Kanban board on north wall, planning area (clear of door at x=88-140) */}
+      <SprintKanban x={160} y={165} doneCount={totalDoneToday} />
 
       {/* Team area labels */}
       <text x={200} y={200} textAnchor="middle" fontSize="7" fill="#378ADD" fontFamily="monospace" opacity="0.4">PLANNING</text>

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -12,6 +12,51 @@ import {
   ServerRack, Clock, Printer, Rug, CoffeeCup, DeskLamp
 } from './TopDownFurniture'
 
+// ─── Sprint Kanban Board ─────────────────────────────────────────────────
+function SprintKanban({ x, y, doneCount = 0 }) {
+  const W = 78, H = 52
+  const MAX_CELLS = 6  // 3 rows × 2 per row, leaves row 4 for overflow text
+  const filled = Math.min(doneCount, MAX_CELLS)
+  const overflow = doneCount > MAX_CELLS ? doneCount - MAX_CELLS : 0
+  const todoCards = ['#F5A623', '#7F77DD', '#4A90D9']
+  const doingCards = ['#1D9E75', '#E24B4A']
+  return (
+    <g>
+      <rect x={x} y={y} width={W} height={H} rx={2} fill="#F8F4E8" stroke="#C8C0A8" strokeWidth="0.8" />
+      {/* Header bar */}
+      <rect x={x} y={y} width={W} height={10} rx={2} fill="#7070A0" opacity="0.9" />
+      <text x={x + 28} y={y + 7} textAnchor="middle" fontSize="5" fill="white" fontFamily="monospace" fontWeight="bold">SPRINT</text>
+      <text x={x + W - 4} y={y + 7} textAnchor="end" fontSize="4.5" fill="#FFE08A" fontFamily="monospace" fontWeight="bold">{doneCount}</text>
+      {/* Column dividers */}
+      <line x1={x + 26} y1={y + 10} x2={x + 26} y2={y + H} stroke="#D8D0C0" strokeWidth="0.6" />
+      <line x1={x + 52} y1={y + 10} x2={x + 52} y2={y + H} stroke="#D8D0C0" strokeWidth="0.6" />
+      {/* Column headers */}
+      <text x={x + 13} y={y + 17} textAnchor="middle" fontSize="3.5" fill="#999" fontFamily="monospace">TODO</text>
+      <text x={x + 39} y={y + 17} textAnchor="middle" fontSize="3.5" fill="#999" fontFamily="monospace">DOING</text>
+      <text x={x + 65} y={y + 17} textAnchor="middle" fontSize="3.5" fill={filled > 0 ? '#2E7D32' : '#999'} fontFamily="monospace" fontWeight={filled > 0 ? 'bold' : 'normal'}>DONE</text>
+      {/* TODO column: static colored task cards */}
+      {todoCards.map((color, i) => (
+        <rect key={i} x={x + 3} y={y + 20 + i * 8} width={20} height={6} rx={1} fill={color} opacity="0.25" />
+      ))}
+      {/* DOING column: static cards */}
+      {doingCards.map((color, i) => (
+        <rect key={i} x={x + 29} y={y + 20 + i * 8} width={20} height={6} rx={1} fill={color} opacity="0.35" />
+      ))}
+      {/* DONE column: fills dynamically — max 6 cells (3 rows × 2) */}
+      {Array.from({ length: filled }).map((_, i) => (
+        <rect key={i}
+          x={x + 55 + (i % 2) * 9} y={y + 20 + Math.floor(i / 2) * 8}
+          width={7} height={6} rx={1} fill="#4CAF50" opacity="0.75"
+        />
+      ))}
+      {/* Row 4: overflow indicator when done count exceeds 6 */}
+      {overflow > 0 && (
+        <text x={x + 65} y={y + 47} textAnchor="middle" fontSize="4" fill="#2E7D32" fontFamily="monospace" fontWeight="bold">+{overflow}</text>
+      )}
+    </g>
+  )
+}
+
 // ─── Flying Document Animation ──────────────────────────────────────────
 function FlyingDocument({ fromPos, toPos, onComplete }) {
   const [progress, setProgress] = React.useState(0)
@@ -548,6 +593,9 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
   const coffeeCounts = useOfficeStore(useShallow((s) => DESK_IDS.map((id) => s.agents[id]?.deskItemCount?.coffee || 0)))
   const stickyCounts = useOfficeStore(useShallow((s) => DESK_IDS.map((id) => s.agents[id]?.deskItemCount?.sticky || 0)))
   const booksCounts = useOfficeStore(useShallow((s) => DESK_IDS.map((id) => s.agents[id]?.deskItemCount?.books || 0)))
+  const totalDoneToday = useOfficeStore((s) =>
+    Object.values(s.dailyDoneLedger?.counts || {}).reduce((sum, c) => sum + c, 0)
+  )
   const hour = useOfficeStore((s) => s.hour)
   const minute = useOfficeStore((s) => s.minute)
   const activeEvent = useOfficeStore((s) => s.activeEvent)
@@ -761,6 +809,9 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
       <rect x={15} y={170} width={50} height={28} rx={2} fill="#F5F0E0" stroke="#CCC" strokeWidth="0.8" />
       <text x={40} y={184} textAnchor="middle" fontSize="5.5" fill="#7F77DD" fontFamily="monospace">SHIP IT</text>
       <text x={40} y={193} textAnchor="middle" fontSize="4.5" fill="#888" fontFamily="monospace">everyday</text>
+
+      {/* Sprint Kanban board on north wall */}
+      <SprintKanban x={80} y={163} doneCount={totalDoneToday} />
 
       {/* Team area labels */}
       <text x={200} y={200} textAnchor="middle" fontSize="7" fill="#378ADD" fontFamily="monospace" opacity="0.4">PLANNING</text>

--- a/src/config/officeEvents.json
+++ b/src/config/officeEvents.json
@@ -55,6 +55,27 @@
       "participants": "random-2-3",
       "duration": 20000,
       "description": "2-3人走到會議室開會"
+    },
+    {
+      "id": "dev-arch-disagree",
+      "name": "技術爭論",
+      "participants": ["dev", "arch"],
+      "duration": 20000,
+      "description": "dev 和 arch 對設計方向不同意見，來回辯論後妥協"
+    },
+    {
+      "id": "ops-dev-deploy-check",
+      "name": "能部署了嗎",
+      "participants": ["ops", "dev"],
+      "duration": 16000,
+      "description": "ops 問 dev 能不能 deploy，dev 猶豫後答應"
+    },
+    {
+      "id": "pm-all-meeting",
+      "name": "臨時小會",
+      "participants": "all",
+      "duration": 18000,
+      "description": "PM 宣布臨時開會，其他人翻白眼後勉強去會議室"
     }
   ],
   "rare": [

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,7 +54,10 @@
     "dog-visit": { "name": "Office Dog", "description": "A dog running around the office" },
     "ac-broken": { "name": "AC Broke", "description": "Everyone fanning themselves, sweat drops" },
     "boss-visit": { "name": "Boss Walk-by", "description": "Everyone sits up straight and pretends to be busy" },
-    "group-stretch": { "name": "Group Stretch", "description": "Everyone stretches at the same time" }
+    "group-stretch": { "name": "Group Stretch", "description": "Everyone stretches at the same time" },
+    "dev-arch-disagree": { "name": "Tech Debate", "description": "Dev and Arch disagree on design, argue, then compromise" },
+    "ops-dev-deploy-check": { "name": "Deploy Check", "description": "Ops asks Dev if it's safe to deploy, Dev hesitates then agrees" },
+    "pm-all-meeting": { "name": "Surprise Sync", "description": "PM calls a sudden meeting, everyone grudgingly shows up" }
   },
   "bubbles": {
     "typing": ["hmm...", "this looks ugly...", "almost done!", "forgot a semicolon", "SO save me"],
@@ -104,7 +107,21 @@
     "ac-broken": ["so hot...", "fan me please", "who broke the AC?", "melting..."],
     "ac-fan": "💨 ahhh~",
     "group-stretch": ["stretch~", "my back...", "ahh feels good", "deep breath~"],
-    "lunch-nap": ["zzz...", "food coma~", "nap time", "so sleepy after lunch"]
+    "lunch-nap": ["zzz...", "food coma~", "nap time", "so sleepy after lunch"],
+    "dev-arch-dis-1": ["this design is wrong", "the architecture is off", "I have a better way"],
+    "arch-dis-1": ["stick to the plan", "design is finalized", "trust my judgment"],
+    "dev-arch-dis-2": ["but it'll be slow", "look at this bottleneck", "how does this scale?"],
+    "arch-dis-2": ["then what do you propose?", "hmm...go on", "that's fair, continue"],
+    "dev-arch-dis-3": "...fine, for now",
+    "arch-dis-3": "told you it'd be fine",
+    "ops-dev-check-1": "ready to deploy?",
+    "ops-dev-check-2": "really ready this time?",
+    "ops-dev-check-3": "🚀 deploying!",
+    "dev-ops-check-1": "gimme a sec...almost there",
+    "dev-ops-check-2": "OK! we're good!",
+    "pm-meeting-call": "quick sync everyone! 📢",
+    "pm-meeting-react": ["another meeting...", "seriously?", "ok fine...", "how long?"],
+    "pm-meeting-lead": "listen up everyone~"
   },
   "statusLabels": {
     "working": "Working",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -54,7 +54,10 @@
     "dog-visit": { "name": "有人帶狗", "description": "小狗在辦公室跑來跑去" },
     "ac-broken": { "name": "空調壞了", "description": "所有人搧風動作，冒汗滴" },
     "boss-visit": { "name": "老闆巡視", "description": "所有人回座位坐好假裝忙" },
-    "group-stretch": { "name": "集體伸懶腰", "description": "所有人同時伸懶腰" }
+    "group-stretch": { "name": "集體伸懶腰", "description": "所有人同時伸懶腰" },
+    "dev-arch-disagree": { "name": "技術爭論", "description": "dev 和 arch 對設計方向不同意見，來回辯論後妥協" },
+    "ops-dev-deploy-check": { "name": "能部署了嗎", "description": "ops 問 dev 能不能 deploy，dev 猶豫後答應" },
+    "pm-all-meeting": { "name": "臨時小會", "description": "PM 宣布臨時開會，其他人翻白眼後勉強去會議室" }
   },
   "bubbles": {
     "typing": ["嗯嗯嗯...", "這段好醜...", "快好了!", "忘了分號", "SO 救我"],
@@ -104,7 +107,21 @@
     "ac-broken": ["好熱...", "搧一下", "誰弄壞冷氣的？", "快融化了..."],
     "ac-fan": "💨 呼~",
     "group-stretch": ["伸懶腰~", "腰好痠...", "舒服~", "深呼吸~"],
-    "lunch-nap": ["zzz...", "飯後好睏~", "午休一下", "吃飽就想睡"]
+    "lunch-nap": ["zzz...", "飯後好睏~", "午休一下", "吃飽就想睡"],
+    "dev-arch-dis-1": ["這個設計有問題", "架構這樣不對吧", "我有更好的方法"],
+    "arch-dis-1": ["照計劃走", "設計是這樣定的", "信任我的判斷"],
+    "dev-arch-dis-2": ["但效能會很差", "你看這個 bottleneck", "這樣怎麼 scale？"],
+    "arch-dis-2": ["那你說怎麼辦？", "嗯...說來聽聽", "有道理繼續說"],
+    "dev-arch-dis-3": "...好吧先這樣",
+    "arch-dis-3": "我說會 OK 的",
+    "ops-dev-check-1": "能 deploy 了嗎？",
+    "ops-dev-check-2": "真的 ready 了？",
+    "ops-dev-check-3": "🚀 開始部署！",
+    "dev-ops-check-1": "等我一下...還差一點",
+    "dev-ops-check-2": "好了！可以了",
+    "pm-meeting-call": "臨時開個小會！📢",
+    "pm-meeting-react": ["又開會...", "怎麼又？", "好吧...", "幾分鐘？"],
+    "pm-meeting-lead": "大家注意一下~"
   },
   "statusLabels": {
     "working": "工作中",

--- a/src/systems/behaviorEngine.js
+++ b/src/systems/behaviorEngine.js
@@ -64,8 +64,9 @@ function weightedRandom(weights) {
 }
 
 function pickBehavior(agentId, category) {
+  const baseRole = agentId.includes('~') ? agentId.split('~').pop() : agentId
   const pool = behaviors[category] || behaviors.work
-  const valid = pool.filter((b) => !b.only || b.only.includes(agentId))
+  const valid = pool.filter((b) => !b.only || b.only.includes(baseRole))
   if (valid.length === 0) return { behaviorId: 'typing', msgKey: null, duration: 8000 }
   return valid[Math.floor(Math.random() * valid.length)]
 }

--- a/src/systems/behaviorEngine.js
+++ b/src/systems/behaviorEngine.js
@@ -75,7 +75,7 @@ function pickMessage(msgKey) {
   // Try i18n locale first, fall back to officeEvents.json
   const localized = randomBubble(msgKey)
   if (localized) return localized
-  const pool = eventsData.bubbleMessages[msgKey]
+  const pool = eventsData.bubbleMessages?.[msgKey]
   if (!pool || pool.length === 0) return null
   return pool[Math.floor(Math.random() * pool.length)]
 }

--- a/src/systems/contextBubble.js
+++ b/src/systems/contextBubble.js
@@ -76,32 +76,35 @@ export function toolToAction(task) {
 export function generateContextBubble(agentId, update, allExternalStatus) {
   if (!update) return null
 
+  // Strip worktree session prefix so 'feat-x~dev' resolves to 'dev' templates
+  const baseRole = agentId.includes('~') ? agentId.split('~').pop() : agentId
+
   const { status, task, label, hint } = update
   const ctx = extractContext(label)
   const action = toolToAction(task)
 
   // 1. Error reactions — highest priority, always show
   if (hint === 'error' || status === 'blocked') {
-    const errorBubble = fromTemplate(`${agentId}-error`, ctx)
+    const errorBubble = fromTemplate(`${baseRole}-error`, ctx)
       || fromTemplate('any-error', ctx)
     if (errorBubble) return errorBubble
   }
 
   // 2. Done reactions
   if (status === 'done') {
-    const doneBubble = fromTemplate(`${agentId}-done`, ctx)
+    const doneBubble = fromTemplate(`${baseRole}-done`, ctx)
       || fromTemplate('any-done', ctx)
     if (doneBubble) return doneBubble
   }
 
   // 3. Role × action specific (e.g., dev-edit, qa-search, ops-bash)
   if (action) {
-    const specific = fromTemplate(`${agentId}-${action}`, ctx)
+    const specific = fromTemplate(`${baseRole}-${action}`, ctx)
     if (specific) return specific
   }
 
   // 4. Role generic working
-  const working = fromTemplate(`${agentId}-working`, ctx)
+  const working = fromTemplate(`${baseRole}-working`, ctx)
   if (working) return working
 
   // 5. Cross-agent awareness — react to other agents

--- a/src/systems/officeLife.js
+++ b/src/systems/officeLife.js
@@ -287,6 +287,7 @@ const EVENT_HANDLERS = {
   },
 
   'pm-all-meeting': (store, participants, cancelled) => {
+    if (!participants.includes('pm')) return
     const s = store.getState()
     if (!s.agents['pm']) return
     s.setAgentGroupEvent('pm', {

--- a/src/systems/officeLife.js
+++ b/src/systems/officeLife.js
@@ -225,6 +225,84 @@ const EVENT_HANDLERS = {
     }, 8000)
   },
 
+  'dev-arch-disagree': (store, participants, cancelled) => {
+    const s = store.getState()
+    if (!s.agents['dev'] || !s.agents['arch']) return
+    const meetPoint = { x: 300, y: 305 }
+    s.setAgentGroupEvent('dev', {
+      behavior: 'chat', expression: 'confused',
+      bubble: eventBubble('dev-arch-dis-1'),
+      groupTarget: jitter({ x: meetPoint.x - 20, y: meetPoint.y }, 8),
+    })
+    s.setAgentGroupEvent('arch', {
+      behavior: 'whiteboard', expression: 'focused',
+      bubble: eventBubble('arch-dis-1'),
+      groupTarget: jitter({ x: meetPoint.x + 20, y: meetPoint.y }, 8),
+    })
+    setTimeout(() => {
+      if (cancelled?.value) return
+      const s = store.getState()
+      if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'chat', 'focused', eventBubble('dev-arch-dis-2'))
+      if (s.agents.arch?.inGroupEvent) s.setAgentBehavior('arch', 'chat', 'normal', eventBubble('arch-dis-2'))
+    }, 6000)
+    setTimeout(() => {
+      if (cancelled?.value) return
+      const s = store.getState()
+      if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'typing', 'normal', eventBubble('dev-arch-dis-3'))
+      if (s.agents.arch?.inGroupEvent) s.setAgentBehavior('arch', 'chat', 'happy', eventBubble('arch-dis-3'))
+    }, 13000)
+  },
+
+  'ops-dev-deploy-check': (store, participants, cancelled) => {
+    const s = store.getState()
+    if (!s.agents['ops'] || !s.agents['dev']) return
+    const devPos = HOME_POSITIONS.dev || { x: 340, y: 364 }
+    s.setAgentGroupEvent('ops', {
+      behavior: 'chat', expression: 'normal',
+      bubble: eventBubble('ops-dev-check-1'),
+      groupTarget: jitter({ x: devPos.x + 35, y: devPos.y }, 10),
+    })
+    setTimeout(() => {
+      if (cancelled?.value) return
+      const s = store.getState()
+      if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'scratch-head', 'confused', eventBubble('dev-ops-check-1'))
+      if (s.agents.ops?.inGroupEvent) s.setAgentBehavior('ops', 'chat', 'normal', eventBubble('ops-dev-check-2'))
+    }, 4000)
+    setTimeout(() => {
+      if (cancelled?.value) return
+      const s = store.getState()
+      if (s.agents.dev?.inGroupEvent) s.setAgentBehavior('dev', 'thumbs-up', 'happy', eventBubble('dev-ops-check-2'))
+      if (s.agents.ops?.inGroupEvent) s.setAgentBehavior('ops', 'deploy-button', 'happy', eventBubble('ops-dev-check-3'))
+    }, 10000)
+  },
+
+  'pm-all-meeting': (store, participants, cancelled) => {
+    const s = store.getState()
+    if (!s.agents['pm']) return
+    s.setAgentGroupEvent('pm', {
+      behavior: 'chat', expression: 'happy',
+      bubble: eventBubble('pm-meeting-call'),
+      groupTarget: null,
+    })
+    setTimeout(() => {
+      if (cancelled?.value) return
+      const chairs = [...MEETING_CHAIRS].sort(() => Math.random() - 0.5)
+      const otherIds = participants.filter(id => id !== 'pm')
+      store.getState().setMultipleAgentGroupEvents(
+        otherIds.map((id, i) => ({
+          id, behavior: 'meeting', expression: 'confused',
+          bubble: eventBubble('pm-meeting-react'),
+          groupTarget: jitter(chairs[(i + 1) % chairs.length], 6),
+        }))
+      )
+      store.getState().setAgentGroupEvent('pm', {
+        behavior: 'meeting', expression: 'happy',
+        bubble: eventBubble('pm-meeting-lead'),
+        groupTarget: jitter(chairs[0], 6),
+      })
+    }, 2500)
+  },
+
   // ─── Rare events ─────────────────────────────────────────────────
 
   'boss-visit': (store, participants, cancelled) => {

--- a/src/systems/officeLife.js
+++ b/src/systems/officeLife.js
@@ -257,6 +257,11 @@ const EVENT_HANDLERS = {
     const s = store.getState()
     if (!s.agents['ops'] || !s.agents['dev']) return
     const devPos = HOME_POSITIONS.dev || { x: 340, y: 364 }
+    // Lock dev in place so doSchedule doesn't move them away while ops walks over
+    s.setAgentGroupEvent('dev', {
+      behavior: 'typing', expression: 'normal',
+      bubble: null, groupTarget: null,
+    })
     s.setAgentGroupEvent('ops', {
       behavior: 'chat', expression: 'normal',
       bubble: eventBubble('ops-dev-check-1'),

--- a/src/systems/officeLife.js
+++ b/src/systems/officeLife.js
@@ -141,6 +141,7 @@ const EVENT_HANDLERS = {
   },
 
   'eureka': (store, participants) => {
+    if (!participants.includes('arch')) return
     const s = store.getState()
     if (!s.agents['arch']) return
     s.setAgentGroupEvent('arch', {
@@ -152,6 +153,7 @@ const EVENT_HANDLERS = {
   },
 
   'review-debate': (store, participants, cancelled) => {
+    if (!participants.includes('dev') || !participants.includes('qa')) return
     const s = store.getState()
     if (!s.agents['dev'] || !s.agents['qa']) return
     const devPos = HOME_POSITIONS.dev || { x: 340, y: 364 }
@@ -185,6 +187,7 @@ const EVENT_HANDLERS = {
   },
 
   'deploy-success': (store, participants, cancelled) => {
+    if (!participants.includes('ops')) return
     const s = store.getState()
     if (!s.agents['ops']) return
     s.setAgentGroupEvent('ops', {
@@ -226,6 +229,7 @@ const EVENT_HANDLERS = {
   },
 
   'dev-arch-disagree': (store, participants, cancelled) => {
+    if (!participants.includes('dev') || !participants.includes('arch')) return
     const s = store.getState()
     if (!s.agents['dev'] || !s.agents['arch']) return
     const meetPoint = { x: 300, y: 305 }
@@ -254,6 +258,7 @@ const EVENT_HANDLERS = {
   },
 
   'ops-dev-deploy-check': (store, participants, cancelled) => {
+    if (!participants.includes('ops') || !participants.includes('dev')) return
     const s = store.getState()
     if (!s.agents['ops'] || !s.agents['dev']) return
     const devPos = HOME_POSITIONS.dev || { x: 340, y: 364 }

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -404,7 +404,7 @@ export const useOfficeStore = create((set) => ({
         // Context-aware bubble > status pool fallback
         const bubble = generateContextBubble(u.agentId, u, ext)
           || randomBubble(u.status === 'blocked' ? 'blocked-status' : u.status === 'done' ? 'done-status' : 'working-status')
-        if (bubble) agents[u.agentId] = { ...agents[u.agentId], bubble }
+        if (bubble && !inGroup) agents[u.agentId] = { ...agents[u.agentId], bubble }
         // Log activity inline (single loop instead of two)
         if (u.status === 'done' || u.status === 'blocked' || (u.status === 'working' && u.label)) {
           activities.push(mkActivity({ type: 'status', agentId: u.agentId, status: u.status, message: u.label || u.status }))

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -306,7 +306,7 @@ export const useOfficeStore = create((set) => ({
       const agent = s.agents[id]
       if (!agent) return s
       const count = { ...agent.deskItemCount }
-      count[item] = ((count[item] || 0) + 1) % 6
+      count[item] = Math.min((count[item] || 0) + 1, 5)
       return { agents: { ...s.agents, [id]: { ...agent, deskItemCount: count } } }
     }),
 

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -350,6 +350,12 @@ export const useOfficeStore = create((set) => ({
       const agents = { ...s.agents }
       const activities = []
       const dailyDoneLedger = ensureCurrentDailyDoneLedger(s.dailyDoneLedger, now)
+      const dayChanged = s.dailyDoneLedger?.dayKey && dailyDoneLedger.dayKey !== s.dailyDoneLedger.dayKey
+      if (dayChanged) {
+        for (const id of Object.keys(agents)) {
+          agents[id] = { ...agents[id], deskItemCount: { coffee: 0, sticky: 0, books: 0 } }
+        }
+      }
       for (const u of updates) {
         const previousStatus = ext[u.agentId]?.status || agents[u.agentId]?.status || 'idle'
         if (!agents[u.agentId]) {
@@ -426,7 +432,7 @@ export const useOfficeStore = create((set) => ({
           const agent = agents[u.agentId]
           if (agent) {
             const count = { ...agent.deskItemCount }
-            count[growthItem] = ((count[growthItem] || 0) + 1) % 6
+            count[growthItem] = Math.min((count[growthItem] || 0) + 1, 5)
             agents[u.agentId] = { ...agent, deskItemCount: count }
           }
         }

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -421,19 +421,21 @@ export const useOfficeStore = create((set) => ({
               dailyDoneLedger.seenEventKeys = [...dailyDoneLedger.seenEventKeys, eventKey].slice(-500)
             }
           }
-          // Growth system: accumulate desk items on done events
-          const roleItems = {
-            pm: 'sticky', arch: 'books', dev: 'coffee',
-            qa: 'sticky', ops: 'coffee', res: 'books',
-            gate: 'sticky', designer: 'sticky',
-          }
-          const baseRole = u.agentId.includes('~') ? u.agentId.split('~')[1] : u.agentId
-          const growthItem = roleItems[baseRole] || 'coffee'
-          const agent = agents[u.agentId]
-          if (agent) {
-            const count = { ...agent.deskItemCount }
-            count[growthItem] = Math.min((count[growthItem] || 0) + 1, 5)
-            agents[u.agentId] = { ...agent, deskItemCount: count }
+          // Growth system: accumulate desk items on genuinely new done transitions only
+          if (isFreshDoneTransition) {
+            const roleItems = {
+              pm: 'sticky', arch: 'books', dev: 'coffee',
+              qa: 'sticky', ops: 'coffee', res: 'books',
+              gate: 'sticky', designer: 'sticky',
+            }
+            const baseRole = u.agentId.includes('~') ? u.agentId.split('~')[1] : u.agentId
+            const growthItem = roleItems[baseRole] || 'coffee'
+            const agent = agents[u.agentId]
+            if (agent) {
+              const count = { ...agent.deskItemCount }
+              count[growthItem] = Math.min((count[growthItem] || 0) + 1, 5)
+              agents[u.agentId] = { ...agent, deskItemCount: count }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

v0.10 Office Vitality feature + five rounds of defensive review & fixes.

### Feature (5b79616)
- **Growth system**: desk items accumulate as agents complete work (coffee/sticky/books, role-specific, max 5)
- **3 new interactive events**: eureka (whiteboard click), deploy-success (deploy button click), tea-break (coffee machine click)
- **Sprint Kanban**: on-wall board showing live daily done count across all agents

### Bug fixes across 5 review passes

**Pass 2 (78e9a21)**: event double-dispatch lock, counter cap, kanban clipping
**Pass 3 (2cd6a0e)**: growth dedup, watchdog vs group event conflict, 5 hardcoded-agent handlers missing participant guards, behaviorEngine crash guard
**Pass 4 (62d2172)**: `contextBubble.generateContextBubble` never resolved role-specific templates for worktree agents (`feat-x~dev` → always hit `any-*` fallbacks)
**Pass 5 (aa6ffd4)**: 3 more
- `behaviorEngine.pickBehavior` matched `b.only` against session-prefixed ID — worktree arch/qa/ops/res agents lost role-specific behaviors
- `officeLife.pm-all-meeting` missing `participants.includes('pm')` guard — pm stuck with `inGroupEvent` forever if externally busy
- `store.applyExternalStatus` `inGroupEvent` guard applied to behavior/expression but not bubble — event narrative silently overwritten by hook updates

## Test plan

- [x] 149/149 unit tests pass
- [ ] Manual: load office with external hook integration, verify role-specific bubbles for worktree agents (`feat-x~dev`, `feat-x~arch`)
- [ ] Manual: trigger `pm-all-meeting` while pm is externally busy → confirm pm stays external (not stuck)
- [ ] Manual: trigger `standup` event, then fire hook updates on a participant → confirm event bubble persists (no hook-bubble override)
- [ ] Manual: worktree arch agent with status=idle → should occasionally do whiteboard/research behaviors

🤖 Generated with [Claude Code](https://claude.com/claude-code)