### PR TITLE
docs(v1.1.0): backfill 11 feature specs + architecture + design + decision logs

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,7 +12,7 @@
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
 - **Last Updated**: 2026-05-29
-- **Update Sequence**: 18
+- **Update Sequence**: 19
 - **ADR Index**:
   - `.agentcortex/adr/ADR-001-vnext-self-managed-architecture.md`
   - `docs/adr/ADR-003-status-source-parity-for-codex.md`
@@ -53,6 +53,17 @@
   - [architecture] docs/specs/codex-status-parity-and-done-count.md [Shipped]
   - [feature] docs/specs/character-growth-system.md [Shipped]
   - [feature] docs/specs/clickable-office-objects.md [Shipped]
+  - [v1.1.0 classifier] docs/specs/classifier-foundation.md [Shipped]  *(#A1)*
+  - [v1.1.0 classifier] docs/specs/classifier-wiring.md [Shipped]  *(#A2 + #A2.1)*
+  - [v1.1.0 classifier] docs/specs/classifier-unknown-log.md [Shipped]  *(#A3)*
+  - [v1.1.0 classifier] docs/specs/mcp-inner-verb-fix.md [Shipped]  *(MCP follow-up)*
+  - [v1.1.0 visual] docs/specs/perf-metrics-chip.md [Shipped]  *(#6)*
+  - [v1.1.0 visual] docs/specs/weather-system.md [Shipped]  *(#14 + #15 closure)*
+  - [v1.1.0 visual] docs/specs/tool-inventory-label.md [Shipped]  *(AVO-103)*
+  - [v1.1.0 visual] docs/specs/workflow-handoff-arrows.md [Shipped]  *(AVO-105)*
+  - [v1.1.0 inference] docs/specs/desktop-notifications.md [Shipped]  *(#8)*
+  - [v1.1.0 inference] docs/specs/idle-gap-inference.md [Shipped]  *(#C)*
+  - [v1.1.0 compatibility] docs/specs/csp-compatibility.md [Shipped]  *(#27)*
   - When reading specs: only open files tagged with the current task's module.
 - **Canonical Commands**:
   - `/spec-intake`: Import external specs (from other LLMs, documents, or natural language). Handles large product specs via decomposition. Runs before `/bootstrap`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -534,3 +534,184 @@ server.tool('get_office_vibe', { project_root: 'string' }, async ({ project_root
 ```
 
 但這是以後的事。先把辦公室做活、做可愛。
+
+---
+
+## v1.1.0 — Classifier + Inference Layer (2026-05-29)
+
+This section appends the architectural additions shipped in the v1.1.0
+classifier + observability wave. The pre-v1.1 sections above describe
+the original status/behavior/movement runtime — that layer is unchanged.
+v1.1.0 adds **a classification pipeline above the existing store
+subscriptions and a polling-based inference layer alongside the existing
+SSE/poll integration**.
+
+```
+                                          ┌─────────────────────────┐
+                                          │   Hook events (status)  │
+                                          └────────────┬────────────┘
+                                                       │
+                                                       ▼
+                                          ┌─────────────────────────┐
+                                          │  inferStatus.applyMessage │
+                                          └────────────┬────────────┘
+                                                       │
+                          ┌────────────────────────────┼────────────────────────────┐
+                          ▼                            ▼                            ▼
+              ┌──────────────────────┐  ┌─────────────────────────┐  ┌──────────────────────────┐
+              │  applyExternalStatus │  │   pushEventBatch (mood)  │  │  startWorkflowHandoffs   │
+              │  (store mutation)    │  │   moodEngine sliding-win │  │  (subscription watcher)  │
+              └──────────┬───────────┘  └────────────┬─────────────┘  └────────────┬─────────────┘
+                         │                            │                            │
+                         │              ┌─────────────┴─────────────┐               │
+                         ▼              ▼                           ▼               ▼
+                  ┌─────────────┐ ┌──────────────┐         ┌──────────────┐ ┌──────────────────┐
+                  │decideBehavior│ │moodToWeather │         │  Weather     │ │  addHandoff      │
+                  │  resolver   │ │  delegator   │         │  Overlay     │ │  (subtle: true)  │
+                  └──────┬──────┘ └──────┬───────┘         └──────────────┘ └──────────────────┘
+                         │               │
+                         ▼               ▼
+                ┌──────────────┐ ┌──────────────┐
+                │ classifyTask │ │ classifyMood │
+                │  + Role +    │ │              │
+                │  Workflow    │ │              │
+                └──────────────┘ └──────────────┘
+
+Meanwhile, two polling watchers run on a separate cadence:
+
+  desktopNotifier (5s tick)     idleGapInfer (10s tick)
+  ──────────────────────         ──────────────────────
+  blocked ≥ 30s                  working+45s gap → 'thinking'
+  + tab.hidden                   blocked+90s gap → 'awaiting-approval'
+  + permission granted           Routes inferred status back through
+  → browser Notification         applyExternalStatus(meta.source='idle-gap-infer')
+```
+
+### Layer 1 — Standards-aligned classifier (`src/systems/classify.js`)
+
+**Four-tier waterfall.** Every raw signal (task name, status, mood,
+role, workflow) is classified into a `{ tier, family, severity, visualLabel, a11yLabel, raw }` shape:
+
+- **Tier 0** — Built-in registry: Claude Code's 11 canonical tools
+  (Bash / Read / Edit / Write / Grep / Glob / Task / WebFetch /
+  WebSearch / NotebookEdit / ExitPlanMode) + TodoRead / TodoWrite.
+  Hand-mapped to FAMILIES.
+- **Tier 3** — Verb heuristic: word-boundary regex on the tool name
+  using **[W3C Activity Streams 2.0](https://www.w3.org/TR/activitystreams-vocabulary/)
+  verb taxonomy** (Read / Create / Update / Delete / Search / Execute /
+  Auth / Communicate / Navigate / Dispatch / Memory). Word-boundary
+  matters: `redo` must not match `read*`, `delegate` must not match
+  `delete*`. Tested explicitly.
+- **Tier 4** — MCP namespace: `mcp__server__tool` is parsed into
+  `(server, tool)`; the inner tool name is then re-classified via
+  Tier 3 verbs so the *family* bubbles up (`mcp__notion__create_page`
+  → `family: CREATE, subFamily: notion`). Was Tier 4 → flat EXTERNAL
+  in initial #A2; promoted to inner-verb routing in the follow-up fix.
+- **Tier 5** — Unknown: preserves the raw string, truncates the
+  visualLabel to 16 chars, marks `family: 'unknown'`. Also notifies
+  `unknownLog` (see Layer 4 below).
+
+**The 4-priority resolver** (`decideBehavior({task, role, status, workflow})`)
+combines four classifier outputs in a strict precedence order:
+
+```
+status > workflow > role > family-default
+```
+
+Rationale: a `blocked` agent must look confused regardless of role
+or workflow (status is immediate reality); a `/ship` phase overrides
+QA's default magnifier with a deploy-button (phase context is more
+specific than role); a `qa` role overrides the default typing
+animation with `magnifier` (role describes how this agent works).
+
+**Role profiles** are derived from **AgentCortex skill associations**
+(`.agent/skills/`):
+- `pm`, `arch` own writing-plans, dispatching-parallel-agents → CREATE/UPDATE
+  bias toward `gantt-chart`
+- `qa`, `checker` own test-driven-development, red-team-adversarial,
+  verification-before-completion → EXECUTE/READ/SEARCH bias toward `magnifier`
+- `ops` owns finishing-a-development-branch → EXECUTE bias toward
+  `deploy-button`
+- `gate` owns auth-security, red-team-adversarial → EXECUTE bias toward
+  `shield-verify`; READ/SEARCH toward `magnifier`
+- `designer` owns frontend-patterns → CREATE/UPDATE bias toward `whiteboard`
+- `dev`/`worker` are generalists with zero overrides (byte-identical to pre-#A2.1)
+
+### Layer 2 — Mood-driven weather (`src/components/TopDownFurniture.jsx`)
+
+`moodToWeather(mood)` delegates to `classifyMood(mood).family` so the
+mapping lives in one place:
+
+| mood | weather family | visual |
+|---|---|---|
+| `frustrated` | rain | 5 raindrop `<line>` per window with CSS `weather-raindrop-fall` |
+| `stuck` | thunderstorm | rain + lightning `<rect>` flash, opacity capped 0.35 |
+| `rushing` | cloudy | 2 drifting `<ellipse>` per window |
+| `smooth`/`intense`/`normal`/`idle`/`unknown` | clear | null overlay |
+
+12 `WallWindow` instances each receive `weather` and `reducedMotion`
+props. Photosensitivity safety: lightning fires twice per 5-second
+cycle and caps opacity at 0.35 — well below the 3 Hz seizure threshold.
+
+CSP compatibility (#27): `@keyframes` definitions live in
+`src/index.css` (bundled by Vite into the regular stylesheet) instead
+of an inline `<style>` tag inside the SVG, so strict `style-src 'self'`
+environments serve the animations without `'unsafe-inline'`.
+
+### Layer 3 — Inference modules (`src/inference/`)
+
+Two polling watchers extend the existing SSE/poll status integration
+without modifying it:
+
+- **`desktopNotifier.js`** — 5-second tick. Per-agent tracks
+  `blockedSince[id]` timestamp and `notifiedFor[id]` dedupe marker.
+  When an agent stays `status === 'blocked'` ≥ 30 seconds AND
+  `document.hidden === true` AND `Notification.permission === 'granted'`,
+  fires `new Notification()` with `tag: office-blocked-<agentId>` so
+  the OS replaces older notifications for the same agent. Transition
+  out of blocked clears both maps so the next episode is independent.
+  jsdom-safe: every browser-API access is `typeof`-checked.
+- **`idleGapInfer.js`** — 10-second tick. Subscribes to the store with
+  a `(status, task)` signature so the watcher re-stamps `lastUpdatedAt`
+  only on meaningful changes (not on 60 Hz movement ticks). When
+  `now - lastUpdatedAt[id] ≥ 45s` AND status is `working`, injects
+  `status: 'thinking'` through `applyExternalStatus(meta.source =
+  'idle-gap-infer')`. Same for blocked ≥ 90s → `awaiting-approval`.
+  Reversibility by construction: real hook events flow through the
+  same `applyExternalStatus` and overwrite the inferred state, no
+  cleanup needed. Closes [Pixel Agents'](https://github.com/pablodelucca/pixel-agents)
+  publicly admitted heuristic gap with deliberately conservative
+  thresholds (the 30-60s typical `npm test` doesn't misfire).
+- **`workflowHandoff.js`** — subscription watcher (not polling).
+  Maps 7 specific `activeWorkflow` phase transitions to
+  `(fromRole, toRole)` pairs and fires `addHandoff(from, to, {subtle: true})`.
+  `subtle` flag tells `FlyingDocument` to render the calm variant
+  (no sparkle, 60° rotation, no scale pulse) so workflow handoffs
+  coexist with organic officeLife pass-document handoffs without
+  visual clash.
+
+### Layer 4 — Self-improving classifier (`src/systems/unknownLog.js`)
+
+Dev-mode aggregator following the **LangSmith auto-clustering pattern**:
+every Tier 5 fallback from any `classify*` function records the raw
+input into a per-kind bucket (task / status / mood / role / workflow,
+capped at 200 entries per kind, oldest-evict). Exposes
+`window.__office_unknownLog` (raw Maps) and `window.__office_logUnknowns()`
+(sorted console reporter) for DevTools introspection. Production
+zero-cost: `isDevMode()` returns false when `import.meta.env.PROD ===
+true` and `recordUnknown` becomes a no-op.
+
+Operational pattern: over time, high-frequency entries in the log are
+candidates for promotion to Tier 0 in `classify.js`. The
+`feedback_classification_rigor` memory note also reminds future
+classifier work to check `.agent/skills/` + `.agent/workflows/` before
+defaulting to generic W3C verbs.
+
+### Per-feature specs
+
+Detailed rationale + acceptance criteria + rollback for each shipped
+piece live in `docs/specs/`:
+- [[classifier-foundation]] · [[classifier-wiring]] · [[classifier-unknown-log]] · [[mcp-inner-verb-fix]]
+- [[weather-system]] · [[csp-compatibility]]
+- [[desktop-notifications]] · [[idle-gap-inference]] · [[workflow-handoff-arrows]]
+- [[tool-inventory-label]] · [[perf-metrics-chip]]

--- a/docs/DESIGN_SPEC.md
+++ b/docs/DESIGN_SPEC.md
@@ -449,3 +449,141 @@ function getLighting(hour) {
 19.5s 全場冒出慶祝氣泡 🎉
 20.0s 所有人回座位，恢復日常
 ```
+
+---
+
+## v1.1.0 — Visual Additions (2026-05-29)
+
+This section catalogs the visual layer added in v1.1.0. The pre-v1.1
+sections above describe the original character / behavior / office
+layout — those visuals are unchanged. v1.1.0 introduces four new visual
+signals plus a CSP compatibility fix, all designed to obey the user
+brief **「畫面要清楚好懂、不過分花俏」** (clear and easy to read, never flashy).
+
+### Bottom-status `✓N / ✗M` metric chip (#6)
+
+A short label in the `ControlPanel` Full + Panel modes showing today's
+completed and blocked count, both pulled from the new `dailyDoneLedger`
+and `dailyBlockedLedger`.
+
+- Color: emerald `text-emerald-600 dark:text-emerald-400` for `✓N`,
+  red `text-red-600 dark:text-red-400` for `✗M`, separated by a muted
+  ` / ` divider.
+- Tooltip via `title=` carries the full i18n string
+  (`ui.todayMetricsTooltip`).
+- A11y: `<span className="sr-only">` mirror for screen readers,
+  `aria-hidden="true"` on the icon spans.
+- Atomic day rollover: both ledgers reset together via a shared
+  `dayChanged` gate that ORs each ledger's staleness — caught a latent
+  drift bug during deep review (see [[perf-metrics-chip]]).
+
+### Window weather (#14)
+
+Mood drives the weather visible through all 12 `WallWindow` instances:
+
+| `store.mood` | Weather | Visual |
+|---|---|---|
+| `frustrated` | rain | 5 raindrops × 12 windows, stroke `#5478A0` @ 0.85 opacity |
+| `stuck` | thunderstorm | rain + lightning `<rect>` flash at 0.35 opacity / 5s cycle |
+| `rushing` | cloudy | 2 drifting cloud `<ellipse>` per window |
+| `smooth` / `intense` / `normal` / `idle` / `<unknown>` | clear | overlay returns null |
+
+Design tuning:
+- **Raindrop contrast**: original `#A4BCD6` @ 0.7 opacity was nearly
+  invisible against the daytime sky `#87CEEB` (~1.1:1 contrast).
+  Mid-slate `#5478A0` @ 0.85 hits ~2.6:1 in day, ~6:1 at night —
+  still subtle enough to read as "drizzle" not "downpour".
+- **Photosensitivity safety**: lightning fires twice per 5-second
+  cycle, opacity capped at 0.35 — well below the 3 Hz seizure
+  threshold. Documented in the spec.
+- **reducedMotion**: drops every `animation` style prop, leaving
+  static decorative raindrops/clouds in place. No motion at all.
+- **CSP compatibility (#27)**: `@keyframes` rules live in
+  `src/index.css` and bundle to the regular stylesheet — strict
+  `style-src 'self'` environments work without `'unsafe-inline'`.
+
+The whiteboard handwriting animation (#15) was pre-existing at
+`PixelOffice.jsx:146` `WhiteboardAnimation` (subscribes `activeEvent`,
+triggers on `eureka`, animates 3 lines + circle + `!` over 3000ms via
+`stroke-dashoffset`). Closure-documented in the v1.1.0 wave; no new
+work needed.
+
+### Per-agent tool inventory label (AVO-103)
+
+A small monospace pill above each agent character showing the current
+tool the agent is running.
+
+- Position: `y=-29` in the inverse-scaled name-tag group (below the
+  name tag, above the head — visible but never blocking the face).
+- Style: 7px monospace text `fill="#E8E8E8"` on a `fill="#1a1a1a"`
+  rounded rect at `opacity="0.55"`. Low contrast, no animation, no
+  colour coding.
+- Source of label: `classifyTask(task).visualLabel` — built-ins show
+  concise names (`Bash`, `Read`, `Edit`, `Notebook`, `Plan`), MCP
+  tools collapse to `server::tool` (`mcp__notion__create_page` →
+  `notion::create`).
+- Returns null when `externalStatus[id]?.task` is absent → idle agents
+  stay clean.
+
+Why understated: in real Claude Code sessions the office shows 7+
+labels at once. Bright icons or animation would compete with the agent
+characters themselves; a quiet pill at consistent position reads at a
+glance and disappears into the background otherwise.
+
+### Workflow handoff arrows (AVO-105)
+
+When `activeWorkflow` flips between specific phase pairs (`/spec-intake
+→ /spec`, `/spec → /plan`, `/plan → /implement`, `/implement → /test`,
+`/implement → /review`, `/test → /review`, `/review → /ship`),
+`workflowHandoff` fires the existing `addHandoff` between the
+role pair that semantically owns that transition. Reuses the existing
+`FlyingDocument` paper-arc animation infrastructure.
+
+Visual variants (`subtle` prop on `FlyingDocument`):
+
+|   | Organic (officeLife pass-document) | Workflow (AVO-105) |
+|---|---|---|
+| Rotation | 360° | **60°** |
+| Scale pulse | 1 → 1.3 → 1 | **none** |
+| Sparkle trail | gold `circle` × 2, opacity fade | **none** |
+| Duration | 800ms | 800ms (same) |
+| Paper SVG | same white `rect` with line strokes | same |
+
+Two styles coexist in the same frame because workflow handoffs fire
+more frequently and would feel noisy if they sparkled. Organic
+handoffs (the rare PM → all "look what I made" moment) keep their
+celebratory animation.
+
+### Desktop notifications (#8) — non-visual signal
+
+For completeness: when an agent stays blocked ≥ 30 seconds with the
+tab hidden and Notification permission granted, the office fires a
+browser-level `Notification` (`tag: office-blocked-<agentId>` so the
+OS replaces older notifications for the same agent). The
+`ControlPanel` 🔔 button is the user-gesture handler for permission
+request (modern browsers reject auto-requests). i18n: `notify.*`
+keys in en + zh-TW with separate tooltip and aria state maps.
+
+### Status-bar metric pill, 🔔 button, and platform badge — composition
+
+The bottom `ControlPanel` is the canonical place new status pills land.
+Order, left to right:
+
+1. Clock
+2. Agent row (per-character bubble + status dot)
+3. activeEvent indicator
+4. Status source pill (`Live` / fallback / offline)
+5. **`✓N / ✗M` metric chip** (v1.1.0)
+6. Platform badge (`Browser` / `Claude CLI` / `Antigravity` / ...)
+7. **🔔 notification permission button** (v1.1.0)
+8. Language toggle
+9. Pause / Run / Test / Info buttons
+
+New pills go between platform badge and the action buttons so they're
+visible but don't disrupt the existing button cluster.
+
+### Per-feature specs
+
+Detailed acceptance criteria + rollback for each visual addition:
+- [[perf-metrics-chip]] · [[weather-system]] · [[csp-compatibility]]
+- [[tool-inventory-label]] · [[workflow-handoff-arrows]] · [[desktop-notifications]]

--- a/docs/architecture/hook-integration.log.md
+++ b/docs/architecture/hook-integration.log.md
@@ -6,3 +6,15 @@ cross_ref: docs/architecture/office-runtime.log.md
 
 - [CROSS-REF] Claude file hooks remain the baseline external integration path and must stay backward compatible.
 - [CROSS-REF] Codex CLI helper and Codex App bridge are parity extensions that emit the same normalized `office-status` payloads instead of introducing a parallel hook contract.
+
+### [hook-integration][2026-05-29][main]
+source_spec: docs/specs/desktop-notifications.md, docs/specs/idle-gap-inference.md, docs/specs/classifier-foundation.md
+cross_ref: docs/architecture/office-runtime.log.md
+
+- [DECISION] The classifier consumes the existing `task` string from `office-status` payloads as-is. No hook contract change required for v1.1.0 — MCP, Tier 3 verb routing, role overrides, workflow handoffs all parse what already arrives.
+- [DECISION] Inferred statuses (`thinking`, `awaiting-approval`) are pre-registered in `classify.js` STATUS_TABLE but only produced by the local `idleGapInfer` module, never emitted by hook scripts directly. Hook authors don't need to learn the new values.
+- [DECISION] `desktopNotifier` subscribes to store state, not to the hook channel. The hook fires → `applyExternalStatus` → store mutation → notifier reads the next tick. This keeps the hook contract unchanged and the notification logic testable without simulating a transport.
+- [DECISION] `unknownLog` records raw hook payloads that fall to Tier 5. Repeat unknowns are the signal to extend Tier 0 — operationally, hook authors and classifier maintainers communicate via this log rather than direct schema coordination.
+- [TRADEOFF] Idle-gap inference uses a 10-second polling tick rather than reacting to absence-of-events on the SSE channel. Polling is simpler and decoupled from transport, at the cost of up to a 10-second jitter before inferring `thinking` / `awaiting-approval`.
+- [CONSTRAINT] OpenTelemetry GenAI semantic conventions (`gen_ai.tool.name`, `gen_ai.usage.*`) are the target for future hook payload upgrades. The classifier's `visualLabel`, MCP server::tool routing, and `unknownLog` keys are deliberately compatible with that direction.
+- [FORWARD-LOOKING] AVO-101 plan-mode visualization and AVO-108 token & cost meter will require hook payload extensions. Until then they live as backlog items, not partial implementations on the existing contract.

--- a/docs/architecture/office-runtime.log.md
+++ b/docs/architecture/office-runtime.log.md
@@ -10,3 +10,16 @@ source_sha: 21ab91955c1d10f8e82d3cd514c4878af7523f07
 - [TRADEOFF] Passive heuristics like title watching may remain as fallback signals, but they are not trusted as the primary Codex integration path because they are too lossy.
 - [CONSTRAINT] Existing Claude and manual `POST /api/status` flows must keep working through the migration.
 - [CONSTRAINT] Codex App parity can only be claimed with real evidence from the running platform or an explicit documented limitation.
+
+### [office-runtime][2026-05-29][main]
+source_spec: docs/specs/perf-metrics-chip.md, docs/specs/classifier-foundation.md, docs/specs/classifier-wiring.md, docs/specs/idle-gap-inference.md
+source_sha: 0ea5bdfb82b5c7a7c0c1b1e6aa20c4e16966efcf (v1.1.0 wave merged)
+
+- [DECISION] Behavior selection is owned by a single resolver `decideBehavior({task, role, status, workflow})` with strict priority `status > workflow > role > family-default`. Old explicit `STATUS_BEHAVIOR_MAP[u.status].behavior[u.task]` lookups are kept as Tier 0 overrides so Bash/Read/Grep/Glob remain byte-identical.
+- [DECISION] Mood is a single read in PixelOffice (`useOfficeStore((s) => s.mood)`) and feeds `moodToWeather` via `classifyMood(mood).family`. The mood-to-weather mapping lives in `classify.js` not in the view layer so the contract is testable in isolation.
+- [DECISION] `dailyDoneLedger` and `dailyBlockedLedger` reset atomically. `dayChanged` ORs each ledger's staleness check rather than reading only the done ledger — caught a latent drift bug where a manually-mutated blocked ledger could silently accumulate to a stale day.
+- [DECISION] Idle-gap inference routes through the same `applyExternalStatus` as real hook events with `meta.source: 'idle-gap-infer'`. Reversibility is by construction — a real event simply overwrites the inferred status, no flag-tracking needed.
+- [TRADEOFF] Inference thresholds (45s working → thinking, 90s blocked → awaiting-approval) are deliberately higher than Pixel Agents' equivalent heuristics. The cost is a 45s lag before the office reflects extended thinking; the benefit is no false-positive on a 30-60s `npm test`.
+- [TRADEOFF] `pushEventBatch([])` is now a strict no-op (`if (added > 0)`). The two existing moodEngine tests that relied on the empty-batch recompute hack were updated; the new contract is defensive but breaks a debugging idiom.
+- [CONSTRAINT] The classifier output shape `{tier, family, severity, visualLabel, a11yLabel, raw}` is part of the public contract. New tier values must not collide with the existing 0/3/4/5 numbering. New family values must extend `FAMILIES`, not invent strings.
+- [CONSTRAINT] Production bundles must contain zero `@keyframes` strings in the JS bundle. The weather rules live in `src/index.css`; future animation work follows the same path.

--- a/docs/architecture/ui-rendering.log.md
+++ b/docs/architecture/ui-rendering.log.md
@@ -6,3 +6,18 @@ cross_ref: docs/architecture/office-runtime.log.md
 
 - [CROSS-REF] Inspector rendering stays source-agnostic because runtime inputs are normalized before UI consumption.
 - [CROSS-REF] Durable same-day done counts replace capped activity-feed inference without changing the overall inspector surface contract.
+
+### [ui-rendering][2026-05-29][main]
+source_spec: docs/specs/weather-system.md, docs/specs/tool-inventory-label.md, docs/specs/workflow-handoff-arrows.md, docs/specs/csp-compatibility.md
+cross_ref: docs/architecture/office-runtime.log.md, docs/DESIGN_SPEC.md
+
+- [DECISION] Per-agent reactive subscriptions stay narrow. `AgentCharacter` reads `s.externalStatus[id]?.task ?? null` (one field, not the whole externalStatus object) so the tool inventory label re-renders only when the tool changes — not on every label/expiresAt tick.
+- [DECISION] WallWindow weather overlays do NOT share clipPaths across 12 instances. The clip rect depends on per-window (x,y,w,h) so each gets its own `<clipPath id="weather-clip-{x}-{y}">`. The `<defs>` wrapper around each was redundant though, and was removed (12→1 DOM defs node).
+- [DECISION] Workflow handoffs reuse the existing `FlyingDocument` SVG via a new `subtle` boolean prop. The component branches inside the same render function — no second component, no parallel pathway. Organic vs workflow handoff is one variable's flip.
+- [DECISION] All new TextLabels and pills use monospace 7-10px text with low-opacity dark backgrounds (`fill="#1a1a1a"` @ 0.55). Consistent visual language across `✓N/✗M` metric chip, tool inventory label, and 🔔 button.
+- [DECISION] `@keyframes` definitions migrate from inline `<style>` (CSP violation) to bundled `src/index.css`. Future SVG animations follow the same pattern; reach for index.css before reaching for `<style>`.
+- [TRADEOFF] The tool inventory label sits at y=-29 in the inverse-scaled name-tag group — between the name tag and the head. There's only ~9 SVG units of clear space; we accepted the tight fit so the label doesnt overlap the agent's face during walking animations.
+- [TRADEOFF] The mood-driven weather overlays add up to 60 raindrop `<line>` elements during frustrated / stuck states (5 per window × 12 windows). Tested at 30fps no jank, but if PixelOffice ever exceeds 30 simultaneous SVG animations a higher-level perf strategy is needed.
+- [CONSTRAINT] `reducedMotion` (from `prefers-reduced-motion` or pause) MUST disable animations across the new visual surfaces — weather overlays drop every `animation` style prop, FlyingDocuments don't render, tool inventory label stays static (no animation anyway). New animated work must register the same gate.
+- [CONSTRAINT] Lightning opacity caps at 0.35 with at most 2 flashes per 5-second cycle. Future flash effects must obey the same photosensitivity ceiling.
+- [CONSTRAINT] Workflow handoff visual variant ("subtle") must coexist with the organic (flashier) variant in the same frame without visual clash. Tested live with simultaneous `arch→dev` workflow + `res→gate` organic handoffs.

--- a/docs/specs/classifier-foundation.md
+++ b/docs/specs/classifier-foundation.md
@@ -1,0 +1,81 @@
+---
+title: Standards-aligned classifier foundation
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [fec8a53]
+primary_files: [src/systems/classify.js]
+test_file: tests/classify.test.js
+---
+
+# Standards-aligned classifier foundation (#A1)
+
+## Problem
+
+Prior art (Pixel Agents) admits "JSONL doesn't signal waiting/finished —
+heuristics often misfire". Our hook event schema is richer but we had no
+shared vocabulary: `STATUS_BEHAVIOR_MAP`, `moodToWeather`, and ad-hoc
+`indexOf` checks all classified tasks/statuses/moods independently, and
+MCP-namespaced tools (`mcp__<server>__<tool>`) had no parser at all.
+
+## Solution
+
+`src/systems/classify.js` is a pure 4-tier waterfall keyed off public
+standards so the vocabulary survives future tool additions:
+
+- **Tier 0** — Built-in registry of Claude Code canonical tools
+  (Bash/Read/Edit/Write/Grep/Glob/Task/WebFetch/WebSearch/NotebookEdit/
+  ExitPlanMode + TodoRead/TodoWrite).
+- **Tier 3** — Verb heuristic from W3C Activity Streams 2.0 vocabulary
+  with **word-boundary regex** so `redo`/`delegate`/`refresh` don't
+  misroute into Read/Dispatch.
+- **Tier 4** — MCP namespace parser: splits on the **first** `__` so
+  server names with dashes and tool names with underscores both work.
+- **Tier 5** — Unknown fallback; preserves raw, truncates UI label to
+  16 chars, never throws (null/undefined/non-string defensive).
+
+Every `classify*` call returns the same shape
+`{ tier, family, subFamily?, severity, visualLabel, a11yLabel, raw }`
+and the `FAMILIES` export is the frozen vocabulary used downstream.
+
+## Files
+
+- `src/systems/classify.js` — pure classifier module; exports
+  `classifyTask`, `classifyStatus`, `classifyMood`, `FAMILIES`.
+- `tests/classify.test.js` — 90 unit tests covering all 4 tiers,
+  defensive inputs, severity, and label truncation.
+
+## Key decisions
+
+- **Standards over invention**: W3C Activity Streams 2.0 + MCP spec
+  + OpenTelemetry GenAI cited in the module docstring. Pins future work
+  (#B1 OT GenAI export) to the same taxonomy.
+- **Word-boundary regex for Tier 3**: substring matching caused
+  `redo → READ`, `delegate → DELETE`, `refresh → SEARCH` misroutes.
+- **Tier 5 never throws**: classifier is in the hot path of every
+  hook event; defensive return shape is mandatory.
+- **No wiring in this PR**: foundation only — `classify.js` is
+  tree-shaken until #A2 imports it. Keeps the diff reviewable and
+  makes regression risk zero for #A1.
+
+## Acceptance criteria (Done)
+
+- [x] All 4 tiers implemented with documented vocabulary
+- [x] `classifyTask` / `classifyStatus` / `classifyMood` exported
+- [x] `classifyMood` mirrors `moodToWeather` (#14) shape — parity check
+- [x] 90 unit tests, build clean, no behavior change in app
+
+## Rollback
+
+`git revert fec8a53` — module is unimported in #A1, so revert is a
+no-op for runtime behavior. Removes the foundation #A2/#A2.1/#A3
+depend on.
+
+## References
+
+- Commit: `fec8a53 feat(#A1): standards-aligned classifier foundation
+  (W3C + OT GenAI + MCP)`
+- CHANGELOG v1.1.0 → "#A1 Standards-aligned classifier foundation"
+- Backlog row: `_shipped-log.md` (rotated 2026-05-29)
+- Related: [[classifier-wiring]], [[classifier-unknown-log]],
+  [[mcp-inner-verb-fix]]

--- a/docs/specs/classifier-unknown-log.md
+++ b/docs/specs/classifier-unknown-log.md
@@ -1,0 +1,82 @@
+---
+title: unknownLog — self-improving classifier
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [5175a53]
+primary_files: [src/systems/unknownLog.js, src/systems/classify.js]
+test_file: tests/unknownLog.test.js
+---
+
+# unknownLog — self-improving classifier (#A3)
+
+## Problem
+
+The classifier (#A1) has a Tier 5 fallback for any task/status/mood/role/
+workflow it doesn't recognize, but the raw inputs that landed there
+were thrown away. With no visibility into what real-world traffic was
+missing, the Tier 0 built-in registry could only grow by guesswork.
+LangSmith solves the analogous problem by auto-clustering "unknown
+topic" buckets — we needed the same loop for our classifier.
+
+## Solution
+
+A dev-mode in-memory aggregator records every Tier 5 fallback per
+kind. Five buckets (`task` / `status` / `mood` / `role` / `workflow`),
+cap **200 per kind** with oldest-evict via Map insertion order.
+
+- `recordUnknown(kind, raw)` — no-op outside dev mode.
+- `getUnknownReport()` — top-20 per kind, count desc.
+- `clearUnknownLog()` — resets all buckets.
+- `window.__office_unknownLog` — raw Maps for DevTools.
+- `window.__office_logUnknowns()` — sorted console reporter.
+
+`classify.js` calls `recordUnknown` from each Tier 5 path; **Tier 0/3/4
+hits never record** so only genuine vocabulary gaps surface, not
+known-but-unhandled cases. Production safety: `import.meta.env.PROD`
+flips `isDevMode()` false → `recordUnknown` is a no-op (bundle still
+ships the module, ≈+1 KB raw / +0.45 KB gzip, but no runtime work).
+
+## Files
+
+- `src/systems/unknownLog.js` — aggregator + DevTools globals.
+- `src/systems/classify.js` — Tier 5 call sites in all 5 classifiers.
+- `tests/unknownLog.test.js` — 24 tests covering cap behavior,
+  per-kind isolation, prod no-op, override flag.
+
+## Key decisions
+
+- **Dev-mode gate via `import.meta.env.PROD`** — zero-cost in
+  production by construction; the audit is on by default for anyone
+  running the dev server, which is where the signal is.
+- **200/kind oldest-evict** — bounded memory; insertion-order Map
+  gives natural FIFO without extra bookkeeping.
+- **Only Tier 5 records** — correctness invariant. Recording Tier 0/3/4
+  would drown signal in known-good traffic and bias the "what to add
+  next" decision.
+- **Override hook `globalThis.__OFFICE_FORCE_UNKNOWN_LOG__`** — used
+  by vitest `beforeEach` to force-enable deterministic recording in
+  tests without depending on env detection.
+
+## Acceptance criteria (Done)
+
+- [x] All 5 classifier kinds record on Tier 5 fallback
+- [x] No recording on Tier 0/3/4 hits
+- [x] `getUnknownReport` returns top-20 sorted desc per kind
+- [x] Production env → `recordUnknown` is no-op
+- [x] DevTools globals exposed on `window`
+- [x] 875 tests passing (+24)
+
+## Rollback
+
+`git revert 5175a53` — removes the module + the Tier 5 call sites in
+`classify.js`. No persistent state to clean up (in-memory only). Blast
+radius is the dev-mode feedback signal; classifier output unchanged.
+
+## References
+
+- Commit: `5175a53 feat(#A3): unknownLog — self-improving classifier
+  (LangSmith pattern)`
+- CHANGELOG v1.1.0 → "#A3 unknownLog (self-improving classifier)"
+- Backlog row: `_shipped-log.md` (rotated 2026-05-29)
+- Related: [[classifier-foundation]], [[classifier-wiring]]

--- a/docs/specs/classifier-wiring.md
+++ b/docs/specs/classifier-wiring.md
@@ -1,0 +1,97 @@
+---
+title: Classifier wiring (store + weather, role/workflow aware)
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [9086faf, caaa57a]
+primary_files: [src/systems/classify.js, src/systems/store.js, src/components/TopDownFurniture.jsx]
+test_file: tests/classifierWiring.test.js
+---
+
+# Classifier wiring (#A2 + #A2.1)
+
+## Problem
+
+#A1 shipped the classifier as a pure island; nothing in the app
+consumed it yet. `store.applyExternalStatus` still fell through to a
+flat `|| 'typing'` for any tool not in `STATUS_BEHAVIOR_MAP`, and
+`moodToWeather` had a duplicated mood→family table. Additionally the
+classifier was role-agnostic — user feedback "記得不要分類的太隨便" — so
+`qa+Bash`, `ops+Bash`, and `dev+Bash` all produced the same animation
+despite AgentCortex already encoding rich role/skill/workflow semantics.
+
+## Solution
+
+**#A2 (wiring)** replaces the two existing consumers with classifier
+reads. `store.applyExternalStatus`'s `|| 'typing'` fallback becomes
+`|| familyToBehavior(classifyTask(u.task).family)`; `moodToWeather`
+becomes a single-line delegation to `classifyMood(mood).family`.
+Built-in tools (Bash/Read/Grep/Glob) remain byte-identical via the
+`bm.behavior[u.task]` hit-first path. Status overrides preserved:
+`blocked → scratch-head`, `done → thumbs-up` regardless of task.
+
+**#A2.1 (role-aware)** adds `classifyRole`, `classifyWorkflow`, and a
+4-priority resolver `decideBehavior({task, role, status, workflow})`
+where **status > workflow > role > family-default**. Role overrides
+are rooted in AgentCortex skill associations (e.g. qa/checker has
+TDD + verification-before-completion → magnifier; ops has finishing-a-
+development-branch → deploy-button; gate has auth-security →
+shield-verify). Workflow phase wins over role because phase context
+is more specific than persona.
+
+## Files
+
+- `src/systems/classify.js` — adds `familyToBehavior` (#A2),
+  `classifyRole` / `classifyWorkflow` / `decideBehavior` (#A2.1).
+- `src/systems/store.js` — `applyExternalStatus` calls `decideBehavior`
+  with role + workflow + status context.
+- `src/components/TopDownFurniture.jsx` — `moodToWeather` delegates
+  to `classifyMood`.
+- `tests/classifierWiring.test.js` — 180+ lines covering MCP routing,
+  status-override precedence, byte-identical built-in regression.
+- `tests/classifierRoleContext.test.js` — role + workflow priority
+  ladder, dev=zero-overrides invariant.
+
+## Key decisions
+
+- **status > workflow > role > family**: a `done` event must always
+  thumbs-up regardless of role; phase context (`/ship`) beats persona
+  (`pm`) because phase is what the agent is currently doing.
+- **dev/worker has zero role overrides** — guarantees backward
+  compatibility for all existing `agents.dev.behavior` assertions
+  (grep-verified before merge).
+- **EXTERNAL → typing** as conservative MCP default — see
+  [[mcp-inner-verb-fix]] which later bubbles the inner verb up.
+- **moodToWeather single-line delegation** instead of removing it,
+  so the public name in TopDownFurniture stays stable for future
+  weather-only consumers.
+
+## Acceptance criteria (Done)
+
+- [x] Built-in tools byte-identical to pre-#A2 (regression-tested)
+- [x] MCP and verb-recognizable tools route to family-appropriate
+  animations
+- [x] `qa+Bash → magnifier`, `ops+Bash → deploy-button`,
+  `gate+Bash → shield-verify`, `designer+Edit → whiteboard`
+- [x] `/ship` workflow overrides role for EXECUTE tasks
+- [x] 748 tests passing after #A2 (+44); 851 after #A2.1 (+103)
+
+## Rollback
+
+`git revert caaa57a 9086faf` (in that order — #A2.1 first since it
+extends #A2). Reverting only #A2.1 returns to family-only behavior;
+reverting #A2 too restores the flat `|| 'typing'` fallback. Blast
+radius is animation selection only — no state-machine or persistence
+change.
+
+## References
+
+- Commit: `9086faf feat(#A2): wire classifier into store.behavior +
+  moodToWeather`
+- Commit: `caaa57a feat(#A2.1): role-aware classifier — same tool,
+  different role, different animation`
+- CHANGELOG v1.1.0 → "#A2 Classifier wiring" + "#A2.1 Role-aware
+  classifier"
+- Memory: `feedback_classification_rigor.md` (don't default to W3C
+  taxonomy when `.agent/skills/` + `.agent/workflows/` exist)
+- Related: [[classifier-foundation]], [[mcp-inner-verb-fix]]

--- a/docs/specs/csp-compatibility.md
+++ b/docs/specs/csp-compatibility.md
@@ -1,0 +1,84 @@
+---
+title: CSP compatibility — bundled weather keyframes
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [0cd0920]
+primary_files: [src/index.css, src/components/PixelOffice.jsx, src/components/TopDownFurniture.jsx]
+test_file: tests/weatherSystem.test.js
+---
+
+# CSP compatibility (#27)
+
+## Problem
+
+The #14 weather system injected `@keyframes weather-raindrop-fall` /
+`weather-cloud-drift` / `weather-lightning-flash` via an inline
+`<style>` tag inside `PixelOffice`. Strict corporate CSPs deny
+`style-src 'self'` without `'unsafe-inline'`, which silently drops the
+inline keyframes block and leaves rain/clouds/lightning frozen — the
+office "weather" turns into static SVG geometry. Users on hardened
+intranets reported it as a layout bug.
+
+## Solution
+
+Move the three `@keyframes` declarations from the runtime-injected
+`WeatherKeyframes` React component into `src/index.css`, where Vite
+bundles them into the production stylesheet that ships via
+`<link rel="stylesheet">` — the path covered by `style-src 'self'`. The
+inline `<style>` component is deleted; `TopDownFurniture` continues to
+reference the same animation-name strings, so no markup-side change is
+needed. Production JS now contains **zero `@keyframes` declarations**;
+verified by grep on the built bundle. The CSS bundle grows ~0.3 KB raw.
+README troubleshooting gained a CSP section recommending
+`style-src 'self' 'unsafe-inline'` for general compatibility and
+documenting the advanced nonce-based path for the strictest environments.
+
+## Files
+
+- `src/index.css` — three `@keyframes` blocks with a comment explaining
+  the CSP rationale and photosensitivity caps.
+- `src/components/PixelOffice.jsx` — removed the `WeatherKeyframes`
+  component and its single-shot inline `<style>` mount.
+- `src/components/TopDownFurniture.jsx` — minor adjustments to keep
+  animation references consistent post-move.
+- `README.md` — Troubleshooting CSP subsection.
+- Tests: existing `tests/weatherSystem.test.js` continues to cover the
+  mapping and overlay — the move is structurally invisible to JS.
+
+## Key decisions
+
+- **Bundled CSS, not nonce injection**: a nonce path would solve it but
+  requires server-side coordination per deploy. Static bundling works
+  for every host (S3, Nginx, Vite dev) with no infra changes.
+- **Delete the inline component entirely**: keeping it as a fallback
+  would double-define keyframes and risk CSP violation under the very
+  policies we are trying to support.
+- **Comment the photosensitivity caps in CSS too**: the constraints
+  (lightning ≤0.35 opacity, <3 Hz flash) belong with the keyframes, not
+  only in the spec — future edits to the CSS see the rule inline.
+- **README guidance, not auto-detection**: detecting CSP from JS is
+  unreliable; document the recommendation and let admins choose.
+
+## Acceptance criteria (Done)
+
+- [x] Production JS bundle contains zero `@keyframes`
+- [x] Weather animations render under `style-src 'self'` (no
+      `'unsafe-inline'`)
+- [x] No visual regression vs. pre-move build
+- [x] Lightning still capped 0.35 / <3 Hz
+- [x] README Troubleshooting documents CSP guidance
+
+## Rollback
+
+`git revert 0cd0920` — restores the inline `<style>` and re-introduces
+the CSP violation under strict policies. Visual behavior is identical
+on permissive CSPs. Blast radius: weather rendering only.
+
+## References
+
+- Commit: `0cd0920 feat(#27): move weather keyframes to bundled CSS for
+  strict CSP compatibility`
+- CHANGELOG v1.1.0 → "#27 CSP compatibility"
+- Backlog row: `_shipped-log.md` #27
+- Related: [[weather-system]] (the #14 feature whose keyframes moved)

--- a/docs/specs/desktop-notifications.md
+++ b/docs/specs/desktop-notifications.md
@@ -1,0 +1,84 @@
+---
+title: Desktop notifications for sustained-blocked agents
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [2f7d693]
+primary_files: [src/inference/desktopNotifier.js, src/components/ControlPanel.jsx, src/components/PixelOffice.jsx]
+test_file: tests/desktopNotifier.test.js
+---
+
+# Desktop notifications (#8)
+
+## Problem
+
+`blocked` is the single status worth interrupting the user for — it means
+an agent is stuck on a permission prompt or an external dependency. But
+the office tab is usually buried behind editors and terminals, so the
+status bar chip is invisible exactly when it matters. The team needs an
+OS-level nudge that respects browser permission gates and does not spam
+when the user is already watching.
+
+## Solution
+
+`startDesktopNotifier(store)` runs a 5s polling loop. Each tick walks
+`store.getState().agents`, stamps a per-agent `blockedSince` timestamp
+when an agent first enters `blocked`, and clears it on transition out.
+When an agent has been blocked ≥30s AND `document.hidden` is true AND
+`Notification.permission === 'granted'`, the loop fires one Notification
+with `tag: office-blocked-<agentId>` so the OS collapses repeats.
+Per-episode dedupe is keyed by the `blockedSince` timestamp itself — a
+`blocked → working → blocked` cycle counts as two episodes. Permission
+is requested via a separate `requestNotificationPermission()` exposed on
+ControlPanel's 🔔 button so the browser sees a user gesture; auto-call
+on mount would auto-reject in Chrome/Firefox/Safari.
+
+## Files
+
+- `src/inference/desktopNotifier.js` — module-scope dedupe maps,
+  `tick()`, `startDesktopNotifier()`, `requestNotificationPermission()`,
+  `_resetDesktopNotifierState()` test helper.
+- `src/components/PixelOffice.jsx` — `useEffect` starts the notifier and
+  returns the stop function for cleanup on unmount.
+- `src/components/ControlPanel.jsx` — 🔔 button wired to permission
+  request, label + sr-only mirror via `notify.*` i18n keys.
+- `src/locales/{en,zh-TW}.json` — `notify.blockedTitle`,
+  `notify.blockedBody` with `{0}` agent-name placeholder.
+- `tests/desktopNotifier.test.js` — episode dedupe, transition-out
+  reset, permission/visibility short-circuits, jsdom safety.
+
+## Key decisions
+
+- **5s poll, not subscribe**: status transitions are bursty; a coarse
+  poll smooths CPU and aligns with the 30s threshold's granularity.
+- **Per-episode dedupe via `blockedSince` timestamp**: simpler than
+  tracking notification IDs; a re-block naturally gets a new timestamp.
+- **User-gesture permission request**: modern browsers reject
+  auto-prompts. ControlPanel's button is the only entry point.
+- **`document.hidden` gate**: no notifications while the office is the
+  active tab — the chip is already visible.
+- **jsdom + SSR safety**: every `Notification` / `window` / `document`
+  access is `typeof`-guarded; the module becomes a no-op when missing.
+
+## Acceptance criteria (Done)
+
+- [x] Notification fires exactly once per blocked episode
+- [x] No fire when tab is visible
+- [x] No fire when permission is `default` or `denied`
+- [x] Tag-collapse prevents stacked OS notifications per agent
+- [x] Stop function clears the interval cleanly on unmount
+- [x] i18n + sr-only parity with the rest of ControlPanel
+
+## Rollback
+
+`git revert 2f7d693` — removes the notifier module, the 🔔 button, the
+PixelOffice subscription, and the i18n keys. Blast radius: ControlPanel
+header layout (one button removed), no behavior change elsewhere.
+
+## References
+
+- Commit: `2f7d693 feat(#8): desktop notifications for sustained-blocked agents`
+- CHANGELOG v1.1.0 → "#8 桌面通知 (desktop notifications)"
+- Backlog row: `_shipped-log.md` #8
+- Related: [[idle-gap-inference]] (sister inference module, shares
+  PixelOffice useEffect pattern)

--- a/docs/specs/idle-gap-inference.md
+++ b/docs/specs/idle-gap-inference.md
@@ -1,0 +1,90 @@
+---
+title: Idle-gap inference for thinking and awaiting-approval
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [b5efc92]
+primary_files: [src/inference/idleGapInfer.js, src/components/PixelOffice.jsx]
+test_file: tests/idleGapInfer.test.js
+---
+
+# Idle-gap inference (#C)
+
+## Problem
+
+Claude Code's hooks emit `PreToolUse` / `PostToolUse` / `Stop`, but
+extended-thinking sessions and unanswered permission prompts produce no
+intermediate events — the agent visually freezes mid-`working` or
+mid-`blocked` for minutes. Pixel Agents (the upstream inspiration)
+publicly admits this heuristic gap as the limit of hook-only inference.
+The office needs to bridge it without inventing fake activity.
+
+## Solution
+
+`startIdleGapInference(store)` runs a 10s polling loop and a zustand
+subscription. The subscription stamps `lastUpdatedAt.set(id, now())`
+whenever an agent's `(status, task)` signature changes — *not* on
+position/behavior, which mutate every animation frame. Each tick
+computes `elapsed = now - lastUpdatedAt[id]`. If an agent is `working`
+and elapsed ≥45s, it is reclassified to `thinking`; if `blocked` and
+elapsed ≥90s, it is reclassified to `awaiting-approval`. Updates are
+routed through `applyExternalStatus(..., { source: 'idle-gap-infer',
+hasWorkflow: false })` so they share the real-hook pipeline (behavior
+selection, classifier mapping) but skip the mood engine — inferred
+states must not bias rushing/frustrated/stuck patterns. Real hook
+events naturally overwrite the inferred status, giving reversibility
+by construction.
+
+## Files
+
+- `src/inference/idleGapInfer.js` — `computeSig()`, `parseSig()`,
+  `subscribeAgentUpdates()`, `tick()`, `startIdleGapInference()`,
+  `_resetIdleGapState()` test helper.
+- `src/components/PixelOffice.jsx` — `useEffect` starts the inference
+  loop alongside the desktop notifier; cleanup returns the stop fn.
+- `tests/idleGapInfer.test.js` — threshold edges, signature diffing,
+  thrash prevention via `INFERRED_STATUSES` short-circuit, real-hook
+  override, jsdom safety.
+
+## Key decisions
+
+- **Conservative thresholds (45s / 90s)**: a normal Bash test can run
+  30–60s with no hook traffic. 30s working would misfire on every test
+  run; 45s catches genuine stalls. 90s for blocked is deliberately even
+  more lenient — permission prompts often sit for minutes.
+- **Skip mood-engine emit**: `classifyStatus('thinking')` belongs to
+  the COGNITION family; counting it toward team mood would conflate
+  *inferred* state with *measured* state. `hasWorkflow: false` blocks
+  the emit cleanly.
+- **`(status, task)` signature, not full agent**: position/behavior tick
+  ~60 Hz from movementSystem; subscribing to the full object would
+  reset the clock every frame and defeat the entire mechanism.
+- **No marker on the inferred state**: real hook events flow through
+  `applyExternalStatus` and overwrite status directly; nothing to clean
+  up. Reversibility is free.
+- **Re-stamp inferred agents after firing**: prevents the same tick
+  immediately re-firing on the next interval.
+
+## Acceptance criteria (Done)
+
+- [x] working + 45s gap → `thinking`
+- [x] blocked + 90s gap → `awaiting-approval`
+- [x] Real hook event overwrites inferred status
+- [x] Mood engine does not see inferred events
+- [x] No thrashing once an agent is already inferred
+- [x] Stop function clears interval + unsubscribes
+
+## Rollback
+
+`git revert b5efc92` — removes the inference module and the PixelOffice
+useEffect. Agents stuck in extended thinking will visually freeze again
+(pre-#C behavior). Blast radius: PixelOffice only.
+
+## References
+
+- Commit: `b5efc92 feat(#C): idle-gap inference — close Pixel Agents'
+  admitted heuristic gap`
+- CHANGELOG v1.1.0 → "#C Idle-gap inference"
+- Pixel Agents project (upstream): publicly documented heuristic gap
+- Related: [[desktop-notifications]] (sister inference module),
+  [[classifier-foundation]] (status family taxonomy)

--- a/docs/specs/mcp-inner-verb-fix.md
+++ b/docs/specs/mcp-inner-verb-fix.md
@@ -1,0 +1,87 @@
+---
+title: MCP Tier 4 inner-verb bubble-up fix
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [fb011a8]
+primary_files: [src/systems/classify.js]
+test_file: tests/classify.test.js
+---
+
+# MCP Tier 4 inner-verb bubble-up fix
+
+## Problem
+
+`classifyTask` Tier 4 hard-coded `family: FAMILIES.EXTERNAL` even when
+`classifyVerb(mcp.tool)` had already extracted the inner verb's
+family. `decideBehavior()` reads only `family`, so MCP
+create/delete/search/read all collapsed to `behavior='typing'` —
+visually identical despite semantically different operations.
+
+## Solution
+
+When the inner verb matches, return `family: inner.family` directly
+(option B from the spawn prompt — cleaner than a parallel
+`effectiveFamily` field). The MCP server is preserved in `subFamily`
+for hover / debug. When no verb matches (e.g.
+`mcp__notion__weirdtool`), keep the `EXTERNAL` fallback so the tool
+still has a category.
+
+Behavior changes (semantic improvements, not regressions):
+
+| Task | Before | After |
+| --- | --- | --- |
+| `mcp__notion__create_page` | EXTERNAL→typing | CREATE→writing-notes |
+| `mcp__notion__delete_page` | EXTERNAL→typing | DELETE→typing (high severity) |
+| `mcp__notion__read_database` | EXTERNAL→typing | READ→reading-screen |
+| `mcp__atlassian__search_*` | EXTERNAL→typing | SEARCH→research |
+| `mcp__notion__weirdtool` | EXTERNAL→typing | EXTERNAL→typing (unchanged) |
+
+## Files
+
+- `src/systems/classify.js` — Tier 4 branch returns `inner.family`
+  when present; `subFamily` carries the MCP server.
+- `tests/classify.test.js` — MCP Tier 4 describe block asserts
+  bubbled families; explicit cases for delete (severity), read, and
+  weirdtool (no-verb fallback). MCP-namespaced `familyToBehavior`
+  test split into 4 cases.
+- `tests/classifierWiring.test.js` — MCP wiring test asserts
+  `writing-notes`; +2 new tests for `search→research` and
+  `weirdtool→typing`.
+
+## Key decisions
+
+- **Bubble inner family up directly** (option B) instead of adding an
+  `effectiveFamily` parallel field — one less invariant for downstream
+  to know about; `decideBehavior` already reads `family`.
+- **Preserve MCP server in `subFamily`** — debug/hover surface stays
+  intact even though `family` no longer carries it.
+- **Keep EXTERNAL when inner verb is unknown** — conservative default
+  for the `mcp__notion__weirdtool` shape; `unknownLog` (#A3) will
+  surface these for future Tier 0 promotion.
+
+## Acceptance criteria (Done)
+
+- [x] MCP create/update/read/delete/search route to verb-family
+  animations
+- [x] `mcp__server__tool` with unrecognized verb still falls back to
+  EXTERNAL → typing
+- [x] DELETE severity propagates through MCP Tier 4
+- [x] 925 tests passing (+8 new MCP cases); build clean; bundle
+  unchanged (~385 KB raw / ~120.5 KB gzip)
+
+## Rollback
+
+`git revert fb011a8` — restores the flat
+`family: FAMILIES.EXTERNAL` for all Tier 4 hits. Blast radius is
+animation selection for MCP-namespaced tasks only; no state or
+persistence change. Re-collapses 4 distinct operations into one
+`typing` animation.
+
+## References
+
+- Commit: `fb011a8 fix(classify): MCP Tier 4 bubbles inner verb
+  family up instead of flat EXTERNAL`
+- CHANGELOG v1.1.0 → "Fixed → MCP Tier 4 inner-verb bubble-up"
+- Related: [[classifier-foundation]], [[classifier-wiring]],
+  [[classifier-unknown-log]]

--- a/docs/specs/perf-metrics-chip.md
+++ b/docs/specs/perf-metrics-chip.md
@@ -1,0 +1,79 @@
+---
+title: Perf metrics chip
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [fca854a, 0f4ef51]
+primary_files: [src/systems/store.js, src/components/ControlPanel.jsx]
+test_file: tests/storeBlockedLedger.test.js
+---
+
+# Perf metrics chip (#6)
+
+## Problem
+
+The bottom status bar showed per-agent state and platform badge but no
+aggregate "how is today going?" signal. `dailyDoneLedger` already counted
+completions for character growth (#1), but `blocked` events were
+visualized only per-agent and vanished as soon as the agent recovered —
+there was no day-level tally to glance at.
+
+## Solution
+
+Add `dailyBlockedLedger` as a per-day transition counter parallel to
+`dailyDoneLedger`: increment only when `previousStatus !== 'blocked' &&
+nextStatus === 'blocked'` so a polling/SSE flap on a single stuck tool
+call doesn't double-count. Both ledgers share the same `dayChanged`
+gate inside `applyExternalStatus` so midnight rollover resets them
+atomically even when the first cross-midnight update touches only one
+counter. ControlPanel subscribes to both ledger objects via `useShallow`
+(clone-on-write identity), sums in `useMemo`, and renders a compact
+monospace `✓N / ✗M` chip in both Full and Panel modes with tooltip,
+sr-only mirror, and i18n in en + zh-TW. No `eventKey` dedup — `blocked`
+has no PostToolUse-style anchor to key on.
+
+## Files
+
+- `src/systems/store.js` — `createDailyBlockedLedger`,
+  `ensureCurrentDailyBlockedLedger`, `validatePersistedDailyBlockedLedger`,
+  transition-counting branch in `applyExternalStatus`, atomic dayChanged gate.
+- `src/components/ControlPanel.jsx` — `useShallow` ledger subscription,
+  `useMemo` reduction, two chip render sites (Full + Panel modes).
+- `src/locales/en.json`, `src/locales/zh-TW.json` — `ui.todayMetricsTooltip`
+  + `ui.todayMetricsA11y` keys.
+- `tests/storeBlockedLedger.test.js` — 12 cases for transition counting,
+  flap dedup, day rollover, clone-on-write identity, sanitization.
+
+## Key decisions
+
+- **Transition counter, not event counter**: `blocked` has no
+  PostToolUse-anchored `eventKey`; the simpler "only count the first
+  blocked tick in a contiguous run" rule avoids over-counting polling
+  duplicates without inventing a fragile dedup key.
+- **Shared dayChanged gate**: both ledgers must reset on the same tick.
+  The 0f4ef51 follow-up hardens this so a stale dayKey in either ledger
+  alone still triggers a full atomic rollover.
+- **`useShallow` + `useMemo`**: ledger objects are clone-on-write — identity
+  changes only on actual increment or rollover. The reduction therefore
+  doesn't re-run on minute ticks or agent movement.
+
+## Acceptance criteria (Done)
+
+- [x] `dailyBlockedLedger` increments only on working→blocked transition
+- [x] Day rollover resets both ledgers atomically
+- [x] Chip visible in Full and Panel modes with i18n + sr-only + tooltip
+- [x] 12 unit tests, 552/552 vitest at ship
+
+## Rollback
+
+`git revert 0f4ef51 fca854a` — removes the ledger field, chip, and i18n
+keys. No data migration needed (persisted blocked ledger sanitizes to
+null on load and re-seeds). Blast radius: ControlPanel chrome + store
+state shape; no downstream consumers.
+
+## References
+
+- Commits: `fca854a feat(#6)`, `0f4ef51 fix(#6)` atomic rollover
+- CHANGELOG v1.1.0 → "#6 底部效能指標"
+- Backlog row: `_shipped-log.md` #6
+- Related: [[character-growth-system]] (parallel `dailyDoneLedger`)

--- a/docs/specs/tool-inventory-label.md
+++ b/docs/specs/tool-inventory-label.md
@@ -1,0 +1,79 @@
+---
+title: Tool inventory label
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [d1a68d5]
+primary_files: [src/components/AgentCharacter.jsx]
+test_file: tests/taskLabel.test.js
+---
+
+# Tool inventory label (AVO-103)
+
+## Problem
+
+The office classified incoming tool calls but didn't surface *which*
+tool each agent was using right now. Hovering opened the inspector; a
+glance across 7 agents told you only their status colors. Real Claude
+Code sessions hit different tools rapidly (Bash → Read → Edit → MCP
+calls), and that texture was invisible without opening the inspector.
+
+## Solution
+
+`TaskLabel` SVG component inside `AgentCharacter.jsx`: a 7px monospace
+pill positioned at `y=-29` in the inverse-scaled name-tag group —
+between name tag and head, visible but not blocking the face. Label
+text is `classifyTask(task).visualLabel` so built-in tools render
+concise names (`Bash`/`Read`/`Edit`) while MCP tools use the Tier 4
+inner-verb bubble-up (`mcp__notion__create_page → notion::create`).
+Unknown labels truncate to ≤16 chars with `…`. Returns `null` when
+`task` is empty/null/undefined so idle agents stay clean. Per-agent
+subscription is intentionally narrow:
+`useOfficeStore((s) => s.externalStatus[id]?.task ?? null)` — re-renders
+fire only when the tool itself changes, not on label/expiresAt/hint
+ticks. Visual restraint per brief: no icons, no animation, no color
+coding, fill `#E8E8E8` on `#1a1a1a` opacity 0.55.
+
+## Files
+
+- `src/components/AgentCharacter.jsx` — `TaskLabel` component, narrow
+  per-agent task subscription, render slot in the name-tag group.
+- `tests/taskLabel.test.js` — 17 cases: built-in routing, MCP
+  server::tool routing, MCP no-verb fallback, verb-classified routing,
+  long-name truncation, defensive null/undefined/empty inputs.
+
+## Key decisions
+
+- **Reuse `classifyTask().visualLabel`**: AVO-103 ships zero new
+  vocabulary; the label string is already family-aware because the
+  classifier (#A1) and MCP inner-verb fix shipped earlier.
+- **Narrow subscription**: subscribing to the whole `externalStatus[id]`
+  object would re-render on every poll tick. Selecting only `.task`
+  means the pill updates on tool change only.
+- **No animation, no color**: design brief was "畫面要清楚好懂、不過分花俏".
+  At 7 agents × frequent tool changes, anything flashier would become
+  visual noise.
+- **`null` for idle**: idle agents have no task; returning null keeps
+  the head area clean rather than rendering an empty pill.
+
+## Acceptance criteria (Done)
+
+- [x] Pill appears below name tag, above head, never covers the face
+- [x] Built-in tool names render as concise labels
+- [x] MCP tools collapse via Tier 4 bubble-up
+- [x] Idle agents render no pill
+- [x] 17 unit tests; 960/960 vitest at ship; +0.6 KB raw / +0.13 KB gzip
+
+## Rollback
+
+`git revert d1a68d5` — removes the `TaskLabel` component and its render
+slot. AgentCharacter falls back to name-tag-only above-head chrome. No
+store-shape change, no migration. Blast radius: visual only, single
+component.
+
+## References
+
+- Commit: `d1a68d5 feat(AVO-103) tool inventory label above each agent`
+- CHANGELOG v1.1.0 → AVO-103 entry (via backlog)
+- Backlog row: `_product-backlog.md` AVO-103
+- Related: [[classifier-foundation]], [[mcp-inner-verb-fix]]

--- a/docs/specs/weather-system.md
+++ b/docs/specs/weather-system.md
@@ -1,0 +1,88 @@
+---
+title: Weather system
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [678e7e0, 6a171d6, 16754b3, 0cd0920]
+primary_files: [src/components/TopDownFurniture.jsx, src/components/PixelOffice.jsx, src/index.css]
+test_file: tests/weatherSystem.test.js
+---
+
+# Weather system (#14, closes #15)
+
+## Problem
+
+Window panes were static decoration regardless of team state. With the
+mood engine already classifying team-wide feeling (smooth / rushing /
+frustrated / stuck / intense / normal / idle), the ambient setting could
+mirror it without adding new signal load. Separately, #15 白板手寫動畫 was
+listed Pending in backlog but `WhiteboardAnimation` at
+`PixelOffice.jsx:146` already implemented it (eureka → 3000ms
+stroke-dashoffset animation) — needed closure documentation.
+
+## Solution
+
+Pure `moodToWeather(mood)` mapping in `TopDownFurniture.jsx`:
+`stuck → thunderstorm`, `frustrated → rain`, `rushing → cloudy`, all
+others → `clear`. `WeatherOverlay` renders inside each `WallWindow`
+under the cross muntins, clipped to the pane via a per-instance
+`clipPath` (id keyed by `x-y` so 12 windows don't share masks). Rain is
+5 `<line>` drops with staggered delay; clouds are 2 drifting ellipses;
+thunderstorm overlays a single rect flashing at capped 0.35 opacity
+twice per 5s cycle — well below 3 Hz photosensitivity threshold.
+`reducedMotion` renders the same DOM but drops every `animation` style
+prop. PixelOffice subscribes `mood` (primitive enum, no `useShallow`)
+once and passes the resolved weather to all WallWindow call-sites; the
+React.memo prop comparison still gates re-renders because weather is a
+string.
+
+#15 closure: confirmed pre-existing — same pattern as #7 closure.
+
+## Files
+
+- `src/components/TopDownFurniture.jsx` — `moodToWeather()`, `WeatherOverlay`,
+  WallWindow weather/reducedMotion props.
+- `src/components/PixelOffice.jsx` — mood + reducedMotion subscriptions,
+  `WeatherKeyframes` component (later moved to CSS in #27).
+- `src/index.css` — `@keyframes weather-raindrop-fall` / `weather-cloud-drift`
+  / `weather-lightning-flash` (moved from inline `<style>` in 0cd0920 for
+  strict CSP compatibility).
+- `tests/weatherSystem.test.js` + `tests/weatherDriveChain.test.js` +
+  `tests/weatherRealWorld.test.js` — mood mapping, full hook→mood→weather
+  drive chain, raindrop daytime visibility regressions.
+
+## Key decisions
+
+- **Pure mapping function**: `moodToWeather` is testable in isolation and
+  defaults to `clear` for unrecognized inputs — backward-compat with
+  WallWindow callers that don't pass weather is automatic.
+- **Photosensitivity cap**: lightning opacity 0.35, twice-per-5s — design
+  brief explicitly traded "more dramatic storm" for seizure safety.
+- **Keyframes in bundled CSS (#27)**: original inline `<style>` violated
+  strict `style-src 'self'` CSP. 0cd0920 moved them to `src/index.css` so
+  production JS contains zero `@keyframes`; CSS bundle +0.3 KB.
+- **#15 closure pattern**: same as #7 (clickable objects) — mark Done with
+  evidence pointer to the pre-existing implementation, no new code.
+
+## Acceptance criteria (Done)
+
+- [x] All 7 mood enum values map deterministically
+- [x] reducedMotion drops all `animation` props
+- [x] Lightning capped at 0.35 opacity / <3 Hz
+- [x] CSP-safe (zero `@keyframes` in production JS)
+- [x] #15 closure-documented in backlog and CHANGELOG
+
+## Rollback
+
+`git revert 0cd0920 16754b3 6a171d6 678e7e0` — removes WeatherOverlay,
+mapping, CSS keyframes, all tests. WallWindow falls back to its
+pre-weather signature (props ignored, no visual change). Blast radius:
+all 12 window instances + mood subscription in PixelOffice.
+
+## References
+
+- Commits: `678e7e0 feat(#14)`, `6a171d6 test`, `16754b3 fix raindrop`,
+  `0cd0920 feat(#27) CSP`
+- CHANGELOG v1.1.0 → "#14 天氣系統", "#27 CSP compatibility"
+- Backlog rows: `_shipped-log.md` #14, #15, #27
+- Related: [[classifier-foundation]] (mood vocabulary parity)

--- a/docs/specs/workflow-handoff-arrows.md
+++ b/docs/specs/workflow-handoff-arrows.md
@@ -1,0 +1,92 @@
+---
+title: Workflow handoff arrows
+status: shipped
+date: 2026-05-29
+shipped_in: v1.1.0
+commits: [dde593f]
+primary_files: [src/inference/workflowHandoff.js, src/components/PixelOffice.jsx, src/systems/store.js]
+test_file: tests/workflowHandoff.test.js
+---
+
+# Workflow handoff arrows (AVO-105)
+
+## Problem
+
+The PM→Arch→Dev→QA→Gate→Ops workflow is the office's core narrative,
+but `activeWorkflow` flipped silently between phases. Users had to
+read the broadcast banner to know a handoff had happened; the spatial
+choreography of "code passing between roles" was invisible.
+
+## Solution
+
+`startWorkflowHandoffs(store)` subscribes to the store, snapshots
+`activeWorkflow` on each change, and looks up an explicit 7-row table
+of `phase→phase` transitions mapped to role pairs (e.g.
+`plan→implement → arch→dev`, `review→ship → gate→ops`). On a hit, it
+calls `addHandoff(from, to, { subtle: true })` — reusing the
+existing FlyingDocument arc infrastructure. The `subtle` flag is
+persisted on the handoff entry; `FlyingDocument` renders the calm
+variant (60° rotation, no scale pulse, no sparkle) for workflow
+handoffs while keeping the flashy 360° + sparkle variant for organic
+officeLife pass-document events. Boot safety: `null↔phase` transitions
+never fire; identical workflows skip; unmapped pairs skip; lightweight
+roster (planner/worker/checker) silently skips when named roles are
+absent. **Re-entrancy bug-pin**: `prevWorkflow` MUST advance BEFORE
+`addHandoff` — zustand fires listeners synchronously on every setState,
+so a side effect that mutates state re-fires the watcher; without the
+early advance, the closure observes the same `next` against the
+unchanged `prev` and recurses to a stack overflow.
+
+## Files
+
+- `src/inference/workflowHandoff.js` — `HANDOFFS` table (7 transitions),
+  `normalizeWorkflow`, `startWorkflowHandoffs` subscription, exported
+  `WORKFLOW_HANDOFFS` for test iteration.
+- `src/components/PixelOffice.jsx` — `startWorkflowHandoffs` lifecycle
+  wire-up; `FlyingDocument` honors `handoff.subtle`.
+- `src/systems/store.js` — `addHandoff(from, to, opts)` extended with
+  `opts.subtle` boolean, persisted on the handoff entry.
+- `tests/workflowHandoff.test.js` — 18 cases: each mapped row, subtle
+  flag, null/boot safety, unmapped transitions, identical workflow,
+  lightweight roster skip, BUG-PIN re-entrancy, full
+  spec→plan→implement→test→review→ship narrative chain.
+
+## Key decisions
+
+- **Explicit table, not heuristics**: only 7 mapped pairs. Anything not
+  listed produces no arrow. Keeps arrows meaningful signal, not noise.
+- **`subtle` flag, not new component**: reusing FlyingDocument keeps
+  visual language consistent; the flag toggles decoration only (same
+  paper SVG, same 800ms, same arc).
+- **Advance prev BEFORE side effect**: the re-entrancy bug only
+  surfaces in live preview because tests usually drive `setState`
+  through a wrapper. A BUG-PIN test simulates the synchronous re-entry
+  so a regression can't slip through.
+- **Boot-safety asymmetry**: `null → /plan` is the FIRST observation,
+  not a transition — firing on it would spam a handoff every time the
+  office starts.
+
+## Acceptance criteria (Done)
+
+- [x] 7 mapped transitions fire correct role-pair handoffs
+- [x] Organic handoffs keep flashy variant; workflow handoffs are subtle
+- [x] Boot, identical, unmapped, lightweight-roster cases all no-op
+- [x] Re-entrancy BUG-PIN test in place
+- [x] 18 unit tests; 943/943 vitest at ship; +0.9 KB raw / +0.3 KB gzip
+
+## Rollback
+
+`git revert dde593f` — removes the `workflowHandoff.js` module, the
+`subtle` opt on `addHandoff`, and the PixelOffice subscription wire-up.
+Existing organic handoffs continue to fire (flashy variant only).
+Blast radius: workflow visualization layer; store-shape change is
+additive (`opts.subtle` only).
+
+## References
+
+- Commit: `dde593f feat(AVO-105) workflow handoff arrows — subtle paper-arc
+  on phase transitions`
+- CHANGELOG v1.1.0 → AVO-105 entry (via backlog)
+- Backlog row: `_product-backlog.md` AVO-105
+- Related: [[classifier-wiring]] (workflow classification),
+  [[tool-inventory-label]]


### PR DESCRIPTION
## Summary

Closes the documentation gap the session retro flagged. Before this PR, `docs/ARCHITECTURE.md` (last touched 2026-04-02) and `docs/DESIGN_SPEC.md` (last touched 2026-03-18) had **zero mention** of the v1.1.0 classifier system, weather overlays, idle-gap inference, desktop notifications, CSP move, or any other addition. Each of the 10 features shipped this wave was a one-line backlog row + commit-message rationale only.

This PR is docs-only — source / tests untouched.

## What's in

- **11 new feature specs** in `docs/specs/`, uniform template (60–100 lines each):
  - Classifier batch: `classifier-foundation.md`, `classifier-wiring.md`, `classifier-unknown-log.md`, `mcp-inner-verb-fix.md`
  - Visual batch: `perf-metrics-chip.md`, `weather-system.md`, `tool-inventory-label.md`, `workflow-handoff-arrows.md`
  - Inference + compatibility: `desktop-notifications.md`, `idle-gap-inference.md`, `csp-compatibility.md`
- **`docs/ARCHITECTURE.md`** — appended ~150-line *v1.1.0 — Classifier + Inference Layer* section with ASCII pipeline diagram, 4-tier waterfall description, `decideBehavior` priority resolver, AgentCortex-skill-driven role profiles, inference modules, `unknownLog` operational pattern.
- **`docs/DESIGN_SPEC.md`** — appended ~120-line *v1.1.0 — Visual Additions* section covering the metric chip, weather, tool inventory label, subtle handoff variant, notifications, and the bottom-status pill composition order.
- **3 decision logs** (`docs/architecture/{office-runtime,hook-integration,ui-rendering}.log.md`) — each gained a dated 2026-05-29 entry capturing the [DECISION]s, [TRADEOFF]s, and [CONSTRAINT]s that drove v1.1.0, cross-referenced to specs.
- **SSoT Spec Index** (`.agentcortex/context/current_state.md` seq 18 → 19 via guard) expanded with all 11 new specs grouped by category.

## Why now

The session retro called this out as the *biggest* gap. Without these specs:
- A new maintainer reading `docs/ARCHITECTURE.md` would believe the project is still pre-classifier.
- The *rationale* for each design decision (why 30s threshold for notifications, why role profiles mirror skill associations, why subtle vs sparkly handoff) lived only in commit messages.
- `_shipped-log.md` covered *what shipped*; nothing covered *why this design over another*.

This PR makes the decision history greppable from `docs/`.

## Test plan

- [x] vitest 960/960 still passing locally — no source changes
- [x] Every new spec links to a real commit SHA reachable from current `main`
- [x] Every new spec references the actual test file under `tests/`
- [x] ARCHITECTURE.md + DESIGN_SPEC.md retain the pre-v1.1 sections verbatim (purely additive)
- [x] Decision logs append new entries; prior 2026-04-08 entries untouched
- [x] SSoT Spec Index entries point to files that exist
- [ ] CI green on this PR

## After merge

This is the last docs-housekeeping piece for v1.1.0. The repo state after merge:
- `_product-backlog.md` lean (14 AVO-* items)
- `_shipped-log.md` historical archive
- `CHANGELOG.md` user-facing summary
- `docs/reviews/2026-05-29-session-retro.md` engineering retro
- `docs/specs/<feature>.md` per-feature rationale (NEW — this PR)
- `docs/ARCHITECTURE.md` + `docs/DESIGN_SPEC.md` (REFRESHED — this PR)
- `docs/architecture/*.log.md` decision logs (REFRESHED — this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)