### PR TITLE
fix(hook): make extractContext locale-injectable so its test is host-portable

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Full notes in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 ## Tech stack
 
 React 19 + Vite 6 · SVG (no canvas, no GPU) · Zustand · Tailwind CSS v4 · `requestAnimationFrame` · zero backend.
-1263 tests (classifier, inference, store, movement, event honesty). Deep dive → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+1276 tests (classifier, inference, store, movement, event honesty). Deep dive → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 
 ## Contributing
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -153,7 +153,7 @@ http://localhost:5174?lang=zh-TW     # 強制繁體中文
 ## 技術選型
 
 React 19 + Vite 6 · SVG（不用 canvas、不吃 GPU）· Zustand · Tailwind CSS v4 · `requestAnimationFrame` · 零後端。
-1263 個測試（分類器、推論、store、移動、事件誠實性）。深入細節 → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**。
+1276 個測試（分類器、推論、store、移動、事件誠實性）。深入細節 → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**。
 
 ## 貢獻
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Pixel-art virtual office that visualizes AI agent activity in real-time. Works with Claude Code, Gemini CLI, Codex, and any tool that can POST status.",
   "main": "bin/cli.js",
   "bin": {

--- a/public/hooks/office-status-hook.js
+++ b/public/hooks/office-status-hook.js
@@ -255,7 +255,7 @@ function bashVibeLabel(cmd, lang = LANG) {
   return fallback
 }
 
-function extractContext(tool, toolInput) {
+function extractContext(tool, toolInput, lang = LANG) {
   if (!toolInput) return null
   try {
     const input = typeof toolInput === 'string' ? JSON.parse(toolInput) : toolInput
@@ -266,7 +266,7 @@ function extractContext(tool, toolInput) {
         return shortFile(input.file_path || input.path)
       case 'Bash':
         // AVO-126: never surface a raw shell command/path in a bubble — use an office-vibe noun.
-        return bashVibeLabel(input.command || input.cmd)
+        return bashVibeLabel(input.command || input.cmd, lang)
       case 'Grep': {
         // Strip leading path components from the pattern so absolute paths don't leak into
         // bubbles: "/home/user/src/**/*.js" → "*.js"; "useLocale" stays "useLocale"
@@ -297,7 +297,7 @@ function extractContext(tool, toolInput) {
       case 'WebSearch':
         return input.query || input.url?.replace(/^https?:\/\//, '').slice(0, 25) || null
       case 'TodoWrite':
-        return input.todos?.length ? (LANG === 'zh-TW' ? `${input.todos.length} 個任務` : `${input.todos.length} tasks`) : null
+        return input.todos?.length ? (lang === 'zh-TW' ? `${input.todos.length} 個任務` : `${input.todos.length} tasks`) : null
       case 'EnterPlanMode':
       case 'ExitPlanMode':
         return null

--- a/tests/officeStatusHook.test.js
+++ b/tests/officeStatusHook.test.js
@@ -350,7 +350,9 @@ describe('extractContext (hook)', () => {
   })
 
   it('maps Bash input to an office-vibe noun, never the raw command (AVO-126)', () => {
-    const result = extractContext('Bash', { command: 'npm test' })
+    // Pin lang so the assertion is portable — extractContext otherwise localizes via the
+    // machine's ~/.claude/office-lang (this was failing on zh-TW hosts; CI happens to run en).
+    const result = extractContext('Bash', { command: 'npm test' }, 'en')
     expect(result).toBe('tests')
   })
 


### PR DESCRIPTION
## The bug
The full test suite was **red on any zh-TW host** (1275/1276) while green on CI.

`extractContext()` localizes Bash/Todo nouns through the module-level `LANG`, which `detectHookLang()` reads from `~/.claude/office-lang`. The AVO-126 test asserted the English `'tests'` but never pinned the language — so on a Chinese-locale machine `extractContext('Bash', {command:'npm test'})` returned `'測試'` and the test failed. CI happens to run with `en`, which masked it. (This is why v1.2.0's "1276 pass" held on CI but not locally.)

## The fix
- `extractContext(tool, toolInput, lang = LANG)` — thread an optional `lang` through to `bashVibeLabel()` and the `TodoWrite` branch, mirroring the existing `bashVibeLabel(cmd, lang = LANG)` signature. The default preserves production behavior (both call sites pass two args).
- Pin the AVO-126 test to `'en'`, matching its sibling `bashVibeLabel(..., 'en')` tests.
- README EN/zh: correct the stale test count **1263 → 1276**.
- Bump **1.2.0 → 1.2.1**.

## Verification
`npm test` → **1276/1276 passing on a zh-TW host** (previously 1275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)