### PR TITLE
fix(ssot): restore consolidated current_state.md clobbered during PR #56 ship

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -1,5 +1,6 @@
 # Project Current State (vNext)
 
+- **Project Name**: Agent Virtual Office
 - **Project Intent**: Build a self-managed Agent OS for Codex Web / Codex App / Google Antigravity to reduce human procedural burden and continuously lower token costs.
 - **Core Guardrails**:
   - Correctness first: No claim of completion without evidence.
@@ -11,11 +12,13 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-05-30
-- **Update Sequence**: 26
+- **Last Updated**: 2026-06-06T07:00:00Z
+- **Update Sequence**: 34
 - **ADR Index**:
-  - `.agentcortex/adr/ADR-001-vnext-self-managed-architecture.md`
-  - `docs/adr/ADR-003-status-source-parity-for-codex.md`
+  - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
+  - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
+  - docs/adr/ADR-003-status-source-parity-for-codex.md — status-source parity for Codex
+  - .agentcortex/adr/ADR-001-vnext-self-managed-architecture.md — framework scaffold mirror of ADR-001
 - **Active Backlog**: `docs/specs/_product-backlog.md`
   - 15 features across 5 themes: 辦公室生命感、資訊密度、互動性、整合延伸、視覺升級
   - **Done (branch `fix/agent-inspector-hooks-crash`, 2026-04-02)**:
