### PR TITLE
feat(#28): surface watchdogRestarts as a DEV-only diagnostic chip

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -48,6 +48,14 @@ export function agentLineLabel(ext, t) {
     || t(`statusLabels.${ext.status}`, ext.status)
 }
 
+// #28 — DEV-only diagnostics gate for the RAF-watchdog restart counter. Shown only in dev builds AND
+// only once a stall has actually happened (count > 0), so it's invisible at rest and zero-cost in
+// production (`import.meta.env.DEV` is a compile-time constant → the render branch is dead-code-
+// eliminated from the prod bundle). Pure so it can be unit-tested without a DOM.
+export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV) {
+  return !!isDev && typeof count === 'number' && count > 0
+}
+
 export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   // Return full agent objects so useShallow can compare by reference. Mapping to
   // new projected objects {id,color,behavior,status} on every call means the inner
@@ -60,6 +68,9 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const toggleRosterMode = useOfficeStore((s) => s.toggleRosterMode)
   const weatherEffects = useOfficeStore((s) => s.weatherEffects)
   const toggleWeatherEffects = useOfficeStore((s) => s.toggleWeatherEffects)
+  // #28: RAF-watchdog stall counter — surfaced as a DEV-only diagnostic chip (see render). Cheap
+  // primitive subscription; re-renders only when a stall actually bumps the count (rare).
+  const watchdogRestarts = useOfficeStore((s) => s.watchdogRestarts)
   const triggerWorkflow = useOfficeStore((s) => s.triggerWorkflow)
   const activeEvent = useOfficeStore(useShallow((s) => s.activeEvent))
   const hour = useOfficeStore((s) => s.hour)
@@ -350,6 +361,20 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
           </button>
         </div>
       </div>
+
+      {/* #28: DEV-only RAF-watchdog diagnostic. Invisible until a stall bumps the counter. The gate
+          LEADS with the literal `import.meta.env.DEV` so esbuild statically evaluates `false && …` in
+          prod and dead-code-eliminates this whole branch (JSX + strings) — true zero prod cost. The
+          pure `shouldShowWatchdogDiag` mirror is kept for unit testing the count>0 logic. */}
+      {import.meta.env.DEV && shouldShowWatchdogDiag(watchdogRestarts) && (
+        <div
+          className="mt-1 text-[10px] text-amber-600 dark:text-amber-400"
+          data-watchdog-diag={watchdogRestarts}
+          title="AgentCharacter RAF walk-loop watchdog restarts — a rising count means dropped frames (tab throttling, HMR, or an exception in animate()). DEV-only diagnostic."
+        >
+          ⚠ {watchdogRestarts} RAF watchdog restart{watchdogRestarts === 1 ? '' : 's'} (dev)
+        </div>
+      )}
 
       {showTest && (
         <div className="mt-1.5 pt-1.5 border-t border-gray-200 dark:border-gray-700">

--- a/tests/watchdogDiag.test.js
+++ b/tests/watchdogDiag.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowWatchdogDiag } from '../src/components/ControlPanel.jsx'
+
+// #28 — the RAF-watchdog restart counter (store.watchdogRestarts) is surfaced as a DEV-only
+// diagnostic chip, shown only once a stall has actually happened (count > 0). Pure gate so it's
+// unit-testable without a DOM. `isDev` is passed explicitly here to decouple from the test runner's
+// import.meta.env.DEV.
+describe('shouldShowWatchdogDiag (#28)', () => {
+  it('shows in DEV once a stall has been recorded (count > 0)', () => {
+    expect(shouldShowWatchdogDiag(1, true)).toBe(true)
+    expect(shouldShowWatchdogDiag(7, true)).toBe(true)
+  })
+
+  it('stays hidden in DEV while the count is still 0 (unobtrusive at rest)', () => {
+    expect(shouldShowWatchdogDiag(0, true)).toBe(false)
+  })
+
+  it('is never shown in production, even with a non-zero count (zero prod cost)', () => {
+    expect(shouldShowWatchdogDiag(5, false)).toBe(false)
+    expect(shouldShowWatchdogDiag(0, false)).toBe(false)
+  })
+
+  it('guards against non-numeric / negative counts', () => {
+    expect(shouldShowWatchdogDiag(undefined, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(null, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(-1, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(NaN, true)).toBe(false)
+  })
+})


### PR DESCRIPTION
Closes #28.

The RAF walk-loop watchdog counter (`store.watchdogRestarts`, bumped by `recordWatchdogRestart` in `AgentCharacter`) has been console-only since PR #25. This surfaces it as a small amber chip in the **full** ControlPanel, shown **only when count > 0** (invisible at rest, unobtrusive).

**Zero production cost (verified):** the render gate leads with the literal `import.meta.env.DEV` so esbuild statically evaluates `false && …` and dead-code-eliminates the entire branch — JSX, strings, and the helper reference are all absent from the prod bundle (grepped `dist/`). The pure `shouldShowWatchdogDiag` helper is kept for unit testing.

**Evidence:** +4 tests (`watchdogDiag`); full suite 1311 passed; build clean. DEV chip live-verified in the running app (rest → absent; after 2× `recordWatchdogRestart()` → `⚠ 2 RAF watchdog restarts (dev)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
