### PR TITLE
feat(#39 v2): pet readability scaling, mode cross-fade, alert/celebrate states

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T05:45:00Z
-- **Update Sequence**: 36
+- **Last Updated**: 2026-06-08T07:10:00Z
+- **Update Sequence**: 37
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-office-pet-v2-2026-06-08 (#39 v2 — pet optimizations: scaling · alert/celebrate · cross-fade)
+
+- PR #63 (branch `feat/office-pet-v2`), classification feature (extends #39). Spec §v2 in `docs/specs/office-pet-barometer.md`. Origin: 4-expert research panel (game-design · game-feel · calm-tech · feasibility).
+- **Shipped**: `petReadabilityScale(sceneScale)=clamp(1/√scene,1,1.6)` (legible when docked small; size-as-signal vetoed as dishonest). Two transient states via pure `resolvePetMode({base,alert,celebrate})` — `alert` on a NEW-blocker edge (settles to hide), `celebrate` on real eureka/deploy-success (only when not hiding). **Honesty guarantee preserved** (neither shows happy during a real blocker). 220ms mode cross-fade (`pet-fade-in`). alert uses a two-effect timer (owned by `alert`) so an oscillating blockedCount can't leave it stuck (same class as the earlier perk fix, caught in live test).
+- **Review**: 1 acx-reviewer → PASS; honesty airtight by construction + unit-proven; both transient effects leak/stuck-free; protected surfaces untouched. **Tests**: +6 (`resolvePetMode`, `petReadabilityScale`); suite **1323 passed**; build clean. DEV live-verified: alert fires+auto-clears, petScale 0.25→1.6 / 0.64→1.25.
+- **Deferred**: multiple pet types (cat/robot-vacuum/dog, cosmetic) → next PR.
 
 ### Ship-feat-office-pet-barometer-2026-06-08 (#39 / AVO-121 — signal-driven office pet)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -92,3 +92,28 @@ gated by the toggle.
 - Pixel/visual = owner confirm per Protected-Surfaces policy + `getBoundingClientRect`
   measurement (pet stays on floor; absent when toggled off / blocked-state pose). The
   `preview_screenshot` transport is broken in this environment.
+
+## v2 — expert-vetted optimizations (2026-06-08, PR #63)
+
+A 4-expert research panel (game-design · game-feel · calm-tech guardian · feasibility) scoped four
+axes. Shipped increments (all honesty-preserving, Protected Surfaces untouched):
+
+- **AC-v2-1 sceneScale readability** — pure `petReadabilityScale(sceneScale)` = `clamp(1/√sceneScale,
+  1, 1.6)`; the pet stays legible when the office docks small WITHOUT encoding meaning in size
+  (size-as-signal was vetoed as dishonest/illegible). sceneScale ≥ 1 → factor 1 (unchanged).
+- **AC-v2-2 two transient states** — `alert` (a NEW-blocker EDGE: `blockedCount` rose → ears-up
+  "noticing" beat, then settles back into `hide`) and `celebrate` (real `eureka`/`deploy-success`
+  event). Both folded onto the base mode by the pure `resolvePetMode({base, alert, celebrate})`:
+  `alert` wins; `celebrate` shows ONLY when base ≠ hide. **The honesty guarantee is preserved — neither
+  can make the pet look happy during a real blocker.** Total modes now 6 (at the guardian's cap).
+- **AC-v2-3 mode cross-fade** — a 220ms `pet-fade-in` on every mode change (keyed remount) so poses
+  cross instead of snapping; reduced-motion → instant swap.
+- **Guardrails honored**: hide-on-blocker stays the first branch; reduced-motion suppresses all
+  motion (wander, hop, fade); transient overlays are timer-owned so a rapidly-oscillating signal
+  can't leave a state stuck on (alert uses a two-effect pattern keyed on `alert` itself).
+- **Deferred to a follow-up** (panel "nice/cosmetic"): multiple pet types (cat / robot-vacuum / dog,
+  cosmetic-only, behavior-identical, own motion grammar).
+- Tests: `tests/petState.test.js` +6 (`resolvePetMode` precedence/honesty, `petReadabilityScale`).
+  DEV live-verified: alert fires on new-blocker edge + auto-clears (no stuck state); petScale wiring
+  (0.25→1.6, 0.64→1.25). Honesty precedence is unit-proven (live env can't hold a blocker — the hook
+  poll overwrites injected status).

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor } from '../systems/movementSystem.js'
-import { derivePetState, petIsMobile, PET_MODES } from '../systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, PET_MODES } from '../systems/petState.js'
 
 // ─── Office pet — a signal-driven barometer (#39 / AVO-121) ─────────────────────────────────────
 // A small ambient cat whose MODE is an honest readout of real aggregate office state (see
@@ -59,6 +59,46 @@ function CatSprite({ mode, reducedMotion }) {
       </g>
     )
   }
+  if (mode === PET_MODES.ALERT) {
+    // sitting upright, ears UP, head turned, wide eyes — "noticing a new blocker" (settles to hide)
+    return (
+      <g aria-hidden="true">
+        <path d="M -7 1 q -4 2 -3 4" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
+        {/* upright body */}
+        <ellipse cx={0} cy={1} rx={5.5} ry={5} fill={fur} />
+        <ellipse cx={0} cy={2.5} rx={3} ry={2.4} fill={belly} opacity="0.55" />
+        {/* raised head */}
+        <circle cx={2} cy={-4} r={3.8} fill={fur} />
+        {/* tall alert ears */}
+        <path d="M -0.6 -6.4 l -0.4 -3.4 l 2.2 1.8 Z" fill={fur} />
+        <path d="M 4.6 -6.4 l 0.4 -3.4 l -2.2 1.8 Z" fill={fur} />
+        {/* wide eyes */}
+        <circle cx={0.6} cy={-4.2} r={1} fill={dark} />
+        <circle cx={3.4} cy={-4.2} r={1} fill={dark} />
+        {/* small alert mark */}
+        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.CELEBRATE) {
+    // happy: tail straight up, perked, a tiny spark — fires on a real eureka/deploy-success
+    return (
+      <g aria-hidden="true">
+        <path d="M -7 0 q -3 -3 -1 -8" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
+        <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+        <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+        <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+        <circle cx={6} cy={-2} r={4} fill={fur} />
+        <path d="M 3.2 -5 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
+        <path d="M 8.8 -5 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
+        {/* happy closed-arc eyes */}
+        <path d="M 4 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
+        <path d="M 6.8 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
+        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
+      </g>
+    )
+  }
   // wander / excited — standing cat (tail up when excited)
   const excited = mode === PET_MODES.EXCITED
   return (
@@ -95,23 +135,39 @@ export default function OfficePet() {
   const blockedCount = useOfficeStore((s) =>
     Object.values(s.externalStatus).filter((e) => e && e.status === 'blocked').length)
   const activeEventId = useOfficeStore((s) => s.activeEvent?.id || null)
+  const sceneScale = useOfficeStore((s) => s.sceneScale)
 
-  // Transient "perk" on a real positive event (reuses officeLife's existing event surface — never a
-  // synthetic timer). Never overrides a real blocker (hide stays honest).
-  const [perk, setPerk] = useState(false)
+  // ── Two transient event-edge overlays (v2), each a short pose beat over the honest base mode ──
+  // celebrate: a real positive event (eureka/deploy-success) — reuses officeLife's event surface.
+  const [celebrate, setCelebrate] = useState(false)
   useEffect(() => {
     if (activeEventId === 'eureka' || activeEventId === 'deploy-success') {
-      setPerk(true)
-      const t = setTimeout(() => setPerk(false), 2500)
+      setCelebrate(true)
+      const t = setTimeout(() => setCelebrate(false), 2500)
       return () => clearTimeout(t)
     }
-    // Event cleared before the 2.5s window elapsed → drop the perk now, so it can't get stuck
-    // 'true' (the cleanup above cancels the pending reset on the trigger→non-trigger transition).
-    setPerk(false)
+    setCelebrate(false) // event cleared early → drop it so it can't stick (cleanup cancels the reset)
   }, [activeEventId])
 
+  // alert: a NEW blocker just appeared (blockedCount rose) — ears-up "noticing" beat, then it settles
+  // back into hide (base is already hide while blocked). Marks a real new-blocker EDGE, not a feeling.
+  // Two effects so the auto-clear timer is owned by `alert` itself (NOT by blockedCount): a rapidly
+  // oscillating blockedCount would otherwise keep cancelling the reset and leave alert stuck on.
+  const [alert, setAlert] = useState(false)
+  const prevBlockedRef = useRef(blockedCount)
+  useEffect(() => {
+    const rose = blockedCount > prevBlockedRef.current
+    prevBlockedRef.current = blockedCount
+    if (rose) setAlert(true)
+  }, [blockedCount])
+  useEffect(() => {
+    if (!alert) return
+    const t = setTimeout(() => setAlert(false), 2500)
+    return () => clearTimeout(t)
+  }, [alert])
+
   const baseMode = derivePetState({ mood, blockedCount })
-  const mode = perk && baseMode !== PET_MODES.HIDE ? PET_MODES.EXCITED : baseMode
+  const mode = resolvePetMode({ base: baseMode, alert, celebrate })
 
   const [pos, setPos] = useState(START)
   const [facing, setFacing] = useState(1)
@@ -133,7 +189,13 @@ export default function OfficePet() {
   if (!officePet) return null
 
   const glideMs = mode === PET_MODES.EXCITED ? 1400 : 2800
-  const bob = mode === PET_MODES.EXCITED && !reducedMotion ? { animation: 'pet-bob 0.6s ease-in-out infinite' } : undefined
+  // a calm hop on excited momentum and on the celebrate beat (≤1.5px, reduced-motion off)
+  const hop = (mode === PET_MODES.EXCITED || mode === PET_MODES.CELEBRATE) && !reducedMotion
+    ? { animation: 'pet-bob 0.6s ease-in-out infinite' } : undefined
+  // v2: keep the pet legible when the office docks small without faking size (partial √ counter-scale)
+  const petScale = petReadabilityScale(sceneScale)
+  // v2: a gentle 220ms fade-in on every mode change (keyed remount) so poses cross instead of snapping
+  const fadeIn = reducedMotion ? undefined : { animation: 'pet-fade-in 0.22s ease-out' }
 
   return (
     <g
@@ -142,8 +204,10 @@ export default function OfficePet() {
       style={reducedMotion ? undefined : { transition: `transform ${glideMs}ms ease-in-out` }}
       pointerEvents="none"
     >
-      <g transform={`scale(${facing}, 1)`} style={bob}>
-        <CatSprite mode={mode} reducedMotion={reducedMotion} />
+      <g transform={`scale(${facing * petScale}, ${petScale})`} style={hop}>
+        <g key={mode} style={fadeIn}>
+          <CatSprite mode={mode} reducedMotion={reducedMotion} />
+        </g>
       </g>
     </g>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -56,3 +56,9 @@ html, body, #root {
   0%, 100% { transform: translateY(0); }
   50%      { transform: translateY(-1.5px); }
 }
+/* Office pet (v2): a 220ms fade-in on each mode change (keyed remount) so poses cross-fade instead of
+   snapping. reducedMotion skips it (instant swap). */
+@keyframes pet-fade-in {
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
+}

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -7,10 +7,13 @@
 // happy/asleep while someone needs a human. That single rule is what keeps the toy truthful.
 
 export const PET_MODES = Object.freeze({
-  HIDE: 'hide',       // a real blocker, or a rough team mood — the pet crouches/hides
-  NAP: 'nap',         // the team is idle/resting — the pet curls up
-  EXCITED: 'excited', // momentum (smooth/rushing/intense) — the pet trots, tail up
-  WANDER: 'wander',   // ordinary steady activity — the pet ambles
+  HIDE: 'hide',         // a real blocker, or a rough team mood — the pet crouches/hides
+  NAP: 'nap',           // the team is idle/resting — the pet curls up
+  EXCITED: 'excited',   // momentum (smooth/rushing/intense) — the pet trots, tail up
+  WANDER: 'wander',     // ordinary steady activity — the pet ambles
+  // ── transient event-edge overlays (v2) — never part of the base table; resolved on top of it ──
+  ALERT: 'alert',       // a NEW blocker just appeared — ears up, then settles into hide
+  CELEBRATE: 'celebrate', // a real positive event (eureka / deploy-success) — only when not hiding
 })
 
 // mood enum (constants.VALID_MOODS): normal · rushing · frustrated · stuck · smooth · intense · idle
@@ -32,7 +35,27 @@ export function derivePetState({ mood, blockedCount = 0 } = {}) {
   return MOOD_TO_PET[mood] || PET_MODES.WANDER
 }
 
-// The pet only roams in the active modes; nap/hide hold position (and pose conveys the signal).
+// The pet only roams in the active base modes; nap/hide and the transient reaction poses
+// (alert/celebrate) hold position so the pose itself conveys the signal.
 export function petIsMobile(mode) {
   return mode === PET_MODES.WANDER || mode === PET_MODES.EXCITED
+}
+
+// resolvePetMode — fold the two transient event-edge overlays onto the honest base mode (v2). Pure
+// so the precedence is unit-testable. CRITICAL: `alert` only fires on a NEW-blocker edge (so its
+// base is already `hide` — alert is a louder "new blocker!" beat that settles back into hide), and
+// `celebrate` NEVER shows while hiding. Neither can make the pet look happy during a real blocker.
+export function resolvePetMode({ base, alert = false, celebrate = false }) {
+  if (alert) return PET_MODES.ALERT
+  if (celebrate && base !== PET_MODES.HIDE) return PET_MODES.CELEBRATE
+  return base
+}
+
+// petReadabilityScale — keep the pet legible when the office is docked small WITHOUT lying about
+// size. Partial (√) counter-scale of the live sceneScale, floored at 1 and capped at 1.6, so the
+// pet shrinks WITH the room (stays a believable inhabitant, not a HUD sticker) but never becomes an
+// unreadable speck. sceneScale ≥ 1 (office at/above native) → factor 1 (unchanged). Pure.
+export function petReadabilityScale(sceneScale) {
+  if (!(sceneScale > 0)) return 1
+  return Math.min(1.6, Math.max(1, 1 / Math.sqrt(Math.min(sceneScale, 1))))
 }

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { derivePetState, petIsMobile, PET_MODES } from '../src/systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, PET_MODES } from '../src/systems/petState.js'
 // Static import (hoisted above the window shim below) so the store + i18n initialize while `window`
 // is still undefined — matching the repo's node test env. The shim then provides localStorage so the
 // toggle's persistence path runs. (Same approach as weatherEffectsToggle.test.js.)
@@ -45,6 +45,44 @@ describe('derivePetState (#39 — honest barometer)', () => {
     expect(petIsMobile(PET_MODES.EXCITED)).toBe(true)
     expect(petIsMobile(PET_MODES.NAP)).toBe(false)
     expect(petIsMobile(PET_MODES.HIDE)).toBe(false)
+  })
+})
+
+describe('resolvePetMode (#39 v2 — transient overlays never break honesty)', () => {
+  it('returns the base mode when no transient is active', () => {
+    expect(resolvePetMode({ base: PET_MODES.WANDER })).toBe(PET_MODES.WANDER)
+    expect(resolvePetMode({ base: PET_MODES.NAP })).toBe(PET_MODES.NAP)
+    expect(resolvePetMode({ base: PET_MODES.HIDE })).toBe(PET_MODES.HIDE)
+  })
+
+  it('alert overlays any base (it only fires on a new-blocker edge → base is already hide)', () => {
+    expect(resolvePetMode({ base: PET_MODES.HIDE, alert: true })).toBe(PET_MODES.ALERT)
+    // alert wins over a simultaneous celebrate
+    expect(resolvePetMode({ base: PET_MODES.HIDE, alert: true, celebrate: true })).toBe(PET_MODES.ALERT)
+  })
+
+  it('celebrate shows only when NOT hiding — never makes the pet happy during a real blocker', () => {
+    expect(resolvePetMode({ base: PET_MODES.WANDER, celebrate: true })).toBe(PET_MODES.CELEBRATE)
+    expect(resolvePetMode({ base: PET_MODES.HIDE, celebrate: true })).toBe(PET_MODES.HIDE)
+    expect(resolvePetMode({ base: PET_MODES.NAP, celebrate: true })).toBe(PET_MODES.CELEBRATE)
+  })
+})
+
+describe('petReadabilityScale (#39 v2 — legible when docked small, never fakes size)', () => {
+  it('is 1 at or above native (sceneScale >= 1) — unchanged', () => {
+    expect(petReadabilityScale(1)).toBe(1)
+    expect(petReadabilityScale(1.5)).toBe(1)
+  })
+  it('partial-counter-scales as the office shrinks, capped at 1.6', () => {
+    expect(petReadabilityScale(0.64)).toBeCloseTo(1.25, 5)   // 1/sqrt(0.64)=1.25
+    expect(petReadabilityScale(0.25)).toBe(1.6)              // 1/sqrt(0.25)=2 → capped 1.6
+    expect(petReadabilityScale(0.4)).toBeGreaterThan(1)
+    expect(petReadabilityScale(0.4)).toBeLessThanOrEqual(1.6)
+  })
+  it('guards invalid sceneScale → 1', () => {
+    expect(petReadabilityScale(0)).toBe(1)
+    expect(petReadabilityScale(-1)).toBe(1)
+    expect(petReadabilityScale(NaN)).toBe(1)
   })
 })
 


### PR DESCRIPTION
Extends #39 (office pet). 4-expert research panel → these honesty-preserving optimizations.

- **Readability scaling** — pure `petReadabilityScale(sceneScale)=clamp(1/√scene,1,1.6)`: the pet stays legible when the office docks small, WITHOUT encoding meaning in size (size-as-signal was vetoed as dishonest/illegible).
- **Two transient states** via pure `resolvePetMode({base,alert,celebrate})`: `alert` on a NEW-blocker edge (ears-up "noticing", then settles back to hide); `celebrate` on a real eureka/deploy-success. **Honesty guarantee preserved** — celebrate shows ONLY when not hiding; alert resolves into hide; the pet never looks happy during a real blocker (unit-proven).
- **Mode cross-fade** — 220ms `pet-fade-in` on each mode change (reduced-motion: instant).
- `alert` uses a two-effect timer (owned by `alert`) so an oscillating blockedCount cannot leave it stuck — same bug class as the earlier perk fix, caught in live testing.

**Evidence:** +6 tests (`resolvePetMode` honesty/precedence, `petReadabilityScale`); full suite **1323 passed**; build clean. 1 reviewer → PASS (honesty airtight by construction, both transient effects leak/stuck-free, protected surfaces untouched). DEV live-verified: alert fires+auto-clears; petScale 0.25→1.6 / 0.64→1.25.

Multiple pet types (cat/robot-vacuum/dog) follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
