### PR TITLE
[codex] Fix Tailwind source scan warning

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,7 @@
-@import "tailwindcss";
+@import "tailwindcss" source(none);
+
+@source "./";
+@source "../index.html";
 
 html, body, #root {
   margin: 0;


### PR DESCRIPTION
## What changed

Restricts Tailwind v4 source detection in `src/index.css` to the actual app entry points:

- disables automatic project-wide scanning with `source(none)`
- explicitly registers `src/` and `index.html`

## Why

This is a real, reproducible build hygiene issue. Before the fix, `npm run build` passed but emitted an esbuild CSS warning because Tailwind's automatic source detection scanned hidden governance files and interpreted template text like `[file:line]` / `[path:line]` as arbitrary CSS utilities. That generated invalid CSS such as `file: line` / `path: line`.

Root cause evidence:

- `src/index.css` on `main` imported Tailwind with full automatic source detection.
- `rg --hidden "\[file:line\]|\[path:line\]"` found matching template text in `.agent/` and `.agents/`.
- After the fix, `npm run build` emits no CSS warning.
- The generated dist CSS no longer contains `file:line` / `path:line` utilities while normal app utilities are still generated.

## Related issues

Checked open issues for Tailwind/build warning/CSS warning/file:line/path:line. No precise matching open issue was found, so this PR intentionally does not close any issue. The closest search result was #50, but that is about watchdog timer false restarts and is unrelated.

## Validation

- `npm run build` => pass, no CSS warning
- `npm test` => `53` files / `1276` tests passed
- `git diff --check` => pass, with only Git's existing LF-to-CRLF working-copy warning for `src/index.css`
- product-file secret scan on `src/index.css` => no matches