### PR TITLE
feat(#39): multiple pet types — cat / robot-vacuum / dog (cosmetic skins)

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T07:10:00Z
-- **Update Sequence**: 37
+- **Last Updated**: 2026-06-08T07:55:00Z
+- **Update Sequence**: 38
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-office-pet-types-2026-06-08 (#39 — multiple pet types: cat / robot-vacuum / dog)
+
+- PR #64 (branch `feat/office-pet-types`), classification feature (extends #39). Cosmetic personalization, panel-capped at 3 types.
+- **Shipped**: `src/components/petSprites.jsx` — `PetSprite({type,mode})` (extracted `CatSprite` byte-faithfully + new `VacuumSprite` (disc + mode-coloured LED) + `DogSprite` (floppy ears/snout/wag)). `petState.js` adds `PET_TYPES`/`nextPetType`/pure `petMotionGrammar` (Roomba=linear easing/no bob, dog=bigger bob, explicit `bobKeyframe`). `petType` store field (default cat, `office-pet-type` key, validated vs PET_TYPES) + `cyclePetType`. ControlPanel 🐾 on/off + change-pet button + en/zh-TW aria. `pet-bob-lg` keyframe.
+- **HONESTY INVARIANT**: a type changes ONLY the sprite + motion grammar — `derivePetState`/`resolvePetMode` take no `type` arg, so a real blocker → hide for EVERY skin (red-team-confirmed: no skin can paint a happy state while an agent is blocked; vacuum LED is red on hide/alert).
+- **Review**: 1 acx-reviewer → PASS (cat extraction byte-faithful, no circular import store↔petState, SSR+localStorage validated, protected surfaces untouched, i18n parity); 2 LOW advisories fixed (explicit bobKeyframe, dropped unused turnInPlace). **Tests**: +5 (PET_TYPES/nextPetType/petMotionGrammar + cyclePetType persistence + type-independence honesty); suite **1328 passed**; build clean. DEV live-verified: cycle cat→vacuum→dog→cat persists; each skin renders; dog+blocker → alert/hide.
 
 ### Ship-feat-office-pet-v2-2026-06-08 (#39 v2 — pet optimizations: scaling · alert/celebrate · cross-fade)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -111,8 +111,10 @@ axes. Shipped increments (all honesty-preserving, Protected Surfaces untouched):
 - **Guardrails honored**: hide-on-blocker stays the first branch; reduced-motion suppresses all
   motion (wander, hop, fade); transient overlays are timer-owned so a rapidly-oscillating signal
   can't leave a state stuck on (alert uses a two-effect pattern keyed on `alert` itself).
-- **Deferred to a follow-up** (panel "nice/cosmetic"): multiple pet types (cat / robot-vacuum / dog,
-  cosmetic-only, behavior-identical, own motion grammar).
+- **Multiple pet types** (PR #64, shipped) — cosmetic skins cat / robot-vacuum / dog via
+  `PetSprite({type,mode})` + pure `petMotionGrammar(type)` (own motion grammar per skin) +
+  `petType` toggle. COSMETIC ONLY: `derivePetState`/`resolvePetMode` take no `type` argument, so the
+  hide-on-blocker honesty guarantee holds identically for every skin (red-team-confirmed).
 - Tests: `tests/petState.test.js` +6 (`resolvePetMode` precedence/honesty, `petReadabilityScale`).
   DEV live-verified: alert fires on new-blocker edge + auto-clears (no stuck state); petScale wiring
   (0.25→1.6, 0.64→1.25). Honesty precedence is unit-proven (live env can't hold a blocker — the hook

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -56,6 +56,9 @@ export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV) {
   return !!isDev && typeof count === 'number' && count > 0
 }
 
+// #39 types: emoji shown on the "change pet" button per current skin.
+const PET_TYPE_EMOJI = { cat: '🐈', vacuum: '🤖', dog: '🐕' }
+
 export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   // Return full agent objects so useShallow can compare by reference. Mapping to
   // new projected objects {id,color,behavior,status} on every call means the inner
@@ -70,6 +73,8 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const toggleWeatherEffects = useOfficeStore((s) => s.toggleWeatherEffects)
   const officePet = useOfficeStore((s) => s.officePet)
   const toggleOfficePet = useOfficeStore((s) => s.toggleOfficePet)
+  const petType = useOfficeStore((s) => s.petType)
+  const cyclePetType = useOfficeStore((s) => s.cyclePetType)
   // #28: RAF-watchdog stall counter — surfaced as a DEV-only diagnostic chip (see render). Cheap
   // primitive subscription; re-renders only when a stall actually bumps the count (rare).
   const watchdogRestarts = useOfficeStore((s) => s.watchdogRestarts)
@@ -352,8 +357,19 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
             aria-label={officePet ? t('aria.petOff', 'Hide office pet') : t('aria.petOn', 'Show office pet')}
             aria-pressed={officePet}
           >
-            🐈
+            🐾
           </button>
+          {/* #39 types: cycle the pet skin (cosmetic). Only meaningful while the pet is shown. */}
+          {officePet && (
+            <button
+              onClick={cyclePetType}
+              className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              title={t('aria.petType', 'Change pet')}
+              aria-label={t('aria.petType', 'Change pet')}
+            >
+              {PET_TYPE_EMOJI[petType] || PET_TYPE_EMOJI.cat}
+            </button>
+          )}
           <button onClick={triggerWorkflow} className="px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors" title={t('aria.runWorkflow', 'Run workflow animation')}>
             {t('ui.run')}
           </button>

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor } from '../systems/movementSystem.js'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, PET_MODES } from '../systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, PET_MODES } from '../systems/petState.js'
+import PetSprite from './petSprites.jsx'
 
 // ─── Office pet — a signal-driven barometer (#39 / AVO-121) ─────────────────────────────────────
 // A small ambient cat whose MODE is an honest readout of real aggregate office state (see
@@ -20,113 +21,6 @@ function randomFloorTarget() {
   return clampToFloor({ x, y })
 }
 
-// ── Pixel-ish cat sprite. Drawn around local origin; the parent <g> positions + flips it. ──
-function CatSprite({ mode, reducedMotion }) {
-  const fur = '#9B8579', dark = '#6E5E54', belly = '#D9CCBF'
-  if (mode === PET_MODES.NAP) {
-    return (
-      <g aria-hidden="true">
-        {/* curled body */}
-        <ellipse cx={0} cy={0} rx={9} ry={5.5} fill={fur} />
-        <ellipse cx={0} cy={1.5} rx={6} ry={3} fill={belly} opacity="0.5" />
-        {/* tucked head */}
-        <circle cx={-6} cy={-1} r={3.6} fill={fur} />
-        <path d="M -8.6 -3 l 1.4 -2.2 l 1.4 2.2 Z" fill={fur} />
-        {/* closed eye */}
-        <path d="M -7.4 -1.2 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
-        {/* curled tail */}
-        <path d="M 8 0 q 5 0 4 -4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
-        {/* rising z's (calm, slow) */}
-        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
-          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
-      </g>
-    )
-  }
-  if (mode === PET_MODES.HIDE) {
-    return (
-      <g aria-hidden="true">
-        {/* crouched, flattened body, ears down */}
-        <ellipse cx={0} cy={1} rx={8} ry={3.6} fill={fur} />
-        <circle cx={6} cy={-0.5} r={3.4} fill={fur} />
-        {/* flattened ears */}
-        <path d="M 3.4 -3 l -1.8 -1 l 1.2 2 Z" fill={dark} />
-        <path d="M 8.6 -3 l 1.8 -1 l -1.2 2 Z" fill={dark} />
-        {/* wary small eyes */}
-        <circle cx={5} cy={-0.6} r={0.7} fill={dark} />
-        <circle cx={7.4} cy={-0.6} r={0.7} fill={dark} />
-        {/* low tucked tail */}
-        <path d="M -8 1 q -3 1 -2 3" stroke={fur} strokeWidth="2" fill="none" strokeLinecap="round" />
-      </g>
-    )
-  }
-  if (mode === PET_MODES.ALERT) {
-    // sitting upright, ears UP, head turned, wide eyes — "noticing a new blocker" (settles to hide)
-    return (
-      <g aria-hidden="true">
-        <path d="M -7 1 q -4 2 -3 4" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
-        {/* upright body */}
-        <ellipse cx={0} cy={1} rx={5.5} ry={5} fill={fur} />
-        <ellipse cx={0} cy={2.5} rx={3} ry={2.4} fill={belly} opacity="0.55" />
-        {/* raised head */}
-        <circle cx={2} cy={-4} r={3.8} fill={fur} />
-        {/* tall alert ears */}
-        <path d="M -0.6 -6.4 l -0.4 -3.4 l 2.2 1.8 Z" fill={fur} />
-        <path d="M 4.6 -6.4 l 0.4 -3.4 l -2.2 1.8 Z" fill={fur} />
-        {/* wide eyes */}
-        <circle cx={0.6} cy={-4.2} r={1} fill={dark} />
-        <circle cx={3.4} cy={-4.2} r={1} fill={dark} />
-        {/* small alert mark */}
-        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
-      </g>
-    )
-  }
-  if (mode === PET_MODES.CELEBRATE) {
-    // happy: tail straight up, perked, a tiny spark — fires on a real eureka/deploy-success
-    return (
-      <g aria-hidden="true">
-        <path d="M -7 0 q -3 -3 -1 -8" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
-        <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
-        <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
-        <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
-        <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
-        <circle cx={6} cy={-2} r={4} fill={fur} />
-        <path d="M 3.2 -5 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
-        <path d="M 8.8 -5 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
-        {/* happy closed-arc eyes */}
-        <path d="M 4 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
-        <path d="M 6.8 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
-        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
-      </g>
-    )
-  }
-  // wander / excited — standing cat (tail up when excited)
-  const excited = mode === PET_MODES.EXCITED
-  return (
-    <g aria-hidden="true">
-      {/* tail */}
-      {excited
-        ? <path d="M -7 0 q -5 -2 -4 -7" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
-        : <path d="M -7 0 q -5 1 -5 -3" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />}
-      {/* body */}
-      <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
-      <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
-      {/* legs */}
-      <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
-      <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
-      {/* head */}
-      <circle cx={6} cy={-1.5} r={4} fill={fur} />
-      {/* ears */}
-      <path d="M 3.2 -4.4 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
-      <path d="M 8.8 -4.4 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
-      {/* eyes */}
-      <circle cx={4.6} cy={-1.8} r={0.8} fill={dark} />
-      <circle cx={7.4} cy={-1.8} r={0.8} fill={dark} />
-      {/* nose */}
-      <circle cx={6} cy={-0.2} r={0.6} fill="#C77" />
-    </g>
-  )
-}
-
 export default function OfficePet() {
   const officePet = useOfficeStore((s) => s.officePet)
   const reducedMotion = useOfficeStore((s) => s.reducedMotion)
@@ -136,6 +30,10 @@ export default function OfficePet() {
     Object.values(s.externalStatus).filter((e) => e && e.status === 'blocked').length)
   const activeEventId = useOfficeStore((s) => s.activeEvent?.id || null)
   const sceneScale = useOfficeStore((s) => s.sceneScale)
+  const petType = useOfficeStore((s) => s.petType)
+  // per-type motion grammar (cosmetic — a Roomba moves like a machine, a dog like a dog). The MODE
+  // logic is type-independent; only the FEEL changes.
+  const grammar = petMotionGrammar(petType)
 
   // ── Two transient event-edge overlays (v2), each a short pose beat over the honest base mode ──
   // celebrate: a real positive event (eureka/deploy-success) — reuses officeLife's event surface.
@@ -176,7 +74,7 @@ export default function OfficePet() {
   const mobile = officePet && !reducedMotion && petIsMobile(mode)
   useEffect(() => {
     if (!mobile) return
-    const interval = mode === PET_MODES.EXCITED ? 2000 : 3500
+    const interval = (mode === PET_MODES.EXCITED ? 2000 : 3500) * grammar.cadenceMul
     const id = setInterval(() => {
       const t = randomFloorTarget()
       setFacing(t.x >= posRef.current.x ? 1 : -1)
@@ -184,14 +82,15 @@ export default function OfficePet() {
       setPos(t)
     }, interval)
     return () => clearInterval(id)
-  }, [mobile, mode])
+  }, [mobile, mode, grammar.cadenceMul])
 
   if (!officePet) return null
 
   const glideMs = mode === PET_MODES.EXCITED ? 1400 : 2800
-  // a calm hop on excited momentum and on the celebrate beat (≤1.5px, reduced-motion off)
-  const hop = (mode === PET_MODES.EXCITED || mode === PET_MODES.CELEBRATE) && !reducedMotion
-    ? { animation: 'pet-bob 0.6s ease-in-out infinite' } : undefined
+  // a calm hop on excited/celebrate, gated by the type's motion grammar (the vacuum doesn't bob; the
+  // dog bobs bigger). reduced-motion off.
+  const hop = grammar.bob && (mode === PET_MODES.EXCITED || mode === PET_MODES.CELEBRATE) && !reducedMotion
+    ? { animation: `${grammar.bobAmp >= 2 ? 'pet-bob-lg' : 'pet-bob'} 0.6s ease-in-out infinite` } : undefined
   // v2: keep the pet legible when the office docks small without faking size (partial √ counter-scale)
   const petScale = petReadabilityScale(sceneScale)
   // v2: a gentle 220ms fade-in on every mode change (keyed remount) so poses cross instead of snapping
@@ -200,13 +99,14 @@ export default function OfficePet() {
   return (
     <g
       data-office-pet={mode}
+      data-pet-type={petType}
       transform={`translate(${pos.x}, ${pos.y})`}
-      style={reducedMotion ? undefined : { transition: `transform ${glideMs}ms ease-in-out` }}
+      style={reducedMotion ? undefined : { transition: `transform ${glideMs}ms ${grammar.easing}` }}
       pointerEvents="none"
     >
       <g transform={`scale(${facing * petScale}, ${petScale})`} style={hop}>
         <g key={mode} style={fadeIn}>
-          <CatSprite mode={mode} reducedMotion={reducedMotion} />
+          <PetSprite type={petType} mode={mode} reducedMotion={reducedMotion} />
         </g>
       </g>
     </g>

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -90,7 +90,7 @@ export default function OfficePet() {
   // a calm hop on excited/celebrate, gated by the type's motion grammar (the vacuum doesn't bob; the
   // dog bobs bigger). reduced-motion off.
   const hop = grammar.bob && (mode === PET_MODES.EXCITED || mode === PET_MODES.CELEBRATE) && !reducedMotion
-    ? { animation: `${grammar.bobAmp >= 2 ? 'pet-bob-lg' : 'pet-bob'} 0.6s ease-in-out infinite` } : undefined
+    ? { animation: `${grammar.bobKeyframe} 0.6s ease-in-out infinite` } : undefined
   // v2: keep the pet legible when the office docks small without faking size (partial √ counter-scale)
   const petScale = petReadabilityScale(sceneScale)
   // v2: a gentle 220ms fade-in on every mode change (keyed remount) so poses cross instead of snapping

--- a/src/components/petSprites.jsx
+++ b/src/components/petSprites.jsx
@@ -1,0 +1,205 @@
+import React from 'react'
+import { PET_MODES } from '../systems/petState.js'
+
+// ─── Pet sprites (cosmetic skins for #39) ──────────────────────────────────────────────────────
+// Each sprite is a pure function of (mode, reducedMotion). COSMETIC ONLY — the mode is decided
+// upstream by the honest barometer (derivePetState/resolvePetMode); a sprite just draws the pose for
+// whatever mode it's handed, identically across types. Drawn around local origin (0,0) = floor
+// contact; the parent <g> positions/flips/scales it.
+
+// ── Cat (default) ──
+function CatSprite({ mode, reducedMotion }) {
+  const fur = '#9B8579', dark = '#6E5E54', belly = '#D9CCBF'
+  if (mode === PET_MODES.NAP) {
+    return (
+      <g aria-hidden="true">
+        <ellipse cx={0} cy={0} rx={9} ry={5.5} fill={fur} />
+        <ellipse cx={0} cy={1.5} rx={6} ry={3} fill={belly} opacity="0.5" />
+        <circle cx={-6} cy={-1} r={3.6} fill={fur} />
+        <path d="M -8.6 -3 l 1.4 -2.2 l 1.4 2.2 Z" fill={fur} />
+        <path d="M -7.4 -1.2 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
+        <path d="M 8 0 q 5 0 4 -4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
+          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.HIDE) {
+    return (
+      <g aria-hidden="true">
+        <ellipse cx={0} cy={1} rx={8} ry={3.6} fill={fur} />
+        <circle cx={6} cy={-0.5} r={3.4} fill={fur} />
+        <path d="M 3.4 -3 l -1.8 -1 l 1.2 2 Z" fill={dark} />
+        <path d="M 8.6 -3 l 1.8 -1 l -1.2 2 Z" fill={dark} />
+        <circle cx={5} cy={-0.6} r={0.7} fill={dark} />
+        <circle cx={7.4} cy={-0.6} r={0.7} fill={dark} />
+        <path d="M -8 1 q -3 1 -2 3" stroke={fur} strokeWidth="2" fill="none" strokeLinecap="round" />
+      </g>
+    )
+  }
+  if (mode === PET_MODES.ALERT) {
+    return (
+      <g aria-hidden="true">
+        <path d="M -7 1 q -4 2 -3 4" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
+        <ellipse cx={0} cy={1} rx={5.5} ry={5} fill={fur} />
+        <ellipse cx={0} cy={2.5} rx={3} ry={2.4} fill={belly} opacity="0.55" />
+        <circle cx={2} cy={-4} r={3.8} fill={fur} />
+        <path d="M -0.6 -6.4 l -0.4 -3.4 l 2.2 1.8 Z" fill={fur} />
+        <path d="M 4.6 -6.4 l 0.4 -3.4 l -2.2 1.8 Z" fill={fur} />
+        <circle cx={0.6} cy={-4.2} r={1} fill={dark} />
+        <circle cx={3.4} cy={-4.2} r={1} fill={dark} />
+        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.CELEBRATE) {
+    return (
+      <g aria-hidden="true">
+        <path d="M -7 0 q -3 -3 -1 -8" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
+        <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+        <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+        <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+        <circle cx={6} cy={-2} r={4} fill={fur} />
+        <path d="M 3.2 -5 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
+        <path d="M 8.8 -5 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
+        <path d="M 4 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
+        <path d="M 6.8 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
+        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
+      </g>
+    )
+  }
+  const excited = mode === PET_MODES.EXCITED
+  return (
+    <g aria-hidden="true">
+      {excited
+        ? <path d="M -7 0 q -5 -2 -4 -7" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
+        : <path d="M -7 0 q -5 1 -5 -3" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />}
+      <ellipse cx={-1} cy={1} rx={7} ry={4.2} fill={fur} />
+      <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+      <rect x={-4} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+      <rect x={2} y={4} width={1.6} height={3} rx={0.8} fill={dark} />
+      <circle cx={6} cy={-1.5} r={4} fill={fur} />
+      <path d="M 3.2 -4.4 l -0.6 -3 l 2.4 1.6 Z" fill={fur} />
+      <path d="M 8.8 -4.4 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
+      <circle cx={4.6} cy={-1.8} r={0.8} fill={dark} />
+      <circle cx={7.4} cy={-1.8} r={0.8} fill={dark} />
+      <circle cx={6} cy={-0.2} r={0.6} fill="#C77" />
+    </g>
+  )
+}
+
+// ── Robot vacuum (Roomba). Machine motion grammar: a flat disc, a status LED that reads the mode,
+//    a front bumper. Minimal animation by nature (calm-tech friendly). ──
+function VacuumSprite({ mode, reducedMotion }) {
+  const body = '#3A3F44', top = '#4E555C', rim = '#23262A'
+  // LED colour reads the mode (honest: same mode the barometer chose)
+  const led = mode === PET_MODES.HIDE ? '#E24B4A'
+    : mode === PET_MODES.ALERT ? '#E24B4A'
+    : mode === PET_MODES.NAP ? '#E8A317'
+    : mode === PET_MODES.CELEBRATE ? '#19C3E6'
+    : '#1D9E75'
+  const docked = mode === PET_MODES.NAP
+  const blink = (mode === PET_MODES.ALERT) && !reducedMotion
+  return (
+    <g aria-hidden="true">
+      {docked && /* charging dock */ <rect x={-7} y={3} width={14} height={2.4} rx={1} fill="#555" opacity="0.8" />}
+      {/* disc body (flatter ellipse = top-down) */}
+      <ellipse cx={0} cy={1} rx={8} ry={5.4} fill={body} stroke={rim} strokeWidth="0.8" />
+      <ellipse cx={0} cy={0.2} rx={5.4} ry={3.4} fill={top} />
+      {/* front bumper (faces +x; parent flips via scale for direction) */}
+      <path d="M 6 -2 a 6 5.4 0 0 1 0 6" stroke={rim} strokeWidth="1.2" fill="none" opacity="0.7" />
+      {/* status LED */}
+      <circle cx={0} cy={0} r={1.5} fill={led} opacity={mode === PET_MODES.HIDE ? 0.6 : 0.95}
+        style={blink ? { animation: 'pet-snooze 0.8s steps(2,end) infinite' } : undefined} />
+      {mode === PET_MODES.ALERT && <text x={6} y={-5} fontSize="6" fill="#D98324" opacity="0.9">!</text>}
+      {mode === PET_MODES.CELEBRATE && <text x={7} y={-5} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>}
+    </g>
+  )
+}
+
+// ── Dog. Like the cat but doggier: floppy ears, snout, a wagging tail when excited/celebrating. ──
+function DogSprite({ mode, reducedMotion }) {
+  const fur = '#A6713C', dark = '#6E4A28', belly = '#E0C29A'
+  if (mode === PET_MODES.NAP) {
+    return (
+      <g aria-hidden="true">
+        <ellipse cx={0} cy={0} rx={9.5} ry={5.5} fill={fur} />
+        <ellipse cx={0} cy={1.6} rx={6} ry={3} fill={belly} opacity="0.5" />
+        <circle cx={-6.5} cy={-0.5} r={3.8} fill={fur} />
+        <path d="M -9.4 -1.6 q -2 1 -1 3.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />{/* floppy ear */}
+        <path d="M -7.6 -0.6 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
+        <path d="M 8.4 0.4 q 4.4 0 3.6 -3.4" stroke={fur} strokeWidth="2.6" fill="none" strokeLinecap="round" />
+        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
+          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.HIDE) {
+    return (
+      <g aria-hidden="true">
+        <ellipse cx={0} cy={1} rx={8.5} ry={3.8} fill={fur} />
+        <circle cx={6} cy={0} r={3.6} fill={fur} />
+        <path d="M 3.4 -1.6 q -2 0.6 -1.6 2.6" stroke={dark} strokeWidth="1.8" fill="none" strokeLinecap="round" />{/* ear tucked */}
+        <circle cx={5} cy={-0.2} r={0.7} fill={dark} />
+        <circle cx={7.4} cy={-0.2} r={0.7} fill={dark} />
+        <ellipse cx={8.6} cy={1} rx={1.4} ry={1} fill={dark} />{/* snout */}
+        <path d="M -8.4 1.2 q -2.6 1 -1.6 3" stroke={fur} strokeWidth="2.2" fill="none" strokeLinecap="round" />
+      </g>
+    )
+  }
+  if (mode === PET_MODES.ALERT) {
+    return (
+      <g aria-hidden="true">
+        <path d="M -7.4 1 q -4 2 -3 4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        <ellipse cx={0} cy={1} rx={5.8} ry={5} fill={fur} />
+        <ellipse cx={0} cy={2.6} rx={3} ry={2.4} fill={belly} opacity="0.55" />
+        <circle cx={2} cy={-4} r={4} fill={fur} />
+        <path d="M -1.4 -5.4 q -2.4 -0.6 -2.6 2.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />{/* perked floppy ear */}
+        <circle cx={0.8} cy={-4.2} r={1} fill={dark} />
+        <circle cx={3.6} cy={-4.2} r={1} fill={dark} />
+        <ellipse cx={4} cy={-2.6} rx={1.4} ry={1} fill={dark} />
+        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
+      </g>
+    )
+  }
+  if (mode === PET_MODES.CELEBRATE) {
+    return (
+      <g aria-hidden="true">
+        <path d="M -7 0 q -4 -3 -1 -8" stroke={fur} strokeWidth="2.6" fill="none" strokeLinecap="round" />{/* tail up/wag */}
+        <ellipse cx={-1} cy={1} rx={7.2} ry={4.2} fill={fur} />
+        <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+        <rect x={-4} y={4} width={1.8} height={3} rx={0.9} fill={dark} />
+        <rect x={2} y={4} width={1.8} height={3} rx={0.9} fill={dark} />
+        <circle cx={6} cy={-2} r={4.2} fill={fur} />
+        <path d="M 3 -3.6 q -2.2 1 -1.2 3.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />
+        <ellipse cx={8.6} cy={-1.4} rx={1.6} ry={1.1} fill={dark} />
+        <path d="M 8.4 -0.4 l 0 2" stroke="#D9536B" strokeWidth="1" strokeLinecap="round" />{/* tongue */}
+        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
+      </g>
+    )
+  }
+  const excited = mode === PET_MODES.EXCITED
+  return (
+    <g aria-hidden="true">
+      {excited
+        ? <path d="M -7 0 q -5 -2 -3.6 -7" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
+        : <path d="M -7 0 q -5 1 -4.6 -3" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />}
+      <ellipse cx={-1} cy={1} rx={7.2} ry={4.2} fill={fur} />
+      <ellipse cx={-1} cy={2.6} rx={4} ry={2} fill={belly} opacity="0.55" />
+      <rect x={-4} y={4} width={1.8} height={3} rx={0.9} fill={dark} />
+      <rect x={2} y={4} width={1.8} height={3} rx={0.9} fill={dark} />
+      <circle cx={6} cy={-1.5} r={4.2} fill={fur} />
+      <path d="M 3 -3.4 q -2.2 1 -1.2 3.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />{/* floppy ear */}
+      <circle cx={5} cy={-1.8} r={0.8} fill={dark} />
+      <circle cx={7.6} cy={-1.8} r={0.8} fill={dark} />
+      <ellipse cx={8.8} cy={-0.4} rx={1.5} ry={1.1} fill={dark} />{/* snout */}
+    </g>
+  )
+}
+
+export default function PetSprite({ type, mode, reducedMotion }) {
+  if (type === 'vacuum') return <VacuumSprite mode={mode} reducedMotion={reducedMotion} />
+  if (type === 'dog') return <DogSprite mode={mode} reducedMotion={reducedMotion} />
+  return <CatSprite mode={mode} reducedMotion={reducedMotion} />
+}

--- a/src/index.css
+++ b/src/index.css
@@ -56,6 +56,11 @@ html, body, #root {
   0%, 100% { transform: translateY(0); }
   50%      { transform: translateY(-1.5px); }
 }
+/* Larger bob for the dog's livelier motion grammar (#39 types). */
+@keyframes pet-bob-lg {
+  0%, 100% { transform: translateY(0); }
+  50%      { transform: translateY(-2.5px); }
+}
 /* Office pet (v2): a 220ms fade-in on each mode change (keyed remount) so poses cross-fade instead of
    snapping. reducedMotion skips it (instant swap). */
 @keyframes pet-fade-in {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -292,6 +292,7 @@
     "weatherOn": "Enable weather animations",
     "petOff": "Hide office pet",
     "petOn": "Show office pet",
+    "petType": "Change pet",
     "info": "Info"
   },
   "time": {

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -292,6 +292,7 @@
     "weatherOn": "開啟天氣動畫",
     "petOff": "隱藏辦公室寵物",
     "petOn": "顯示辦公室寵物",
+    "petType": "更換寵物",
     "info": "資訊"
   },
   "time": {

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -64,12 +64,12 @@ export function nextPetType(type) {
 
 // petMotionGrammar — per-type movement feel so types aren't just reskins (a Roomba moves like a
 // machine, a dog like a dog). Pure → unit-testable. `cadenceMul` scales the wander interval
-// (smaller = more often), `bob`/`bobAmp` the idle hop, `easing` the glide, `turnInPlace` reserved
-// for the vacuum's mechanical pivot.
+// (smaller = more often), `bob`/`bobAmp` the idle hop (`bobKeyframe` names the CSS animation so the
+// choice is explicit, not a numeric guess), `easing` the glide.
 const MOTION = Object.freeze({
-  cat:    { cadenceMul: 1.0, bob: true,  bobAmp: 1.5, easing: 'ease-in-out', turnInPlace: false },
-  dog:    { cadenceMul: 0.7, bob: true,  bobAmp: 2.5, easing: 'ease-in-out', turnInPlace: false },
-  vacuum: { cadenceMul: 1.1, bob: false, bobAmp: 0,   easing: 'linear',      turnInPlace: true  },
+  cat:    { cadenceMul: 1.0, bob: true,  bobAmp: 1.5, bobKeyframe: 'pet-bob',    easing: 'ease-in-out' },
+  dog:    { cadenceMul: 0.7, bob: true,  bobAmp: 2.5, bobKeyframe: 'pet-bob-lg', easing: 'ease-in-out' },
+  vacuum: { cadenceMul: 1.1, bob: false, bobAmp: 0,   bobKeyframe: 'pet-bob',    easing: 'linear' },
 })
 export function petMotionGrammar(type) {
   return MOTION[type] || MOTION.cat

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -51,6 +51,30 @@ export function resolvePetMode({ base, alert = false, celebrate = false }) {
   return base
 }
 
+// ─── Pet types (cosmetic skins) ────────────────────────────────────────────────────────────────
+// COSMETIC ONLY. A type changes the sprite + motion GRAMMAR (how it moves), NEVER the state logic —
+// every type derives its mode from the same `derivePetState`/`resolvePetMode` and obeys the same
+// hide-on-blocker honesty guarantee. Capped at 3 (calm-tech guardrail: personalization, not a zoo).
+export const PET_TYPES = Object.freeze(['cat', 'vacuum', 'dog'])
+
+export function nextPetType(type) {
+  const i = PET_TYPES.indexOf(type)
+  return PET_TYPES[(i + 1) % PET_TYPES.length] // unknown → index -1 → wraps to PET_TYPES[0]
+}
+
+// petMotionGrammar — per-type movement feel so types aren't just reskins (a Roomba moves like a
+// machine, a dog like a dog). Pure → unit-testable. `cadenceMul` scales the wander interval
+// (smaller = more often), `bob`/`bobAmp` the idle hop, `easing` the glide, `turnInPlace` reserved
+// for the vacuum's mechanical pivot.
+const MOTION = Object.freeze({
+  cat:    { cadenceMul: 1.0, bob: true,  bobAmp: 1.5, easing: 'ease-in-out', turnInPlace: false },
+  dog:    { cadenceMul: 0.7, bob: true,  bobAmp: 2.5, easing: 'ease-in-out', turnInPlace: false },
+  vacuum: { cadenceMul: 1.1, bob: false, bobAmp: 0,   easing: 'linear',      turnInPlace: true  },
+})
+export function petMotionGrammar(type) {
+  return MOTION[type] || MOTION.cat
+}
+
 // petReadabilityScale — keep the pet legible when the office is docked small WITHOUT lying about
 // size. Partial (√) counter-scale of the live sceneScale, floored at 1 and capped at 1.6, so the
 // pet shrinks WITH the room (stays a believable inhabitant, not a HUD sticker) but never becomes an

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -7,6 +7,7 @@ import { detectProjectMode } from './platformDetect'
 import { STATUS_COLORS } from './constants.js'
 import { classifyTask, familyToBehavior, decideBehavior } from './classify.js'
 import { FEED_ORIGINS } from './rosterModel.js'
+import { PET_TYPES, nextPetType } from './petState.js'
 
 export { STATUS_COLORS }
 
@@ -322,6 +323,10 @@ export const useOfficeStore = create((set) => ({
   // #39: ambient office pet (signal-driven barometer). Default ON; persisted via a dedicated
   // localStorage key (same lightweight pattern as weatherEffects). OFF → no pet rendered (zero cost).
   officePet: typeof window === 'undefined' ? true : (() => { try { return localStorage.getItem('office-pet') !== 'off' } catch { return true } })(),
+  // #39 types: cosmetic pet skin ('cat' | 'vacuum' | 'dog'). Persisted; cosmetic only (never changes
+  // the honest mode logic). Validated against PET_TYPES on read so a junk localStorage value can't
+  // select a missing sprite.
+  petType: typeof window === 'undefined' ? 'cat' : (() => { try { const v = localStorage.getItem('office-pet-type'); return PET_TYPES.includes(v) ? v : 'cat' } catch { return 'cat' } })(),
   showWorkflow: false,
   // Diagnostic counter: how many times the AgentCharacter RAF watchdog had to restart a
   // stalled walk loop. A silent restart hides the underlying stall; surfacing a count lets
@@ -614,6 +619,12 @@ export const useOfficeStore = create((set) => ({
     const next = !s.officePet
     try { if (typeof window !== 'undefined') localStorage.setItem('office-pet', next ? 'on' : 'off') } catch {}
     return { officePet: next }
+  }),
+  // #39 types: cycle cat → vacuum → dog → cat (cosmetic), persisted.
+  cyclePetType: () => set((s) => {
+    const next = nextPetType(s.petType)
+    try { if (typeof window !== 'undefined') localStorage.setItem('office-pet-type', next) } catch {}
+    return { petType: next }
   }),
   triggerWorkflow: () => set({ showWorkflow: true }),
   endWorkflow: () => set({ showWorkflow: false }),

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, PET_MODES } from '../src/systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, nextPetType, PET_TYPES, PET_MODES } from '../src/systems/petState.js'
 // Static import (hoisted above the window shim below) so the store + i18n initialize while `window`
 // is still undefined — matching the repo's node test env. The shim then provides localStorage so the
 // toggle's persistence path runs. (Same approach as weatherEffectsToggle.test.js.)
@@ -86,6 +86,28 @@ describe('petReadabilityScale (#39 v2 — legible when docked small, never fakes
   })
 })
 
+describe('pet types (#39 — cosmetic skins, behavior-identical)', () => {
+  it('PET_TYPES is a capped set of 3', () => {
+    expect(PET_TYPES).toEqual(['cat', 'vacuum', 'dog'])
+  })
+  it('nextPetType cycles cat → vacuum → dog → cat (unknown → cat)', () => {
+    expect(nextPetType('cat')).toBe('vacuum')
+    expect(nextPetType('vacuum')).toBe('dog')
+    expect(nextPetType('dog')).toBe('cat')
+    expect(nextPetType('bogus')).toBe('cat')
+  })
+  it('petMotionGrammar gives each type a distinct feel; unknown → cat grammar', () => {
+    expect(petMotionGrammar('vacuum').bob).toBe(false)       // a Roomba does not bob
+    expect(petMotionGrammar('vacuum').easing).toBe('linear') // machines move linearly
+    expect(petMotionGrammar('dog').bobAmp).toBeGreaterThan(petMotionGrammar('cat').bobAmp)
+    expect(petMotionGrammar('bogus')).toEqual(petMotionGrammar('cat'))
+  })
+  it('type changes FEEL only — mode logic is type-independent (honesty unaffected)', () => {
+    // derivePetState/resolvePetMode take no `type` argument, so a real blocker → hide for ALL skins
+    expect(derivePetState({ mood: 'smooth', blockedCount: 1 })).toBe(PET_MODES.HIDE)
+  })
+})
+
 describe('store — officePet toggle (#39)', () => {
   beforeEach(() => {
     localStorage.removeItem('office-pet')
@@ -103,5 +125,18 @@ describe('store — officePet toggle (#39)', () => {
     useOfficeStore.getState().toggleOfficePet()
     expect(useOfficeStore.getState().officePet).toBe(true)
     expect(localStorage.getItem('office-pet')).toBe('on')
+  })
+
+  it('cyclePetType cycles + persists the skin (#39 types)', () => {
+    localStorage.removeItem('office-pet-type')
+    useOfficeStore.setState({ petType: 'cat' })
+    useOfficeStore.getState().cyclePetType()
+    expect(useOfficeStore.getState().petType).toBe('vacuum')
+    expect(localStorage.getItem('office-pet-type')).toBe('vacuum')
+    useOfficeStore.getState().cyclePetType()
+    expect(useOfficeStore.getState().petType).toBe('dog')
+    useOfficeStore.getState().cyclePetType()
+    expect(useOfficeStore.getState().petType).toBe('cat')
+    expect(localStorage.getItem('office-pet-type')).toBe('cat')
   })
 })


### PR DESCRIPTION
Extends #39 (office pet). Cosmetic pet skins — **cat / robot-vacuum / dog** — capped at 3 (panel guardrail).

**The sacred rule holds:** a type changes ONLY the sprite + motion grammar. `derivePetState`/`resolvePetMode` take no `type` argument, so a real blocker → `hide` for **every** skin. Red-team-confirmed: no skin can paint a happy state while an agent is blocked (the vacuum LED is red on hide/alert).

- `src/components/petSprites.jsx` (new) — `PetSprite({type,mode})`: `CatSprite` extracted byte-faithfully + `VacuumSprite` (disc + mode-coloured status LED) + `DogSprite` (floppy ears, snout, wag). Keeps `OfficePet.jsx` lean.
- `petState.js` — `PET_TYPES`, `nextPetType`, pure `petMotionGrammar(type)` (Roomba = linear easing + no bob; dog = bigger bob; explicit `bobKeyframe`).
- store `petType` (default cat, `office-pet-type` key, validated vs PET_TYPES) + `cyclePetType`.
- ControlPanel: 🐾 on/off + a change-pet button (current skin emoji) + en/zh-TW aria. `pet-bob-lg` keyframe.

**Evidence:** +5 tests (PET_TYPES/nextPetType/petMotionGrammar, cyclePetType persistence, a type-independence honesty assertion). Suite **1328 passed**; build clean. 1 reviewer → PASS (cat extraction byte-faithful, no circular import, SSR+localStorage validated, protected surfaces untouched, i18n parity); 2 LOW advisories fixed. DEV live-verified: cycle cat→vacuum→dog→cat persists; each skin renders; dog+blocker → alert/hide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
