### PR TITLE
feat(#39): office pet — signal-driven barometer (AVO-121)

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T03:45:00Z
-- **Update Sequence**: 35
+- **Last Updated**: 2026-06-08T05:45:00Z
+- **Update Sequence**: 36
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -70,6 +70,7 @@
   - [vibe-rebalance] docs/specs/ux-vibe-rebalance.md [Frozen]  *(AVO-126/127/128/129/131/132 — branch feat/ux-vibe-rebalance, not yet merged)*
   - [living-office] docs/specs/living-office-events.md [DRAFT, review-gated]  *(P1-P4 shipped to branch feat/ux-vibe-rebalance, not merged; AC-3 pixel-dominance pending owner visual confirm)*
   - [subagent] docs/specs/subagent-helper-huddle.md [Frozen]  *(SubagentStart→helper sprites; shipped)*
+  - [game-feel] docs/specs/office-pet-barometer.md [Shipped]  *(#39 / AVO-121 — signal-driven office pet)*
   - When reading specs: only open files tagged with the current task's module.
 - **Canonical Commands**:
   - `/spec-intake`: Import external specs (from other LLMs, documents, or natural language). Handles large product specs via decomposition. Runs before `/bootstrap`.
@@ -131,6 +132,14 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-office-pet-barometer-2026-06-08 (#39 / AVO-121 — signal-driven office pet)
+
+- PR #62 (branch `feat/office-pet-barometer`), classification **feature**. Closes #39 (AVO-121). Spec: `docs/specs/office-pet-barometer.md` [shipped].
+- **Origin**: 5-expert brainstorm (game-design · game-feel · calm-tech · feasibility · product). Draggable agents REJECTED 4/5 (breaks position=truth, fights movement system, touches protected `AgentCharacter`). Decorative pet flagged anti-calm. Convergent + user-selected: **pet-as-barometer** — keep the charm, make behavior an HONEST readout of real office state.
+- **What shipped**: `src/systems/petState.js` pure `derivePetState({mood,blockedCount})` (mirrors `moodToWeather`; `hide` ALWAYS wins on a real blocker = honesty guarantee; idle→nap, smooth/rushing/intense→excited, stuck/frustrated→hide, normal→wander). `src/components/OfficePet.jsx` ambient cat: mode→pose, slow CSS-glide wander reusing pure `clampToFloor` (NO calculatePath/HOME_POSITIONS/agent coords — Protected Surfaces untouched), reduced-motion→static, transient perk on real eureka/deploy-success (resets when event clears). `officePet` store toggle (default ON, `office-pet` localStorage key) + ControlPanel 🐈 + en/zh-TW aria. `pet-snooze`/`pet-bob` keyframes in `index.css` (CSP-safe).
+- **Review**: 2 parallel acx-reviewers (correctness + scope/protected/AC) → both **PASS**; all 6 ACs proven; 1 LOW (stuck-perk edge) fixed; protected surfaces untouched; i18n parity; no scope creep.
+- **Tests**: +6 (`tests/petState.test.js`). Full suite **1317 passed / 58 files**; build clean. DEV live-verified incl. blocked→hide honesty guarantee, on-floor placement, toggle-off removal, reduced-motion static.
 
 ### Ship-fix-issue-sweep-52-45-47-2026-06-08 (3 open bugs: roster null-status · weather CPU toggle · bubble edge clip)
 

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -42,7 +42,7 @@ last_updated: 2026-06-05
 | AVO-118 | Workflow graph minimap (DAG view) | product | multi-agent | P2 | — | feature | Pending | AVO-105 |
 | AVO-119 | Language / file-type breakdown | product | info-density | P2 | — | feature | Pending | — |
 | AVO-120 | Daily MVP / productivity leaderboard | product | brand | P2 | — | feature | Pending | — |
-| AVO-121 | Office pet (ambient companion) | product | game-feel | P3 | — | feature | Pending | — |
+| AVO-121 | Office pet (ambient companion) | product | game-feel | P3 | — | feature | Done | reframed as signal-driven barometer; docs/specs/office-pet-barometer.md (PR #62) |
 | AVO-122 | Ambient soundscape (toggle) | product | game-feel | P2 | — | feature | Pending | — |
 | AVO-123 | Office theme / skin selector | product | brand | P2 | — | feature | Pending | — |
 | AVO-124 | Agent appearance customization | product | brand | P3 | — | feature | Pending | — |

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -1,6 +1,6 @@
 ---
 title: Office pet (signal-driven barometer)
-status: draft
+status: shipped
 date: 2026-06-08
 primary_files: [src/components/OfficePet.jsx, src/components/PixelOffice.jsx, src/systems/store.js, src/components/ControlPanel.jsx, src/systems/petState.js]
 test_file: tests/petState.test.js

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -1,0 +1,94 @@
+---
+title: Office pet (signal-driven barometer)
+status: draft
+date: 2026-06-08
+primary_files: [src/components/OfficePet.jsx, src/components/PixelOffice.jsx, src/systems/store.js, src/components/ControlPanel.jsx, src/systems/petState.js]
+test_file: tests/petState.test.js
+related_issue: 39
+backlog_id: AVO-121
+---
+
+# Office pet — signal-driven barometer (#39 / AVO-121)
+
+## Problem
+
+#39 (competitive research: Gather.town added follow-along pets for charm) asks for a
+cute ambient companion. But a *decorative* pet that wanders/naps on its own timer is a
+**second motion source whose state is fiction** — it competes with the office's honest
+real-work signal and reproduces the "cute engine with a dashboard bolted on" failure mode
+that was deliberately deleted in the ux-vibe-rebalance wave. A 5-expert brainstorm panel
+(game-design · game-feel · calm-tech guardian · feasibility · product) independently
+converged: **keep the charm, but make the pet's behavior an HONEST readout of real office
+state** — then the toy and the truth become the same thing. Draggable agents (the
+considered alternative) was rejected 4/5: it breaks "position = real status" and fights the
+movement system.
+
+## Solution
+
+A small ambient pet sprite (cat) rendered once in the office. Its mode is **derived from
+real aggregate office state**, mirroring the established honest `moodToWeather(mood)`
+pattern — no independent "fake" emotional life.
+
+### Pure state derivation — `src/systems/petState.js`
+
+`derivePetState({ mood, blockedCount })` → one of:
+
+| Pet mode | Real trigger | Read as |
+|----------|--------------|---------|
+| `hide`   | `blockedCount > 0` **OR** mood `stuck`/`frustrated` | something needs a human / things are rough |
+| `nap`    | mood `idle` (and nobody blocked) | the team is resting |
+| `excited`| mood `smooth`/`rushing`/`intense` | momentum — work is flowing |
+| `wander` | mood `normal` (default) | steady, ordinary activity |
+
+Priority: `hide` (real blocker) wins over everything — the pet never looks happy while an
+agent is actually blocked. This is the honesty guarantee. The mapping is a frozen table so
+it's unit-testable in isolation (same shape as `classify.js` / `moodToWeather`).
+
+A transient **`perk`** beat (a brief excited hop) is layered on real positive *events*
+(`eureka`, `deploy-success`) by subscribing to the same signals officeLife already fires —
+reusing the existing event surface, never a synthetic timer.
+
+### Sprite + movement — `src/components/OfficePet.jsx`
+
+- A compact pixel-art cat (small DOM, own colour). Modes map to pose/animation:
+  `wander` = slow drift + occasional blink; `nap` = curled with a rising "z"; `excited` =
+  faster trot / tail-up; `hide` = crouched still (ears down).
+- Movement is a **simple wander** (pick a random nearby floor point, walk straight),
+  reusing the exported `clampToFloor` / obstacle helpers from `movementSystem.js`. It does
+  **NOT** use `calculatePath` (no desk-graph routing needed) and does **NOT** touch
+  `HOME_POSITIONS`, agent coords, or the per-agent separation invariants (Protected
+  Surfaces untouched).
+- `reduced-motion`: the pet still renders in its mode-appropriate **static pose** (so it
+  keeps conveying the signal) but performs **no wander and no per-frame animation**.
+
+### Toggle — `store.js` + `ControlPanel.jsx`
+
+`officePet` boolean (default ON), persisted via a dedicated `office-pet` localStorage key
+(same lightweight pattern as `weatherEffects`/`isPaused`/`rosterMode`). ControlPanel gets a
+🐈 toggle. OFF → no pet rendered at all (zero cost). PixelOffice renders `<OfficePet>` once,
+gated by the toggle.
+
+## Acceptance criteria
+
+- AC-1 `derivePetState` returns `hide` whenever `blockedCount > 0`, regardless of mood
+  (honesty guarantee), and maps the mood enum as tabled above. (unit-tested)
+- AC-2 The pet is HONEST: it never shows `excited`/`nap` while any agent is blocked.
+- AC-3 Pet wander never lands on furniture/walls (uses `clampToFloor`/obstacle check);
+  Protected Surfaces (HOME_POSITIONS, agent coords, separation) are untouched.
+- AC-4 `reduced-motion` → static mode-pose, no wander, no animation.
+- AC-5 `officePet` toggle (default ON) persists across reload; OFF removes the pet entirely.
+- AC-6 No regression: full vitest suite green; build clean; weather/agent/roster behavior
+  unchanged.
+
+## Non-goals / deferred
+
+- Multiple pets, pet customization, pet naming, click-to-pet interactions — future.
+- Sound (the panel said sound stays off/optional; not in this MVP).
+- Draggable agents — explicitly rejected by the panel (breaks position-as-truth).
+
+## Verification
+
+- Behavioral correctness = vitest on `derivePetState` (pure) + store toggle test.
+- Pixel/visual = owner confirm per Protected-Surfaces policy + `getBoundingClientRect`
+  measurement (pet stays on floor; absent when toggled off / blocked-state pose). The
+  `preview_screenshot` transport is broken in this environment.

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -68,6 +68,8 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const toggleRosterMode = useOfficeStore((s) => s.toggleRosterMode)
   const weatherEffects = useOfficeStore((s) => s.weatherEffects)
   const toggleWeatherEffects = useOfficeStore((s) => s.toggleWeatherEffects)
+  const officePet = useOfficeStore((s) => s.officePet)
+  const toggleOfficePet = useOfficeStore((s) => s.toggleOfficePet)
   // #28: RAF-watchdog stall counter — surfaced as a DEV-only diagnostic chip (see render). Cheap
   // primitive subscription; re-renders only when a stall actually bumps the count (rare).
   const watchdogRestarts = useOfficeStore((s) => s.watchdogRestarts)
@@ -341,6 +343,16 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
             aria-pressed={!weatherEffects}
           >
             {weatherEffects ? '🌧' : '🌤'}
+          </button>
+          {/* #39: office-pet toggle. Persisted; OFF removes the pet entirely. */}
+          <button
+            onClick={toggleOfficePet}
+            className={`px-2 py-1 rounded border transition-colors ${officePet ? 'bg-amber-100 border-amber-400 text-amber-700 dark:bg-amber-900 dark:text-amber-300' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+            title={officePet ? t('aria.petOff', 'Hide office pet') : t('aria.petOn', 'Show office pet')}
+            aria-label={officePet ? t('aria.petOff', 'Hide office pet') : t('aria.petOn', 'Show office pet')}
+            aria-pressed={officePet}
+          >
+            🐈
           </button>
           <button onClick={triggerWorkflow} className="px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors" title={t('aria.runWorkflow', 'Run workflow animation')}>
             {t('ui.run')}

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,0 +1,147 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { useOfficeStore } from '../systems/store.js'
+import { clampToFloor } from '../systems/movementSystem.js'
+import { derivePetState, petIsMobile, PET_MODES } from '../systems/petState.js'
+
+// ─── Office pet — a signal-driven barometer (#39 / AVO-121) ─────────────────────────────────────
+// A small ambient cat whose MODE is an honest readout of real aggregate office state (see
+// petState.js): hide when an agent is blocked or the mood is rough, nap when idle, excited on
+// momentum, wander otherwise. It is NOT decoration with a fake life — every pose maps to a true
+// signal. Movement is a slow CSS-glide wander reusing `clampToFloor` (never `calculatePath`, never
+// HOME_POSITIONS / agent coords — Protected Surfaces untouched). reduced-motion → static pose.
+
+const START = clampToFloor({ x: 120, y: 505 })
+
+// Sample a floor point in the lower office band (walkway/lounge) so the pet stays low and out of the
+// desk rows. clampToFloor snaps to a floor zone and pushes off any furniture.
+function randomFloorTarget() {
+  const x = 40 + Math.random() * 720
+  const y = 380 + Math.random() * 150
+  return clampToFloor({ x, y })
+}
+
+// ── Pixel-ish cat sprite. Drawn around local origin; the parent <g> positions + flips it. ──
+function CatSprite({ mode, reducedMotion }) {
+  const fur = '#9B8579', dark = '#6E5E54', belly = '#D9CCBF'
+  if (mode === PET_MODES.NAP) {
+    return (
+      <g aria-hidden="true">
+        {/* curled body */}
+        <ellipse cx={0} cy={0} rx={9} ry={5.5} fill={fur} />
+        <ellipse cx={0} cy={1.5} rx={6} ry={3} fill={belly} opacity="0.5" />
+        {/* tucked head */}
+        <circle cx={-6} cy={-1} r={3.6} fill={fur} />
+        <path d="M -8.6 -3 l 1.4 -2.2 l 1.4 2.2 Z" fill={fur} />
+        {/* closed eye */}
+        <path d="M -7.4 -1.2 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
+        {/* curled tail */}
+        <path d="M 8 0 q 5 0 4 -4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        {/* rising z's (calm, slow) */}
+        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
+          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.HIDE) {
+    return (
+      <g aria-hidden="true">
+        {/* crouched, flattened body, ears down */}
+        <ellipse cx={0} cy={1} rx={8} ry={3.6} fill={fur} />
+        <circle cx={6} cy={-0.5} r={3.4} fill={fur} />
+        {/* flattened ears */}
+        <path d="M 3.4 -3 l -1.8 -1 l 1.2 2 Z" fill={dark} />
+        <path d="M 8.6 -3 l 1.8 -1 l -1.2 2 Z" fill={dark} />
+        {/* wary small eyes */}
+        <circle cx={5} cy={-0.6} r={0.7} fill={dark} />
+        <circle cx={7.4} cy={-0.6} r={0.7} fill={dark} />
+        {/* low tucked tail */}
+        <path d="M -8 1 q -3 1 -2 3" stroke={fur} strokeWidth="2" fill="none" strokeLinecap="round" />
+      </g>
+    )
+  }
+  // wander / excited — standing cat (tail up when excited)
+  const excited = mode === PET_MODES.EXCITED
+  return (
+    <g aria-hidden="true">
+      {/* tail */}
+      {excited
+        ? <path d="M -7 0 q -5 -2 -4 -7" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
+        : <path d="M -7 0 q -5 1 -5 -3" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />}
+      {/* body */}
+      <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
+      <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+      {/* legs */}
+      <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+      <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+      {/* head */}
+      <circle cx={6} cy={-1.5} r={4} fill={fur} />
+      {/* ears */}
+      <path d="M 3.2 -4.4 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
+      <path d="M 8.8 -4.4 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
+      {/* eyes */}
+      <circle cx={4.6} cy={-1.8} r={0.8} fill={dark} />
+      <circle cx={7.4} cy={-1.8} r={0.8} fill={dark} />
+      {/* nose */}
+      <circle cx={6} cy={-0.2} r={0.6} fill="#C77" />
+    </g>
+  )
+}
+
+export default function OfficePet() {
+  const officePet = useOfficeStore((s) => s.officePet)
+  const reducedMotion = useOfficeStore((s) => s.reducedMotion)
+  const mood = useOfficeStore((s) => s.mood)
+  // live blocked count — primitive, so the pet re-renders only when it actually changes.
+  const blockedCount = useOfficeStore((s) =>
+    Object.values(s.externalStatus).filter((e) => e && e.status === 'blocked').length)
+  const activeEventId = useOfficeStore((s) => s.activeEvent?.id || null)
+
+  // Transient "perk" on a real positive event (reuses officeLife's existing event surface — never a
+  // synthetic timer). Never overrides a real blocker (hide stays honest).
+  const [perk, setPerk] = useState(false)
+  useEffect(() => {
+    if (activeEventId === 'eureka' || activeEventId === 'deploy-success') {
+      setPerk(true)
+      const t = setTimeout(() => setPerk(false), 2500)
+      return () => clearTimeout(t)
+    }
+  }, [activeEventId])
+
+  const baseMode = derivePetState({ mood, blockedCount })
+  const mode = perk && baseMode !== PET_MODES.HIDE ? PET_MODES.EXCITED : baseMode
+
+  const [pos, setPos] = useState(START)
+  const [facing, setFacing] = useState(1)
+  const posRef = useRef(START)
+
+  const mobile = officePet && !reducedMotion && petIsMobile(mode)
+  useEffect(() => {
+    if (!mobile) return
+    const interval = mode === PET_MODES.EXCITED ? 2000 : 3500
+    const id = setInterval(() => {
+      const t = randomFloorTarget()
+      setFacing(t.x >= posRef.current.x ? 1 : -1)
+      posRef.current = t
+      setPos(t)
+    }, interval)
+    return () => clearInterval(id)
+  }, [mobile, mode])
+
+  if (!officePet) return null
+
+  const glideMs = mode === PET_MODES.EXCITED ? 1400 : 2800
+  const bob = mode === PET_MODES.EXCITED && !reducedMotion ? { animation: 'pet-bob 0.6s ease-in-out infinite' } : undefined
+
+  return (
+    <g
+      data-office-pet={mode}
+      transform={`translate(${pos.x}, ${pos.y})`}
+      style={reducedMotion ? undefined : { transition: `transform ${glideMs}ms ease-in-out` }}
+      pointerEvents="none"
+    >
+      <g transform={`scale(${facing}, 1)`} style={bob}>
+        <CatSprite mode={mode} reducedMotion={reducedMotion} />
+      </g>
+    </g>
+  )
+}

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -105,6 +105,9 @@ export default function OfficePet() {
       const t = setTimeout(() => setPerk(false), 2500)
       return () => clearTimeout(t)
     }
+    // Event cleared before the 2.5s window elapsed → drop the perk now, so it can't get stuck
+    // 'true' (the cleanup above cancels the pending reset on the trigger→non-trigger transition).
+    setPerk(false)
   }, [activeEventId])
 
   const baseMode = derivePetState({ mood, blockedCount })

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -9,6 +9,7 @@ import { startWorkflowHandoffs } from '../inference/workflowHandoff'
 import { eventName, t, useLocale } from '../i18n'
 import AgentCharacter from './AgentCharacter'
 import HelperHuddles from './HelperHuddle'
+import OfficePet from './OfficePet'
 import NarrowRoster from './NarrowRoster'
 import AgentInspector from './AgentInspector'
 import {
@@ -1141,6 +1142,10 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
           </text>
         </g>
       )}
+
+      {/* ═══ OFFICE PET ═══ (#39 — ambient cat; signal-driven barometer. Painted behind agents so
+          they naturally occlude it when overlapping. Renders nothing when toggled off.) */}
+      <OfficePet />
 
       {/* ═══ SUBAGENT HELPER HUDDLES ═══ (capped helper figures — painted BEHIND the agents
           so the full-size lead is never clipped by its own helpers; they trail the lead's live pos) */}

--- a/src/index.css
+++ b/src/index.css
@@ -46,3 +46,13 @@ html, body, #root {
   0%   { opacity: 0; transform: translateY(-3px); }
   100% { opacity: 1; transform: translateY(0); }
 }
+/* Office pet (#39): a slow rising "z" while napping, and a tiny excited bob. Both are gated off
+   when reducedMotion is on (the style prop is simply not applied). Calm cadence by design. */
+@keyframes pet-snooze {
+  0%, 100% { opacity: 0.2; transform: translateY(0); }
+  50%      { opacity: 0.8; transform: translateY(-2px); }
+}
+@keyframes pet-bob {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-1.5px); }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -290,6 +290,8 @@
     "toggleTest": "Toggle test controls",
     "weatherOff": "Disable weather animations",
     "weatherOn": "Enable weather animations",
+    "petOff": "Hide office pet",
+    "petOn": "Show office pet",
     "info": "Info"
   },
   "time": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -290,6 +290,8 @@
     "toggleTest": "切換測試面板",
     "weatherOff": "關閉天氣動畫",
     "weatherOn": "開啟天氣動畫",
+    "petOff": "隱藏辦公室寵物",
+    "petOn": "顯示辦公室寵物",
     "info": "資訊"
   },
   "time": {

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -1,0 +1,38 @@
+// ─── Office pet state — a HONEST barometer of real aggregate office state ──────────────────────
+// The pet is NOT decoration with a fake emotional life. Its mode is derived from real signals the
+// office already computes (the mood enum + the live blocked count), mirroring the honest
+// `moodToWeather(mood)` pattern. Pure + frozen table → unit-testable in isolation.
+//
+// Honesty guarantee: `hide` ALWAYS wins when an agent is actually blocked — the pet must never look
+// happy/asleep while someone needs a human. That single rule is what keeps the toy truthful.
+
+export const PET_MODES = Object.freeze({
+  HIDE: 'hide',       // a real blocker, or a rough team mood — the pet crouches/hides
+  NAP: 'nap',         // the team is idle/resting — the pet curls up
+  EXCITED: 'excited', // momentum (smooth/rushing/intense) — the pet trots, tail up
+  WANDER: 'wander',   // ordinary steady activity — the pet ambles
+})
+
+// mood enum (constants.VALID_MOODS): normal · rushing · frustrated · stuck · smooth · intense · idle
+const MOOD_TO_PET = Object.freeze({
+  stuck: 'hide',
+  frustrated: 'hide',
+  idle: 'nap',
+  smooth: 'excited',
+  rushing: 'excited',
+  intense: 'excited',
+  normal: 'wander',
+})
+
+// derivePetState({ mood, blockedCount }) → one of PET_MODES.
+// blockedCount > 0 forces 'hide' regardless of mood (the honesty guarantee). Unknown/missing mood
+// falls back to 'wander' (steady, neutral) — never to a happy state.
+export function derivePetState({ mood, blockedCount = 0 } = {}) {
+  if (Number.isFinite(blockedCount) && blockedCount > 0) return PET_MODES.HIDE
+  return MOOD_TO_PET[mood] || PET_MODES.WANDER
+}
+
+// The pet only roams in the active modes; nap/hide hold position (and pose conveys the signal).
+export function petIsMobile(mode) {
+  return mode === PET_MODES.WANDER || mode === PET_MODES.EXCITED
+}

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -319,6 +319,9 @@ export const useOfficeStore = create((set) => ({
   // decoration (the mood signal stays; the per-frame animation stops). prefers-reduced-motion
   // already forces static regardless of this toggle.
   weatherEffects: typeof window === 'undefined' ? true : (() => { try { return localStorage.getItem('office-weather') !== 'off' } catch { return true } })(),
+  // #39: ambient office pet (signal-driven barometer). Default ON; persisted via a dedicated
+  // localStorage key (same lightweight pattern as weatherEffects). OFF → no pet rendered (zero cost).
+  officePet: typeof window === 'undefined' ? true : (() => { try { return localStorage.getItem('office-pet') !== 'off' } catch { return true } })(),
   showWorkflow: false,
   // Diagnostic counter: how many times the AgentCharacter RAF watchdog had to restart a
   // stalled walk loop. A silent restart hides the underlying stall; surfacing a count lets
@@ -605,6 +608,12 @@ export const useOfficeStore = create((set) => ({
     const next = !s.weatherEffects
     try { if (typeof window !== 'undefined') localStorage.setItem('office-weather', next ? 'on' : 'off') } catch {}
     return { weatherEffects: next }
+  }),
+  // #39: flip the office-pet preference and persist it ('off' stored explicitly so default reads ON).
+  toggleOfficePet: () => set((s) => {
+    const next = !s.officePet
+    try { if (typeof window !== 'undefined') localStorage.setItem('office-pet', next ? 'on' : 'off') } catch {}
+    return { officePet: next }
   }),
   triggerWorkflow: () => set({ showWorkflow: true }),
   endWorkflow: () => set({ showWorkflow: false }),

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { derivePetState, petIsMobile, PET_MODES } from '../src/systems/petState.js'
+// Static import (hoisted above the window shim below) so the store + i18n initialize while `window`
+// is still undefined — matching the repo's node test env. The shim then provides localStorage so the
+// toggle's persistence path runs. (Same approach as weatherEffectsToggle.test.js.)
+import { useOfficeStore } from '../src/systems/store.js'
+
+const hadWindow = 'window' in globalThis
+const mem = {}
+globalThis.localStorage = {
+  getItem: (k) => (k in mem ? mem[k] : null),
+  setItem: (k, v) => { mem[k] = String(v) },
+  removeItem: (k) => { delete mem[k] },
+}
+globalThis.window = globalThis.window || { location: { search: '' } }
+afterAll(() => { delete globalThis.localStorage; if (!hadWindow) delete globalThis.window })
+
+describe('derivePetState (#39 — honest barometer)', () => {
+  it('maps the mood enum to pet modes', () => {
+    expect(derivePetState({ mood: 'idle' })).toBe(PET_MODES.NAP)
+    expect(derivePetState({ mood: 'smooth' })).toBe(PET_MODES.EXCITED)
+    expect(derivePetState({ mood: 'rushing' })).toBe(PET_MODES.EXCITED)
+    expect(derivePetState({ mood: 'intense' })).toBe(PET_MODES.EXCITED)
+    expect(derivePetState({ mood: 'stuck' })).toBe(PET_MODES.HIDE)
+    expect(derivePetState({ mood: 'frustrated' })).toBe(PET_MODES.HIDE)
+    expect(derivePetState({ mood: 'normal' })).toBe(PET_MODES.WANDER)
+  })
+
+  it('AC-1/AC-2 honesty guarantee: a real blocker forces HIDE regardless of mood', () => {
+    expect(derivePetState({ mood: 'smooth', blockedCount: 1 })).toBe(PET_MODES.HIDE)
+    expect(derivePetState({ mood: 'idle', blockedCount: 3 })).toBe(PET_MODES.HIDE)
+    expect(derivePetState({ mood: 'normal', blockedCount: 1 })).toBe(PET_MODES.HIDE)
+    // the pet NEVER shows excited/nap while any agent is blocked
+    expect(derivePetState({ mood: 'rushing', blockedCount: 2 })).not.toBe(PET_MODES.EXCITED)
+  })
+
+  it('unknown / missing mood falls back to WANDER (never a happy state)', () => {
+    expect(derivePetState({ mood: 'bogus' })).toBe(PET_MODES.WANDER)
+    expect(derivePetState({})).toBe(PET_MODES.WANDER)
+    expect(derivePetState()).toBe(PET_MODES.WANDER)
+  })
+
+  it('petIsMobile: only wander/excited roam; nap/hide hold position', () => {
+    expect(petIsMobile(PET_MODES.WANDER)).toBe(true)
+    expect(petIsMobile(PET_MODES.EXCITED)).toBe(true)
+    expect(petIsMobile(PET_MODES.NAP)).toBe(false)
+    expect(petIsMobile(PET_MODES.HIDE)).toBe(false)
+  })
+})
+
+describe('store — officePet toggle (#39)', () => {
+  beforeEach(() => {
+    localStorage.removeItem('office-pet')
+    useOfficeStore.setState({ officePet: true })
+  })
+
+  it('defaults to ON', () => {
+    expect(useOfficeStore.getState().officePet).toBe(true)
+  })
+
+  it('toggleOfficePet flips and persists (off → "off", on → "on")', () => {
+    useOfficeStore.getState().toggleOfficePet()
+    expect(useOfficeStore.getState().officePet).toBe(false)
+    expect(localStorage.getItem('office-pet')).toBe('off')
+    useOfficeStore.getState().toggleOfficePet()
+    expect(useOfficeStore.getState().officePet).toBe(true)
+    expect(localStorage.getItem('office-pet')).toBe('on')
+  })
+})


### PR DESCRIPTION
Closes #39 (AVO-121).

## Origin
A 5-expert brainstorm (game-design · game-feel · calm-tech guardian · feasibility · product) compared **office pet** vs **draggable agents**. Draggable agents was rejected 4/5 (breaks "position = real status", fights the movement system, touches the protected `AgentCharacter`). A purely decorative pet was flagged anti-calm. The convergent, user-selected synthesis: **keep the charm, make the pet an HONEST barometer of real office state.**

## What ships
- `src/systems/petState.js` — pure `derivePetState({mood, blockedCount})` mirroring the honest `moodToWeather` pattern. **`hide` ALWAYS wins on a real blocker** (the honesty guarantee). idle→nap, smooth/rushing/intense→excited, stuck/frustrated→hide, normal→wander.
- `src/components/OfficePet.jsx` — an ambient cat; mode→pose; slow CSS-glide wander reusing pure `clampToFloor` (**never** `calculatePath`/`HOME_POSITIONS`/agent coords — Protected Surfaces untouched); reduced-motion → static pose; transient perk on real `eureka`/`deploy-success` (resets when the event clears).
- `officePet` store toggle (default ON, `office-pet` localStorage key) + ControlPanel 🐈 button + en/zh-TW aria. OFF removes the pet entirely.
- `pet-snooze`/`pet-bob` keyframes in `index.css` (CSP-safe, reduced-motion gated).

## Evidence
- +6 tests (`petState`: mood mapping, honesty guarantee, toggle persistence). Full suite **1317 passed / 58 files**; build clean.
- **Review:** 2 parallel reviewers (correctness + scope/protected/AC) → both **PASS**; all 6 ACs proven; 1 LOW (stuck-perk edge) fixed; protected surfaces untouched; i18n parity; no scope creep.
- **DEV live-verified:** mood→mode mapping, **blocked-agent → hide even on a happy mood (honesty)**, pet on-floor/off-obstacle, toggle-off removal, reduced-motion static.
- Spec: `docs/specs/office-pet-barometer.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