@@ -64,6 +67,9 @@
   - [v1.1.0 inference] docs/specs/desktop-notifications.md [Shipped]  *(#8)*
   - [v1.1.0 inference] docs/specs/idle-gap-inference.md [Shipped]  *(#C)*
   - [v1.1.0 compatibility] docs/specs/csp-compatibility.md [Shipped]  *(#27)*
+  - [vibe-rebalance] docs/specs/ux-vibe-rebalance.md [Frozen]  *(AVO-126/127/128/129/131/132 — branch feat/ux-vibe-rebalance, not yet merged)*
+  - [living-office] docs/specs/living-office-events.md [DRAFT, review-gated]  *(P1-P4 shipped to branch feat/ux-vibe-rebalance, not merged; AC-3 pixel-dominance pending owner visual confirm)*
+  - [subagent] docs/specs/subagent-helper-huddle.md [Frozen]  *(SubagentStart→helper sprites; shipped)*
   - When reading specs: only open files tagged with the current task's module.
 - **Canonical Commands**:
   - `/spec-intake`: Import external specs (from other LLMs, documents, or natural language). Handles large product specs via decomposition. Runs before `/bootstrap`.
@@ -97,161 +103,126 @@
 >
 > `/implement` reviews active HIGH-severity lessons before code changes. `/retro` may append new structured entries via guarded write.
 
-- [Category: global-memory][Severity: MEDIUM][Trigger: archive-handoff] Branch-local lessons are lost after archival. Use the Global Lessons registry for repeatable patterns that should survive work log rotation.
-- [Category: format-safety][Severity: HIGH][Trigger: apply-patch-line-numbers] Do not copy line numbers from view tools into edits; they corrupt file patches.
-- [Category: path-safety][Severity: HIGH][Trigger: bulk-rename] Validate for accidental double-prefix replacements like `agentcortex/agentcortex/...` immediately after bulk path rewrites.
-- [Category: wrapper-validation][Severity: MEDIUM][Trigger: wrapper-validation] Wrapper checks should assert behaviorally equivalent path construction, not only one literal path string.
-- [Category: shell-portability][Severity: MEDIUM][Trigger: cross-platform-validation] Cross-platform validation entrypoints should prefer portable `grep`-style checks over environment-specific `rg` assumptions.
-- [Category: worklog-contract][Severity: HIGH][Trigger: branch-normalization] Resolve filesystem-safe work log keys from raw branch names before gate checks; missing active logs are recoverable, but missing evidence is not.
-- [Category: patch-fallback][Severity: LOW][Trigger: apply-patch-instability] When `apply_patch` is unstable on this Windows workspace, use tightly scoped whole-file rewrites only for new or text-only files, then immediately re-verify with `git diff --check`.
-- [Category: detector-validation][Severity: MEDIUM][Trigger: integrity-baseline] Validate new integrity checks against real repo bytes before baselining, or pure-LF files may be misclassified as mixed EOL.
-- [Category: shell-dependency][Severity: HIGH][Trigger: validation-runtime-dependency] Cross-platform validation entrypoints must not add new hard runtime dependencies unless the migration path is documented.
-- [Category: path-separation][Severity: HIGH][Trigger: framework-path-migration] Downstream-facing artifacts such as specs and ADRs must stay in project-visible `docs/` paths, not hidden framework directories.
-- [Category: review-process][Severity: LOW][Trigger: multi-role-review] Different reviewer personas catch different failure classes; multi-role review is useful for high-risk template changes.
-- [Category: guard-placement][Severity: HIGH][Trigger: write-path-guard] Place guardrail rules where all relevant classifications read them, not only in documents that some tiers skip.
+- [Category: global-memory][Severity: MEDIUM][Trigger: archive-handoff][prev: GENESIS] Branch-local lessons are lost after archival. Use the Global Lessons registry for repeatable patterns that should survive work log rotation.
+- [Category: format-safety][Severity: HIGH][Trigger: apply-patch-line-numbers][prev: 80ca8332] Do not copy line numbers from view tools into edits; they corrupt file patches.
+- [Category: path-safety][Severity: HIGH][Trigger: bulk-rename][prev: fdff36cc] Validate for accidental double-prefix replacements like `agentcortex/agentcortex/...` immediately after bulk path rewrites.
+- [Category: wrapper-validation][Severity: MEDIUM][Trigger: wrapper-validation][prev: b02467e3] Wrapper checks should assert behaviorally equivalent path construction, not only one literal path string.
+- [Category: shell-portability][Severity: MEDIUM][Trigger: cross-platform-validation][prev: c093febc] Cross-platform validation entrypoints should prefer portable `grep`-style checks over environment-specific `rg` assumptions.
+- [Category: worklog-contract][Severity: HIGH][Trigger: branch-normalization][prev: 7d3ebcee] Resolve filesystem-safe work log keys from raw branch names before gate checks; missing active logs are recoverable, but missing evidence is not.
+- [Category: patch-fallback][Severity: LOW][Trigger: apply-patch-instability][prev: 0d81c21e] When `apply_patch` is unstable on this Windows workspace, use tightly scoped whole-file rewrites only for new or text-only files, then immediately re-verify with `git diff --check`.
+- [Category: detector-validation][Severity: MEDIUM][Trigger: integrity-baseline][prev: bcf3b211] Validate new integrity checks against real repo bytes before baselining, or pure-LF files may be misclassified as mixed EOL.
+- [Category: shell-dependency][Severity: HIGH][Trigger: validation-runtime-dependency][prev: 18be92af] Cross-platform validation entrypoints must not add new hard runtime dependencies unless the migration path is documented.
+- [Category: path-separation][Severity: HIGH][Trigger: framework-path-migration][prev: b8dcf50e] Downstream-facing artifacts such as specs and ADRs must stay in project-visible `docs/` paths, not hidden framework directories.
+- [Category: review-process][Severity: LOW][Trigger: multi-role-review][prev: a9f0a54f] Different reviewer personas catch different failure classes; multi-role review is useful for high-risk template changes.
+- [Category: guard-placement][Severity: HIGH][Trigger: write-path-guard][prev: d5689fc7] Place guardrail rules where all relevant classifications read them, not only in documents that some tiers skip.
+- [Category: packaging][Severity: MEDIUM][Trigger: dependency-presence-check][prev: 9da72f26] An installed package's CLI launcher must detect its own runtime deps via `require.resolve(dep, {paths:[root]})` (honors npm hoisting to a parent node_modules), not `fs.existsSync(root/node_modules/<dep>)` — the latter always misses hoisted deps and re-runs `npm install` on every launch.
+
+## Protected Surfaces (layout/movement/scale-critical — DO NOT casually edit)
+
+> These have caused repeated visual regressions. `preview_screenshot` is BROKEN here and `preview_eval`
+> CANNOT reach the running app's store (module duplication) — so an AI **cannot see pixels**. Before
+> changing ANY of these, verify by `getBoundingClientRect`/computed-font measurement across window
+> sizes AND get OWNER VISUAL CONFIRMATION. Never claim a visual change "works" from code/tests alone.
+
+- **Office viewBox `0 0 800 560` + width-fill layer** (`PixelOffice.jsx` svgElement: `aspect-ratio:800/560`, center, clip) — the responsive proportion. Owner requires fill-width, no L/R whitespace, no crop of agents. Changing risks re-breaking proportions.
+- **`movementSystem.js` agent coordinates / HOME_POSITIONS / MEETING_CHAIRS / event gather spots** (`officeLife.js` EVENT_HANDLERS) — hardcoded. Tight gather spots caused an all-agent pile-up (sprites stack → SVG occlusion hides the lower one). NOW the store (`setMultipleAgentGroupEvents`/`setAgentGroupEvent`) runs every `groupTarget` through `clampToFloor` + `avoidOverlap` (≥`MIN_AGENT_DIST`) so participants can't stack — guarded by `tests/agentSeparationInvariants.test.js`. Keep that deconfliction; don't bypass it by writing `groupTarget`/`position` directly elsewhere. NOTE: there is still NO per-frame separation in free movement (agents pass through each other in transit — AVO-144).
+- **`LABEL_SCALE_MAX = 1.5`** (`AgentCharacter.jsx`) — POINT-2-tuned so active name tags don't collide. Raising it improves small-dock readability but risks label collision — owner's call, verify collisions by measuring label rects at a small window.
+- **`officeLife.js` event cadence** — real-seed triggers are GLOBAL-cooldown-gated to stay rare (calm-tech); do NOT seed all-gather events (e.g. `standup`) off frequent signals (SubagentStart) — that froze the office in perpetual gathering.
+- **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
 
-### main-2026-05-30 (overnight optimization: label consistency + blocked-reason visibility)
+### Ship-docs-audit-baseline-2026-06-05
 
-- Autonomous overnight session (Claude Opus 4.8). Goal: verify features trigger correctly + find/execute optimizations. 3 quick-wins shipped locally (NOT pushed — left for human review; repo remains ahead of origin pending the prior push too).
-- **Trigger verification (no code)**: live preview confirmed the full hook→status-file→vite `/api/status`→store→render pipeline works with REAL Claude Code hook events (dev character rendered the live MCP tool in use, PM=thinking from UserPromptSubmit, today-done counter live). Additionally verified via direct store-module import: weather (mood:'stuck'→thunderstorm, 12 clip-paths/60 rain/12 lightning), done→idle lifecycle (designer done→10s expiry→cleared→idle), idle-gap inference (blocked+90s→awaiting-approval), reduced-motion a11y (weather renders, 0 animated elements), i18n parity (260=260 keys, no leaks), zero console errors.
-- **Ship 1 — `fix(ControlPanel)` 7475760**: collapse raw MCP tool names. Added exported pure `taskChipLabel(task)`→`classifyTask().visualLabel`; the control-panel status line no longer shows `mcp__Server__tool` (now `Server::tool`), matching the AVO-103 character TaskLabel. +10 tests.
-- **Ship 2 — `feat(ControlPanel)` a757af4**: surface blocked failure reason (AVO-110 lite). Added `blockedReasonLabel(ext)` + `agentLineLabel(ext,t)`; a blocked agent's status line now shows the hook's reason (`❌ npm test failed`) instead of the bare tool. Text-reason core of AVO-110; the classified reason-enum + colored sub-icon deferred for user aesthetic review. +10 tests.
-- **Ship 3 — `fix(AgentInspector)` fedb37c**: collapse label-less raw MCP task. Added `inspectorTaskLabel(ext)` to agentInspectorModel.js. Completes the "no raw `mcp__` in ANY surface" invariant (AgentCharacter ✓ / ControlPanel ✓ / AgentInspector ✓ / ActivityFeed uses human label). +4 tests.
-- **Ship 4 — `fix(hook)` dfdf855** (adversarial-review HIGH): a `SubagentStart` without `agent_id` set the `workflow` banner but left `_workflowAgentId` null; a later `SubagentStop` with mismatched/absent `agent_type` failed to clear it and `Stop` PRESERVED it → phantom workflow banner stuck FOREVER until the next prompt. Fix: `workflow: null` unconditionally at Stop (a banner can never outlive a turn) + extracted/tested `shouldClearWorkflowOnSubagentStop()` clearing orphaned banners. Not reachable where subagent dispatch fires as `PreToolUse{Agent}` (this setup), latent elsewhere. +6 tests.
-- **Ship 5 — `fix(inferStatus)` 196ede6** (adversarial-review MED): a workflow-only message (`#workflow=X` hash, no role keys) set `activeWorkflow` without external agents → `statusSource` stayed `'organic'` → the staleness sweep never fired → green banner pinned over an idle office forever. Fix: extracted/tested `stalenessSweepAction()`; sweep now clears an orphaned organic workflow. +3 tests.
-- **Ship 6 — `fix(server)` b5b9a0a** (adversarial-review HIGH): `scanAndMerge` did `(data.agents || []).filter(...)` — a truthy NON-ARRAY `agents` in a corrupt/old-hook/foreign session file threw TypeError, CRASHING the server process at the two unguarded callers (SSE-connect + file-watch debounce timer — the latter fires on ordinary file activity) and blanking the office at the GET path. Fix: `Array.isArray` root guard + try/catch defense-in-depth on both unguarded callers (matching the already-guarded POST/GET callers). TDD (test failed on old code). +2 tests. Verified server boots + serves 200 with the fix.
-- Adversarial sweep covered the ENTIRE trigger pipeline (hook → store → client inferStatus → server/session-merge). Findings: store = clean; hook = 1 HIGH fixed + 1 MED deferred (straggler PreToolUse >30s post-Stop → contradictory `_stopped`+working, narrow edge); client = 1 MED fixed + 1 MED deferred (multi-session exit-reconcile stale-dropped because merged `_seq`=max-child-seq can drop on session exit → exited worktree agent lingers ≤5min; fix needs server+client seq-semantics change); server = 1 HIGH fixed.
-- Tests: 960→995 vitest (+35, all green). Build clean throughout (386.48 KB / 120.96 KB gzip app; server-only fix adds 0 to bundle). 7 commits on `main`, NONE pushed — all for human review.
-- **Ship 7 — `fix(inferStatus)` 6e49ed5** (#6, was deferred MED → FIXED): added `isAuthoritativeSnapshotSource()`; multi-session payloads (whose merged `_seq`=max-child legitimately drops on session exit) are now exempt from the seq stale-drop at all 3 points → exited worktree agents no longer linger ≤5min. Content-dedup at transport prevents spam. +4 tests.
-- **Ship 8 — `fix(hook)` 4dcae10** (#5, was deferred MED → FIXED): added `shouldCarryStoppedSignal()` gating the `_stopped` carry-forward on `activeCount===0`, so a >30s straggler PreToolUse can no longer emit a contradictory `{_stopped:true, activeCount:1, working}`. Winding-down `done` (0 active) still carries the idle signal (race protection intact). +3 tests.
-- Tests: 960→1002 vitest (+42, all green). 11 commits on `main`, NONE pushed.
-- **HOOK-DATA INVESTIGATION (resolved the P0 blocker)**: fetched the official Claude Code hooks spec. Payload fields: `session_id, transcript_path, cwd, permission_mode, effort{level}, hook_event_name, tool_name, tool_input, agent_id, agent_type`. → **AVO-101 (plan-mode) IS FEASIBLE** via `permission_mode === 'plan'` on tool events (no dedicated plan event, but the mode is in every payload). → **AVO-108 (token meter)**: no token/cost in the hook payload, BUT `transcript_path` points to a JSONL with per-message usage → feasible via a transcript-tailing data path (medium effort). → **AVO-102 (thinking aura)**: the new `effort.level` field is a usable signal. AVO-101 build needs: add `'planning'` to `VALID_STATUSES` (constants.js), `STATUS_TABLE` (classify.js), `STATUS_BEHAVIOR_MAP` (store.js), i18n, + hook emits status='planning' when permission_mode==='plan'.
-- **Validator FAILs are NOT real defects** (diagnosed): README.md "mojibake" = framework validator checking its own `'Why AgentCortex?'` sentinel against a downstream PRODUCT readme (false positive — do NOT add the string). README.zh-TW.md "mixed-eol" = local autocrlf working-tree artifact; the COMMITTED blob is already clean uniform LF (`git show HEAD` = 0 CRLF / 230 LF). clickable-office-objects.md = `primary_domain: none` doc-governance quirk. None require a repo change.
-- **Ship 9 — `feat(AVO-101)` 92198e5**: plan mode is now visualized. Hook emits `status:'planning'` (via tested `statusForPreToolUse`) when `permission_mode==='plan'`; wired through VALID_STATUSES + classify STATUS_TABLE (FAMILIES.PLAN) + decideBehavior override (→ gantt-chart) + STATUS_BEHAVIOR_MAP + i18n (Planning/規劃中). Verified end-to-end by driving the real pipeline (routeExternalAgents → applyExternalStatus → gantt-chart + focused). Fancy "scrolling plan outline" visual deferred (aesthetic). +9 tests.
-- **DISTRIBUTION (resolved)**: `main` is a PROTECTED branch (no direct push). All session work is on branch `claude/overnight-trigger-fixes` → **PR #22** (https://github.com/KbWen/agent-virtual-office/pull/22), 14 commits, awaiting human review/merge. Install does NOT need npm publish: repo is PUBLIC, so `npx github:KbWen/agent-virtual-office` (verified working) + `git clone` work once the PR merges. npm publish is optional polish.
-- Tests: 960→1006 vitest (+46, all green) across the session.
-- **Ship 10 — `feat(AVO-108)` 11c73f8**: token meter. Hook tail-reads the transcript (`transcript_path`, 64 KB from end, <1ms) for `usage` → emits `tokens:{ctx,out,model}`; ControlPanel 🪙 chip shows context size (compact) + counts/model in tooltip. Presence-semantics store field. VERIFIED WITH REAL DATA (repo hook wrote my live ~652k context; chip matched). Deferred: rolling-1h / $ cost / sparkline. +18 tests.
-- **Ship 11 — `feat(AVO-102)` a62cd14**: extended-thinking aura. Hook emits `effort.level` (low|medium|high|xhigh|max); active agents render a subtle violet aura scaled by level (high+ only). VERIFIED WITH REAL DATA (my live 'high' effort → 2 auras at r=28). Aura aesthetics conservative, worth a preview look. +8 tests.
-- Session totals: **960→1024 vitest (+64), 17 commits on PR #22**, build clean throughout. AVO-101 + AVO-108 + AVO-102 all shipped (the 3 hook-data features #7 unblocked).
-- **REVIEW + TEST + SHIP (PR #22)**: independent adversarial pre-merge review of the full net diff (22 files, ~760 insertions) → **MERGE-READY, 0 blockers**; correctness, presence-semantics integration, hook safety, validation, server hardening, and test quality all verified. One NIT fixed pre-merge (`scanSessions` multi-session merge now carries `tokens`/`effort` like `mood`, +1 test). Test gate: 1025/1025 vitest, clean Vite build, `git diff --check` clean. Squash-merged to `main`.
-- **Remaining for human**: review+merge PR #22; optional `npm publish` (free, your account); AVO-108 token meter (transcript-tailing path) / AVO-102 thinking aura (effort.level) — feasible, not yet built; visual backlog (AVO-104/106/107/111/112/115, aesthetic) incl. AVO-101's deferred scrolling-outline polish.
+- Documentation-baseline consolidation: 8 audit findings (`docs/reviews/2026-06-05-audit.md`) remediated as doc-only, reversible changes. No `src/`/`tests/` touched.
+- **F1** SSoT 347→206 lines (Ship History pre-2026-06-02 rotated to `docs/specs/_ship-history-archive.md`); **F2/F3** L2 decision logs backfilled with the ux-vibe-rebalance wave (`ui-rendering`+`office-runtime`); **F4** `ARCHITECTURE.md` current-model banner; **F5** ADR-001 dedup + stale-path fix; **F6** ADR-001/002/003 YAML+lifecycle frontmatter; **F7** CORRECTED — the rebalance wave is ALREADY merged to `main` via squash PR #44 (`012d0f2`); the original "unmerged baseline divergence" claim was a stale-SSoT propagation error caught in `/review`.
+- **Review**: 3 fresh acx-reviewers (governance / doc-accuracy / scope) + 1 fresh re-review. Governance + scope PASS first-pass (rotation lossless 24=6+18 reconciled, guards CAS-verified, 0 source files). Doc-accuracy found 1 CRITICAL (stale merge-state) → fixed → re-review Resolved.
+- **Guarded writes**: `current_state.md` + `_product-backlog.md` via `guard_context_write.py` (CAS, receipts).
+- Tests: Pass (`validate.sh` 0 fail; app vitest unaffected — no source change).
 
-### main-2026-05-29 (AVO-103 tool inventory label)
+> [!NOTE]
+> **Reconciliation (2026-06-05):** the four `feat-ux-vibe-rebalance-*` cycles below were written before squash PR #44 merged. As of 2026-06-05 that wave IS merged to `main` (`012d0f2`, v1.2.0); their "NOT pushed/merged" / "Remaining for human: push/merge" lines are stale, preserved only as historical record. `main` is canonical; `feat/ux-vibe-rebalance` is superseded dev history (git-verified: `src/` identical main↔feat, main 3 commits ahead).
 
-- Shipped: `TaskLabel` SVG component inside `src/components/AgentCharacter.jsx`. Per-agent subscription to `s.externalStatus[id]?.task` re-renders only on tool change (not on every label/expiresAt tick). Renders `classifyTask(task).visualLabel` in a 7px monospace pill at y=-29 in the inverse-scaled name-tag group, just below the name tag and above the character head. Fill `#E8E8E8` on `#1a1a1a` opacity 0.55 background — low contrast, no animation, no flashy colour. Returns null when no task is set → idle agents stay clean.
-- Built-in tools display concise names (`Bash`, `Read`, `Edit`, `Write`, `Grep`, `Glob`, `Task`, `WebFetch`, `WebSearch`, `Notebook`, `Plan`). MCP-namespaced tools collapse via the inner-verb bubble-up shipped earlier — `mcp__notion__create_page` shows as `notion::create`, `mcp__atlassian__search_issues` as `atlassian::search`.
-- Live verified during implementation against real Claude Code hook events: dev character showed `Claude_Preview::preview_eval` for an MCP tool call, ops showed `Bash` from npm test runs, qa/designer showed `Edit` from source edits, gate showed `AskUserQuestion` from interactive prompts. All seven agents had their labels update within ~1s of the hook firing.
-- Tests: 960/960 vitest passed (was 943, +17 new in tests/taskLabel.test.js — 11 built-in tools, MCP server::tool routing, MCP no-verb fallback, verb-classified routing, long-name truncation, defensive null/undefined/empty).
-- Build: vite 887ms clean, 386.05 KB raw / 120.80 KB gzip (+0.6 KB raw — minimal component).
+### feat-ux-vibe-rebalance-2026-06-05 (final pre-merge hardening + ship closure)
 
-### main-2026-05-29 (AVO-105 handoff arrows)
+- Branch `feat/ux-vibe-rebalance`, classification feature. Branch closed for merge (owner-directed; main protected → human owns the protected-remote push/PR). Final HEAD `1a708bf`, 59 commits ahead of `main`, clean fast-forward (main behind 0).
+- **Agent-clustering fix ("4 piled, one disappeared")** — root cause: group-event gather (`store.setMultipleAgentGroupEvents` / `setAgentGroupEvent`) wrote `groupTarget` with NO inter-agent separation, so participants stacked on one cell and the y-ordered opaque SVG sprite on top fully occluded the ones beneath. Fix: deconflict every gather target through `clampToFloor` + `avoidOverlap` (push ≥ `MIN_AGENT_DIST`) at the store chokepoint — one fix covers ALL group events; the "disappear" is cured by never fully overlapping.
+- **Test-gap closure** — every prior movement test checked agent-vs-MAP only; NONE checked agent-vs-AGENT (why the suite stayed green while sprites stacked). Added `tests/agentSeparationInvariants.test.js` (+5), incl. the exact-bug case "all participants assigned the SAME cell must fan out" (FAILs pre-fix).
+- **Fresh-eyes pre-merge sweep** — independent full-branch-diff reviewer: **0 HIGH / 0 MED**; no debug leftovers / `.only` / dup exports; i18n en/zh-TW parity intact. Only 2 LOW pre-existing cosmetic items (not on this branch).
+- **Verification**: vitest **1276 passed / 53 files** (+ moodFeedGate, statusBubbleDedup, agentSeparationInvariants over -04b), build clean (414.80 KB JS / 31.05 KB CSS), `validate.sh` **0 fail**. Behavioral logic test-authoritative; **pixel/visual still pending owner confirm** (screenshots broken; eval can't reach the app store).
+- **Deferred**: AVO-144 — sustained free-movement (in-transit) per-frame separation still has no agent-vs-agent push (lower-severity transient pass-through; the visible pile-up/disappear is fixed). AVO-141/142/143 unchanged.
+- **Remaining for human**: protected-remote push / PR-close; visual confirm + v1.2.0 screenshot/GIF re-capture.
 
-- Shipped: `src/inference/workflowHandoff.js` subscribes to `activeWorkflow`; on 7 mapped phase transitions fires `addHandoff(from, to, {subtle: true})`. Mapping: `/spec-intake→/spec` pm→arch, `/spec→/plan` arch→pm, `/plan→/implement` arch→dev, `/implement→/test` dev→qa, `/implement→/review` dev→gate, `/test→/review` qa→gate, `/review→/ship` gate→ops. Unmapped transitions, null endpoints, missing roster roles, and identical workflow → no fire.
-- `addHandoff(from, to, opts)` signature extended with `opts.subtle: boolean`. `FlyingDocument` gained `subtle` prop — workflow handoffs render the calm variant (no gold sparkle trail, 60° rotation instead of 360°, no 1→1.3→1 scale pulse) per the brief "畫面要清楚好懂、不過分花俏". Existing organic officeLife handoffs continue to fire with `subtle: false` (default) and keep their original flashier animation — verified in live preview where a `res→gate` officeLife handoff coexisted with workflow `arch→dev`/`dev→qa` and only the workflow ones lacked sparkles.
-- Re-entrancy bug found and fixed at implementation: zustand fires subscribers synchronously on every setState, so `addHandoff` would re-enter the workflow watcher; without advancing `prevWorkflow` before the side effect the listener would see the SAME new workflow as a "transition" and recurse infinitely. Fixed by advancing the closure variable BEFORE calling addHandoff and pinned as `BUG-PIN` test.
-- Tests: 943/943 vitest passed (was 925, +18 new tests covering 7-row mapping, subtle propagation, null/boot safety, lightweight roster skip, unmapped transitions, lifecycle, re-entrant safety bug-pin, full /spec→/plan→/implement→/test→/review→/ship chain firing 5 handoffs in order).
-- Build: vite 1.07s clean, 385.49 KB raw / 120.67 KB gzip (+0.9 KB raw — module + small inline closure).
+### feat-ux-vibe-rebalance-2026-06-04b (responsive fill + living-office-events honest liveliness)
 
-### main-2026-05-29 (session wrap-up: backlog + docs + perf)
+- Branch `feat/ux-vibe-rebalance`, classification feature. **Committed to branch (8 commits), NOT pushed/merged** — for human PR review (main protected). Owner-directed UX follow-on; living-office-events has its own spec `docs/specs/living-office-events.md` (DRAFT, review-gated). Screenshots broken in env → **all verification is test/measurement-based; PIXEL appearance pending owner visual confirm at PR time.**
+- **Responsive fill** — office now spans full browser WIDTH at every pane shape (`PixelOffice` svg width-driven via `aspect-ratio: 800/560` + center + clip; `b61e020`) fixing the left/right-whitespace complaint; roster fills width (drop `max-w` gutters; `ad1db61`); top-row agents' speech bubbles flip BELOW when they'd clip the office top edge (`BehaviorBubble` `below` prop; `52ba139`). Measured via getBoundingClientRect across sizes.
+- **living-office-events** — the office now HONESTLY reflects real work without faking status, via a 3-expert roundtable (game/AI-systems/calm-tech) ×2 + 2 code audits + adversarial review (all R1/R2 honesty rules upheld in code). 4 phases:
+  - **P1 (`a6c6668`)** L2 derived team-affect: transient `teamPulse` (room "leans in" with real-signal density) + `focusAnchor` (idle agents orient toward the live desk via new `setAgentFacing`), UNTRACKED-only (a tracked desk is never modulated — R1). Derived in `moodEngine.updateStoreMood`.
+  - **P2 (`2a5d7c0`)** honesty gating: 5 work-claim events (deploy-success/ops-dev-deploy-check/dev-arch-disagree/eureka/review-debate) fire ONLY with a matching real signal within `WORK_CLAIM_SIGNAL_WINDOW` (90s); random floor scaled-not-muted when live (`floorTickAllowed`, incl. fallback sessions).
+  - **P3 (`5a288b6`)** reluctant participant: a tracked agent torn by a set-piece shows a sub-dominant ⏳ (PURE OVERLAY — `store.reluctant`; never touches status/behavior/bubble/position; real bubbles preempt).
+  - **P4 (`6f...`/real-seed)** the CAUSAL real→event link (closes owner's "沒有驅動任何一件事情"): a real-signal EDGE (mood→smooth/frustrated, Ops→done, SubagentStart) immediately fires the matching event — honesty-gated + mutex'd + 120s per-event cooldown.
+  - **Review + measurement**: 3-lens adversarial /review (correctness PASS, regression PASS w/ 2 fixes applied, honesty surfaced the causal gap → P4 built); extracted pure `resolveFocusFacing` + exported `floorTickAllowed` for AC-4/AC-7 measurement tests.
+- **AC**: AC-1✅ AC-2✅ **AC-3⚠️** (structural dominance enforced+tested — overlay never touches live channels; pixel dominance + keep-out routing design-asserted, needs owner visual confirm) AC-4✅ AC-5✅ AC-6✅ AC-7✅.
+- **Verification**: vitest **1271 passed / 52 files** (+~50: teamAffectL2 ×13, eventHonestyGate ×6, realSeedTriggers ×6, teamAffectMeasure ×7, gatherTargetsOnFloor ×2, statusBubbleDedup ×4, moodFeedGate ×4, +responsive guards), build clean, validate 0 fail. Behavioral logic test-authoritative (vitest = real modules, no dup); live preview_eval CANNOT drive the app store (module-duplication) + screenshots broken → pixel/visual confirm pending owner.
+- **Post-review QA hardening (owner-driven, this session)**: fixed a whole bug CLASS — side-effects firing per-poll instead of per-change. (1) speech bubble, (2) activity-feed push, (3) moodEngine feed (`changedUpdates`) now all gate on a real status/task change → killed the "every character suddenly speaks for no reason / refresh feeling" + false `rushing`/weather inflation. Audit confirmed ledgers/deskItems/notifier/handoff/router/integration-fields already correctly guarded. Adversarial re-review: all fixes correct, no regressions/over-gating, GO. Deferred AVO-143 (no-op agent re-alloc, perf-only). Also: standup gather-spots respread + `clampToFloor` on all groupTargets (no agent in walls); P4 real-seed global-cooldown + no all-gather on SubagentStart; OT→OVERTIME; README EN+zh de-AI'd + slimmed (detail → ARCHITECTURE.md); v1.2.0 + CHANGELOG.
+- **Remaining for human**: PR review + visual confirm (⏳/lean-in/orientation tells, standup no-pile, fonts) + re-capture v1.2.0 screenshots/GIF + push/merge. Optional deferred: AVO-141/142/143, AC-3 keep-out routing, Standby-roster richness, overlay-pull.
 
-- Docs: `docs/specs/_product-backlog.md` rotated — 73 shipped items moved to new `docs/specs/_shipped-log.md`; lean fresh backlog with 15 AVO-101..AVO-115 next-wave items + #20 deferred carryover. Themes: Real AI Behavior Coverage (plan-mode viz, extended-thinking aura, tool inventory, skill badge), Multi-Agent Collaboration (handoff arrows, pair huddle, review queue), Information Density (token meter, recent-files heatmap, blocked-reason tags), Game Feel (time-of-day lighting, eureka cascade), Performance/Observability (OT GenAI export, replay scrubber), Brand/USP (shareable daily card).
-- Docs: new root `CHANGELOG.md` summarising the entire session (8 features + 2 follow-ups + CSP + wrap-up).
-- Docs: README — refreshed Tech Highlights (replaced 8 old rows with 14 rows covering classifier, role-aware animations, mood-driven weather, idle-gap inference, desktop notifications, self-improving classifier, today metrics chip, reduced-motion/a11y); refreshed Architecture tree with all new modules (`classify.js`, `unknownLog.js`, `moodEngine.js`, `contextBubble.js`, `desktopNotifier.js`, `idleGapInfer.js`, `server.mjs`, etc.).
-- Perf: WeatherOverlay clipPath optimisation — SVG `<clipPath>` doesn't actually need a `<defs>` wrapper; removed it. Live preview confirmed `defsCount: 1` (was 12 during active weather) — 11 DOM nodes saved with zero behavior change. Rain (60), lightning (12), clipPaths (12) all still render correctly.
-- Tests: 925/925 vitest (no test changes; pure docs + structural simplification).
-- Build: vite 838ms clean, 384.57 KB / 120.32 KB gzip.
+### feat-ux-vibe-rebalance-2026-06-04 (POINT 2 readable labels + COMMS vertical living-feed rebuild)
 
-### main-2026-05-29 (2 follow-up fixes from spawned chips)
+- Branch `feat/ux-vibe-rebalance`, classification feature. **Committed to branch, NOT pushed/merged** — for human review (main protected). Informal owner-directed UX follow-on (beyond the frozen `ux-vibe-rebalance` spec; re-spec if formalizing). Autonomous session (user delegated full completion + stepped out).
+- **POINT 2 (`75038c3`)** — in-scene text stays readable as the office scales below native: `store.sceneScale` (measured `meet` scale, svgRef + ResizeObserver + 600ms self-heal poll for the throttled webview) drives counter-scaling of agent name/status/bubble (cap 1.5, anchor-preserving grow-in-place — overlap guard), the click-inspector popover (cap 2.5), the event banner, desk nameplates + room headers. Faint area-labels + decoration left small. Verified 320–1280px: readable, 0 overlap/clip, desktop ~unchanged.
+- **COMMS vertical living-feed rebuild** — the ☰ roster went from a flat lifeless list to a living **presence rail + activity feed**, per a **5-expert design roundtable** (game-feel · UI/chat-UX · operator · systems-engineer · calm-tech; unanimous REFINE). Commits: **`a01a64c`** P1 rail (2-tier salience — blocked pins top, only blocked reorders; idle dimmed in place; honest quiet state; `rosterModel.js` pure logic + `origin`-tagged activityLog + handoffs logged), **`130649a`** P2 feed (real-events-only, heartbeat/health dot, 🔔 notify), **`1988e74`** P3 juice (feed fade-in, tap-to-focus), **`3c5dc18`** fix review HIGH-1 (separate bounded `eventFeed` — organic theater could otherwise evict real events from activityLog's write-time 50-cap), **`9d20dcb`** review LOW (shared FEED_ORIGINS source).
+- **Key design correction (live testing)**: a 3-tier active/idle sort thrashed under live churn → collapsed to 2 tiers (only blocked reorders). **Key proof technique**: dep-free SSR render tests (react-dom/server) since the live office is wired to the active Claude session whose hook poll races injected statuses.
+- **Verification**: vitest **1222 passed / 45 files** (+32: rosterModel, activityOrigin incl. eventFeed-survival regression, narrowRosterOrder SSR), build clean, 0 console errors, i18n en/zh-TW parity. Live-verified each phase (the feed even showed this session's real events). Independent acx-reviewer: round-1 NOT READY (HIGH-1) → fixed → **round-2 READY**.
+- **Remaining for human**: review + push/merge the branch. Then the deferred additive-juice wave (AVO-133–136) + density dial (AVO-137).
 
-- Fix 1: `src/systems/moodEngine.js` `pushEventBatch` wraps `resetIdleTimer()` + `updateStoreMood()` in `if (added > 0)`. Empty-array or all-skipped-entries batches no longer accidentally flip mood→idle. Two existing tests adjusted that relied on the prior `pushEventBatch([])` recompute hack.
-- Fix 2: `src/systems/classify.js` Tier 4 (MCP namespace) now returns `family: inner.family` when the inner verb matches — previously always returned a flat EXTERNAL. `decideBehavior()` now picks family-appropriate animations for MCP create/delete/search/read instead of collapsing all to `typing`. EXTERNAL fallback retained for MCP tools whose inner name doesnt match any verb pattern.
-- Tests: 925/925 vitest passed (was 915, +10 across the two fixes).
-- Files: `src/systems/moodEngine.js`, `src/systems/classify.js`, `tests/moodEngine.test.js`, `tests/weatherRealWorld.test.js`, `tests/classify.test.js`, `tests/classifierWiring.test.js`.
+### feat-ux-vibe-rebalance-2026-06-03 (UX Vibe Rebalance — deletion/demotion core)
 
-### main-2026-05-29 (#8 desktop notifications + #C idle-gap inference)
+- Branch `feat/ux-vibe-rebalance`, classification feature. **Committed to branch, NOT merged** — for human review/merge (main is protected). Spec `docs/specs/ux-vibe-rebalance.md` [Frozen].
+- Sourced from a 5-lens expert design panel (game-designer · calm-tech · first-time-user · audience-readability · clutter-auditor). Verdict: "cute engine with a dashboard bolted on" → cure = deletion, default density glance-L1, detail on-demand. Owner approved "do all"; this branch ships the deletion/demotion core (AVO-126/127/128/129/131/132). Additive juice (AVO-133–136) + density dial (AVO-137) deferred.
+- **AVO-126** — `bashVibeLabel` in `public/hooks/office-status-hook.js`: Bash bubbles map to office nouns (測試/建置/檔案/git/…), never a raw command or path, across working/done/error frames. +5 unit tests incl. a path-leak invariant.
+- **AVO-127 / AVO-129** — `ControlPanel.jsx`: 🪙 token meter and ✓/✗ KPI removed from the persistent bar (full + panel); both surfaced on-demand (full = "?" popover; panel = hover tooltip + sr-only mirror). Data paths (tokens, ledgers) untouched.
+- **AVO-128** — `AgentCharacter.jsx`: name tags revealed only when an agent is non-idle OR hovered; hidden at idle rest (identity rides on sprite+color+desk). Session badge + status icon unaffected. Live-verified 8/8 idle→no name, working→name.
+- **AVO-131** — removed the in-scene monospace TaskLabel pill (+ dead `currentTask`/`classifyTask`); the tool now shows only in the AgentInspector (`inspectorTaskLabel`).
+- **AVO-132** — removed the separate violet ThinkingAura; effort (high/xhigh/max) now folds into the single working glow ring's intensity (op+stroke). Live-verified exactly 1 ring/sprite.
+- **Verification**: vitest 1042→1047 (+5), build clean (390.97 KB / 122.62 KB gzip, −1.5 KB), 0 console errors; live DOM/store ground-truth confirmed each AC.
+- **Review**: independent acx-reviewer on the diff — round 1 NOT READY (AVO-129 panel on-demand gap) → fixed → round 2 PASS. Accepted scoped deviation: `planning` status loses its ring (still has gantt+expression+name; no `STATUS_COLORS` entry) — documented in spec `## Review Deviations`.
+- **Remaining for human**: review + merge branch `feat/ux-vibe-rebalance`; then the additive juice wave (AVO-133–136) + density dial (AVO-137), which benefit from owner visual review.
 
-- #8 shipped: `src/inference/desktopNotifier.js` polls store 5s, fires browser Notification when an agent stays blocked ≥30s + tab hidden + permission granted. Per-episode dedupe (blocked→working→blocked = 2 notifications, but same episode = 1). ControlPanel 🔔 button requests permission on user gesture (modern browsers require this). i18n + sr-only.
-- #C shipped: `src/inference/idleGapInfer.js` closes Pixel Agents' admitted gap. Conservative thresholds: working+45s → inferred 'thinking'; blocked+90s → inferred 'awaiting-approval'. Injected through `applyExternalStatus` so inferred statuses pass through `decideBehavior` (COGNITION/GATE family → reading-screen / shield-verify). Reversibility by construction — real hook events overwrite the inferred status. lastUpdatedAt stamped only on status/task signature changes (not movement ticks).
-- Tests: 915/915 vitest passed (was 875, +24 desktopNotifier + 16 idleGapInfer). Build clean, +5 KB raw / +1.6 KB gzip (two new modules + UI button).
-- Files added: `src/inference/desktopNotifier.js`, `src/inference/idleGapInfer.js`, `tests/desktopNotifier.test.js`, `tests/idleGapInfer.test.js`. Edits: `src/components/PixelOffice.jsx` (2 useEffect), `src/components/ControlPanel.jsx` (🔔 button), `src/locales/en.json` + `zh-TW.json` (notify.* keys), `docs/specs/_product-backlog.md` (#8 → Done).
+### Ship-chore-migrate-agentic-os-v1.2.0-2026-06-02 (governance brain migration + SSoT reconciliation)
 
-### main-2026-05-29 (unknownLog #A3)
+- Migrated the governance brain from **AgentCortex v5.4.0** (source repo went private) to public **Agentic OS v1.2.0** (`source_commit 2354c5f`). Delivered on branch `chore/migrate-agentic-os-v1.2.0` / PR #32 (kept open for human review — NOT merged at this ship).
+- 136 framework files (65 new / 68 updated / 3 deprecated-removed). App `src/`/`tests/` untouched; `npm test` 1042 passed; build clean; CI Node 20/22 green.
+- **SSoT reconciliation (this ship's guarded write)**: corrected the ADR Index — added the previously-missing `docs/adr/ADR-002-multi-worktree-session-design.md` and switched to the plain-path format (no backticks) so the v1.2.0 validator's reverse-check no longer reports phantom entries. Clears the `SSoT ADR Index completeness` FAIL.
+- Also (separate commits on the same branch): added v1.2.0-required lifecycle frontmatter to `_product-backlog.md`.
+- **Remaining post-migration drift (NOT fixed here, by design)**: 13 Global Lessons not yet hash-chained (`[prev:]`), and 3 shipped specs (`agent-inspector-info-enhancement`, `character-growth-system`, `clickable-office-objects`) declare `primary_domain` without a `## Domain Decisions` section — both surfaced only because the v1.2.0 validator is stricter than v5's. Tracked for a deliberate follow-up.
 
-- Shipped: `src/systems/unknownLog.js` — dev-mode in-memory aggregator. Five buckets (task/status/mood/role/workflow) each capped at 200 entries; oldest-evict on overflow. Exposes `recordUnknown(kind, raw)` / `getUnknownReport()` / `clearUnknownLog()` / `isDevMode()`. Globals `window.__office_unknownLog` (Maps) + `window.__office_logUnknowns()` (sorted console reporter) for DevTools.
-- Wired all 5 classify* Tier 5 branches to call recordUnknown. Known classifications (Tier 0–4) never record, so the log only surfaces genuine gaps.
-- Production safety: `isDevMode()` reads `import.meta.env.PROD === true` and short-circuits; override hook `globalThis.__OFFICE_FORCE_UNKNOWN_LOG__` for explicit control.
-- Tests: 875/875 vitest passed (was 851, +24 unknownLog tests covering: basic recording, kind isolation, sorting, cap+eviction, defensive inputs, dev-mode gate, integration with all 5 classify*).
-- Build: vite 946ms clean, 380.17 KB raw / 118.90 KB gzip (+1 KB raw / +0.45 KB gzip).
+### Ship-codex-virtual-office-movement-server-tests-2026-06-02 (movement pathing fix + regression hardening)
 
-### main-2026-05-29 (role-aware classifier #A2.1)
+- PR #25 (https://github.com/KbWen/agent-virtual-office/pull/25), branch `codex/virtual-office-movement-server-tests`. Classification quick-win. CI green (Node 20 & 22); 1042/1042 vitest; Vite build clean. SSoT + work-log archive committed to the SAME PR (per user instruction, not a separate closure PR like #24).
+- **Codex base work (040afc8, 3471808)**: zone-aware `calculatePath` rewrite — door-side approach points, per-zone routing (main office route graph / meeting-table detour / lounge corridor), entrance zone aligned to the visual floor; static agents flagged `returnHomeOnIdle` on external-status clear and `AgentCharacter` walks them home; DOM test hooks `data-agent-id|status|behavior`; non-walking visual-position sync; favicon; deep pathing + multi-task regression suites; deep-sim timeout stabilization.
+- **Hardening batch (77c89d3, 2b450e7)** — added this session:
+  - Latent bug fixed: right-aisle corridor node `{550,290}` sat INSIDE the whiteboard obstacle once the whiteboard joined the line-crossing set (`MAIN_OFFICE_OBSTACLES = slice(0,9)`), making it a dead, never-selectable pathfinding node. Moved to `{505,290}` (left of whiteboard x≥525). Strict non-regression.
+  - Exported `MAIN_ROUTE_NODES`, `DOOR_SIDES`, `getZone` (additive).
+  - `tests/movementLayoutInvariants.test.js` (4): route nodes / door anchors must be on-floor, off-furniture, in their claimed zone, door anchors joined by an on-floor segment — guards against hardcoded-layout drift (which is exactly how the dead node slipped in).
+  - `tests/returnHomeLifecycle.test.js` (3): `clearExternalStatus` flags every static role to return home; intent consumed exactly once (idempotent, idle-safe); every return route TERMINATES at home (≤2px) — the endpoint guarantee the deep test lacked.
+  - `tests/movementPathingFuzz.test.js` (1, 1000 seeded mulberry32 pairs): randomized room-to-room routes never cross a wall or furniture. Zero violations.
+  - Observability: RAF watchdog in `AgentCharacter.jsx` now calls `store.recordWatchdogRestart()` + DEV `console.warn` instead of restarting silently. New transient `watchdogRestarts` store field (excluded from persisted snapshot — verified) + 2 store tests.
+- **Decision**: favicon PNG/apple-touch-icon fallback intentionally NOT added — without a real binary asset it would 404, regressing the console-cleanliness the SVG favicon was added for. Out of proportion to value.
+- **Review**: 0 security findings (A01–A10); secret scan clean (only AVO-108 LLM-token references); no dependency changes; Red Team not auto-triggered for quick-win.
+- **Known (pre-existing, not from this work)**: validator reports README mojibake + document-governance + `plan->ship` gate-chain FAILs — all diagnosed earlier as framework false-positives / codex-log gate-naming, none touched by this PR.
 
-- Wiring shipped: `classifyRole(roleId)` (extracts base role from `slug~role` composites, classifies into orchestrator/builder/verifier/deployer/investigator families); `classifyWorkflow(workflow)` (normalizes leading-slash and case, recognizes 26 AgentCortex lifecycle phases); `decideBehavior({task, role, status, workflow})` central 4-priority resolver (status > workflow > role > family-default).
-- AgentCortex skill associations drive role overrides: pm/arch own writing-plans → gantt-chart bias; qa/checker own TDD+red-team → magnifier bias; ops owns finishing-a-development-branch → deploy-button bias; res owns doc-lookup → research bias; gate owns auth-security → shield-verify bias; designer owns frontend-patterns → whiteboard bias.
-- Workflow overrides outrank role: `/ship`→deploy-button, `/test`→magnifier, `/research`→research, `/plan`→gantt-chart, `/review` & `/audit`→magnifier.
-- Tests: 851/851 vitest passed (was 748, +67 unit + 36 integration). Build clean, +1.4 KB raw / +0.3 KB gzip.
-- Files: `src/systems/classify.js` (+~140 lines: ROLE/WORKFLOW override tables + 3 new exports), `src/systems/store.js` (1 wiring line swap), `tests/classify.test.js` (+~150 lines), `tests/classifierRoleContext.test.js` (new, +220 lines, 36 tests).
-- Memory: saved `feedback_classification_rigor.md` so future classifier work checks `.agent/skills/` + `.agent/workflows/` BEFORE defaulting to generic W3C/schema.org taxonomies.
-
-### main-2026-05-29 (classifier wiring #A2)
-
-- Wiring shipped: `store.applyExternalStatus` augmented with `familyToBehavior(classifyTask(task).family)` fallback (Bash/Read/Grep/Glob still hit static STATUS_BEHAVIOR_MAP first → byte-identical for built-ins); `moodToWeather` delegates to `classifyMood(mood).family` (parity proven by existing weatherSystem.test.js).
-- New capability: MCP / verb-classified / unknown tasks pick family-appropriate animation instead of generic `'typing'` — `Write`→writing-notes, `Task`→gantt-chart (subagent dispatch), `authenticate`→shield-verify, `dispatchJob`→gantt-chart, `sendEmail`→chat, `searchIndex`→research.
-- Tests: 748/748 vitest passed (was 704; +12 familyToBehavior unit tests + 32 classifierWiring integration tests proving regression safety + new capability). Build clean, +6 KB raw / +2.4 KB gzip.
-- Files: `src/systems/classify.js` (familyToBehavior export), `src/systems/store.js` (applyExternalStatus fallback), `src/components/TopDownFurniture.jsx` (moodToWeather delegation), `tests/classify.test.js` (familyToBehavior cases), `tests/classifierWiring.test.js` (new, integration).
-
-### main-2026-05-29 (classifier foundation #A1)
-
-- Foundation shipped: `src/systems/classify.js` pure module exporting `classifyTask` / `classifyStatus` / `classifyMood` + `FAMILIES` vocabulary. Standards-aligned per panel discussion: W3C Activity Streams 2.0 verb taxonomy, OpenTelemetry GenAI attribute naming (forward), MCP `mcp__<server>__<tool>` namespace parser.
-- 4-tier waterfall: Tier 0 built-in (11 Claude Code canonical tools + TodoRead/TodoWrite), Tier 3 verb heuristic (10 verb families with word-boundary regex), Tier 4 MCP namespace, Tier 5 unknown (preserves raw + truncates label to 16 chars).
-- Tests: 90 new (704/704 total vitest passed), build clean, no UI change (foundation only; downstream wiring is #A2).
-- Files: `src/systems/classify.js` (new, +270 lines), `tests/classify.test.js` (new, +250 lines).
-
-### main-2026-05-29 (weather + #15 closure)
-
-- Feature shipped: #14 天氣系統 — `moodToWeather()` pure mapping (stuck→thunderstorm, frustrated→rain, rushing→cloudy, default→clear); `WeatherOverlay` SVG component with rain lines, drifting clouds, lightning flash; `WallWindow` accepts `weather` + `reducedMotion` props; `PixelOffice` subscribes `mood` + `reducedMotion`, injects CSS keyframes once; lightning opacity capped at 0.35 every 5s for photosensitivity safety.
-- Closure: #15 白板手寫動畫 confirmed pre-existing at `PixelOffice.jsx:146` (`WhiteboardAnimation`); marked Done with closure note (no new code, similar to #7 pattern).
-- Tests: Pass (575/575 vitest, build clean, preview all 4 weather modes verified including reducedMotion path)
-- Files: `src/components/TopDownFurniture.jsx`, `src/components/PixelOffice.jsx`, `tests/weatherSystem.test.js` (new, 12 tests)
-
-### main-2026-05-29 (perf metrics + drift fix)
-
-- Feature shipped: #6 底部效能指標 — added `dailyBlockedLedger` (transition counter, parallel to `dailyDoneLedger`) and rendered `✓N / ✗M` chip in ControlPanel Full + Panel modes with i18n + sr-only + tooltip; day rollover resets both ledgers atomically.
-- Follow-up fix: drift defense — `dayChanged` now ORs both ledgers' staleness so a drifted blocked ledger can't silently inflate yesterday's counts (caught by deep review's scenario test).
-- Tests: Pass (563/563 vitest after drift fix, build clean, preview EN+ZH chip reactivity verified)
-- Files: `src/systems/store.js`, `src/components/ControlPanel.jsx`, `src/locales/en.json`, `src/locales/zh-TW.json`, `tests/storeBlockedLedger.test.js` (new, 23 tests including 11 review-pass scenarios)
-
-### feat-v10-office-vitality-2026-05-26 (superseded / closed)
-
-- PR #17 closed without merge: core v0.10 vitality features (growth fix, 3 events, sprint kanban) and production deployment infra (server.mjs, Docker, Nginx, PM2, systemd) were superseded and shipped via PR #19 with deeper hardening (R48–R86 + 30 perf rounds). Merging would have regressed main. Branch deleted.
-- Branch cleanup: 12 stale remote branches deleted (all merged/closed PRs), 2 local branches deleted.
-
-### claude-condescending-raman-1e48a0-2026-05-16 (closure)
-
-- Feature closed: #7 可點擊辦公室物件 — all three objects confirmed clickable in existing code (commit 5b79616); spec doc generated as closure record; no new code required.
-
-### claude-condescending-raman-1e48a0-2026-05-16
-
-- Feature shipped: #1 Character Growth System — daily-reset desk items (coffee/sticky/books) tied to done-event count; 4-level GROWTH_LEVELS [0,1,3,6]; fixed % 6 wrapping bug; gated growth inside shouldCount to prevent polling inflation.
-- Tests: Pass (149/149 vitest, build clean)
-
-### main-2026-04-08
-
-- Feature shipped: Inspector info enhancement with durable same-day done counting, mood/workflow rows, Codex CLI helper, and Codex App bridge parity/docs.
-- Tests: Pass (145/145 vitest, build success, Codex CLI/App live evidence captured)
-
-### fix-agent-inspector-hooks-crash-2026-04-02
-
-- Feature shipped: Designer character, multi-worktree support, skill-aware hooks (Stop/UserPromptSubmit/skill context), smart file routing, webhook endpoint, compound skill routing, review P0/P1 fixes, AgentCortex v5.4.0 upgrade.
-- Tests: Pass (98/98 vitest, no console errors)
+> [!NOTE]
+> **Ship History older than 2026-06-02 was rotated to [`docs/specs/_ship-history-archive.md`](../../docs/specs/_ship-history-archive.md) on 2026-06-05** to keep this SSoT readable in a single pass. The entries above are the current / active feature cycles; the archive holds the full historical record (v1.1.0 classifier wave, v0.10 vitality, and earlier).
 
 ### Ship-fix-watchdog-false-restart-long-commands-2026-06-06
 
-- PR #56 (https://github.com/KbWen/agent-virtual-office/pull/56), external fork `duongynhi000005-oss`, classification quick-win. Fixes #50.
-- **Fix**: the **behavior watchdog** (`AgentCharacter.jsx`, 90s `WATCHDOG_TIMEOUT`) was force-restarting the scheduling chain — resetting the agent's visual posture — whenever a long-running command (compile/test/install) kept the behavior value unchanged past the timeout. It now skips the restart while behavior is held externally. Distinct from the walk/RAF watchdog (`:791`, dropped-frame trigger) that emits the `recordWatchdogRestart()` console line — that one is a separate mechanism, left out of scope (flagged on the PR).
-- **Maintainer follow-up (commit `221c45d`)**: extracted the skip decision into a pure, exported `shouldSkipBehaviorWatchdog(agent)` in `constants.js` (covers BOTH the group-event skip and the active-session skip; one call replaces two duplicated inline branches; Set is module-level not per-tick). Added `planning` to `ACTIVE_SESSION_STATUSES`. Removed the orphaned `INFERRED_STATUSES` constant + stale docstring in `idleGapInfer.js` (the original PR's guard removal was correct; the const just had no callers left).
-- **Tests**: added `tests/behaviorWatchdog.test.js` (13 cases) — pins the active-session skip set AND asserts ambient statuses (idle/done/unknown) are NOT skipped, so the watchdog still recovers a genuinely dead chain. Full suite **1289/1289 pass (54 files)**; production build clean.
-- **Lockfile note**: the PR's `package-lock.json` diff is NOT scope creep — it regenerates a lockfile that had drifted on `main` (`package.json` 1.2.1 / deps-as-dependencies vs lock 1.1.0 / deps-as-devDependencies), which breaks `npm ci`. No new packages, no integrity/registry changes. Documented in the PR body.
-- **Review**: 5-axis + OWASP A01–A10 + secret scan clean; 1 MEDIUM advisory (two-watchdog scope clarification), 1 LOW accepted (behavior watchdog suppressed for full active-session lifetime — mitigated by always-rescheduling doSchedule + stuck-walk retry + ambient-status test coverage). Burden-of-proof: all PROVEN.
+- PR #56 (https://github.com/KbWen/agent-virtual-office/pull/56), external fork `duongynhi000005-oss`, classification quick-win. Fixes #50. Squash-merged as `b246587`.
+- **Fix**: the **behavior watchdog** (`AgentCharacter.jsx`, 90s `WATCHDOG_TIMEOUT`) was force-restarting the scheduling chain — resetting the agent's visual posture — whenever a long-running command (compile/test/install) kept the behavior value unchanged past the timeout. It now skips the restart while behavior is held externally. Distinct from the walk/RAF watchdog (`:791`, dropped-frame trigger) that emits the `recordWatchdogRestart()` console line — separate mechanism, left out of scope.
+- **Maintainer follow-up (`221c45d`)**: extracted a pure exported `shouldSkipBehaviorWatchdog(agent)` in `constants.js` (covers group-event + active-session skip; one call replaces two duplicated branches; Set is module-level). Added `planning` to `ACTIVE_SESSION_STATUSES`. Removed orphaned `INFERRED_STATUSES` + stale docstring in `idleGapInfer.js`.
+- **Tests**: `tests/behaviorWatchdog.test.js` (13 cases) — pins the skip set AND asserts ambient statuses (idle/done/unknown) are NOT skipped. Full suite **1289/1289 (54 files)**; build clean.
+- **Lockfile**: regenerates a drifted `package-lock.json` (was 1.1.0/devDeps vs package.json 1.2.1/deps → broke `npm ci`). No new pkgs, no integrity/registry change.
+- **Review**: 5-axis + OWASP A01–A10 + secrets clean; 1 MEDIUM advisory (two-watchdog scope), 1 LOW accepted (watchdog suppressed for full active lifetime, mitigated + tested).
+- **Ship incident (self-corrected)**: the first ship commit used `guard_context_write.py` with a guard receipt (`337ffd90`) cached from a prior codex session; `replace` mode wrote stale seq-26 content over this consolidated SSoT, dropping the 7 most recent Ship History entries. Caught in post-merge verification; current_state.md restored from `5c4bf49` + this entry, re-committed directly. Lesson: do not reuse stale guard receipts across sessions; verify SSoT seq/entry-count after a guarded write.
 - Tests: Pass


### PR DESCRIPTION
## Problem

The PR #56 ship commit corrupted the SSoT. Its guarded write (`guard_context_write.py` in `replace` mode) reused a guard receipt (`337ffd90`) cached from a prior codex session and wrote **stale seq-26 content** over the consolidated **seq-33** `current_state.md`. Result on `main` (`b246587`): the 7 most recent Ship History entries were dropped and replaced with 17 older (pre-2026-06-05-rotation) ones.

Dropped entries: 2026-06-05 docs-audit baseline, the ux-vibe-rebalance wave (06-03/04/04b/05), agentic-os v1.2.0 migration, movement-server-tests.

## Fix

Restore `current_state.md` from `5c4bf49` (the last good consolidated state), re-apply the ship heartbeat (Update Sequence 33→34, Last Updated 2026-06-06), and re-append the watchdog Ship History entry.

The #56 source / test / lockfile changes are unaffected — this touches only `current_state.md`.

## Verification

- `Update Sequence: 34`, `Last Updated: 2026-06-06`
- 8 `### ` Ship History entries (7 consolidated + watchdog)
- 2026-06-05 audit, ux-vibe, and watchdog entries all present

## Lesson

Don't reuse guard receipts across sessions; verify SSoT seq + entry count after any guarded write. Recorded in the watchdog ship entry.
