### PR TITLE
feat(#39): pet delight pack — bigger, deploy spotlight, click-to-pet, mode pop

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T07:55:00Z
-- **Update Sequence**: 38
+- **Last Updated**: 2026-06-08T08:40:00Z
+- **Update Sequence**: 39
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-office-pet-delight-2026-06-08 (#39 — delight pack: bigger · deploy spotlight · click-to-pet · mode pop)
+
+- PR #65 (branch `feat/office-pet-delight`), feature (extends #39). Origin: 4-expert panel judged the pet "tasteful wallpaper" vs the owner's "obviously interesting" goal (live-measured ~18px speck); guardian reframe = push delight INTO the signal, novelty OFF the timer.
+- **Shipped**: `PET_BASE_SCALE` 1.7 (pet ~18→~30px, readable; wander band tightened off desks + the coffee-machine click target); deploy/eureka ✦ confetti spotlight (real celebrate event, once per event, RM-suppressed); click-to-pet ♥ (cosmetic, never touches mode); squash-stretch `pet-pop` mode-change beat (felt, not faded). All in `OfficePet.jsx` + `index.css`.
+- **Honesty/calm-tech intact**: real-signal-only, reduced-motion suppresses all new motion, no fake narrative, hide-on-blocker untouched (delight code is all downstream of mode). Protected Surfaces untouched. Reviewer PASS (2 LOW fixed: pet off the coffee-machine click target, aria-hidden wrapper). Suite **1328 passed**; build clean. DEV live-verified: pet ~30px, pet-pop on mode change, click→♥, celebrate→confetti.
+- **Deferred (panel, open)**: run-to-blocked-desk (read-only agent.position); distinct vacuum per-mode silhouettes; ControlPanel ⚙ settings-popover consolidation.
 
 ### Ship-feat-office-pet-types-2026-06-08 (#39 — multiple pet types: cat / robot-vacuum / dog)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -106,11 +106,31 @@ axes. Shipped increments (all honesty-preserving, Protected Surfaces untouched):
   event). Both folded onto the base mode by the pure `resolvePetMode({base, alert, celebrate})`:
   `alert` wins; `celebrate` shows ONLY when base ≠ hide. **The honesty guarantee is preserved — neither
   can make the pet look happy during a real blocker.** Total modes now 6 (at the guardian's cap).
-- **AC-v2-3 mode cross-fade** — a 220ms `pet-fade-in` on every mode change (keyed remount) so poses
-  cross instead of snapping; reduced-motion → instant swap.
+- **AC-v2-3 mode change beat** — a squash-stretch `pet-pop` on every mode change (keyed remount) so
+  honest state changes are FELT, not just faded; reduced-motion → instant swap. (Originally a 220ms
+  fade; upgraded to the pop in the delight pack, PR #65.)
 - **Guardrails honored**: hide-on-blocker stays the first branch; reduced-motion suppresses all
   motion (wander, hop, fade); transient overlays are timer-owned so a rapidly-oscillating signal
   can't leave a state stuck on (alert uses a two-effect pattern keyed on `alert` itself).
+## delight pack (PR #65, shipped) — "obviously readable/fun" without breaking honesty
+
+A 4-expert panel (game-design · game-feel · calm-tech guardian · feasibility) judged the pet
+"tasteful wallpaper" against the owner's "obviously interesting" goal (live-measured: ~18px speck,
+subtle state diffs). Guardian reframe: push delight INTO the signal, novelty OFF the timer.
+
+- Bigger pet (`PET_BASE_SCALE` 1.7 → ~30px, pose/face readable; composes with v2 readability scale;
+  wander band tightened to keep it off desks + off the coffee-machine click target).
+- Deploy/eureka **spotlight**: a few ✦ confetti rise on the REAL celebrate event (once per event,
+  reduced-motion suppressed).
+- **Click-to-pet** ♥ — a cosmetic user-initiated beat; never changes the mode/honest reading.
+- Mode change is a squash-stretch `pet-pop` (felt, not just faded).
+- All honesty/calm-tech guardrails held (real-signal-only, reduced-motion off, no fake narrative,
+  hide-on-blocker sacred). Visual layer — verified live (pet ~30px, pop/confetti/♥). Reviewer PASS.
+
+> **Deferred to follow-ups** (panel, still open): the pet running to the actually-blocked desk
+> (read-only `agent.position`); distinct robot-vacuum per-mode silhouettes; ControlPanel button
+> consolidation (⚙ settings popover).
+
 - **Multiple pet types** (PR #64, shipped) — cosmetic skins cat / robot-vacuum / dog via
   `PetSprite({type,mode})` + pure `petMotionGrammar(type)` (own motion grammar per skin) +
   `petType` toggle. COSMETIC ONLY: `derivePetState`/`resolvePetMode` take no `type` argument, so the

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -20,9 +20,10 @@ const START = clampToFloor({ x: 120, y: 512 })
 const PET_BASE_SCALE = 1.7
 
 // Sample a floor point in the lower office band (walkway/lounge) so the pet stays low and out of the
-// desk rows. Band tightened slightly (y 400–525) so the larger pet can't reach up into desks.
+// desk rows. Band: y 400–525 (so the larger pet can't reach up into desks) and x ≥ 80 (so the now-
+// clickable pet doesn't sit over the lower-left coffee-machine tea-break click target at ~x20 y445).
 function randomFloorTarget() {
-  const x = 50 + Math.random() * 700
+  const x = 80 + Math.random() * 670
   const y = 400 + Math.random() * 125
   return clampToFloor({ x, y })
 }
@@ -121,6 +122,7 @@ export default function OfficePet() {
       data-office-pet={mode}
       data-pet-type={petType}
       data-petted={petted ? '1' : undefined}
+      aria-hidden="true"
       transform={`translate(${pos.x}, ${pos.y})`}
       style={reducedMotion ? { cursor: 'pointer' } : { transition: `transform ${glideMs}ms ${grammar.easing}`, cursor: 'pointer' }}
       pointerEvents="auto"

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -11,13 +11,19 @@ import PetSprite from './petSprites.jsx'
 // signal. Movement is a slow CSS-glide wander reusing `clampToFloor` (never `calculatePath`, never
 // HOME_POSITIONS / agent coords — Protected Surfaces untouched). reduced-motion → static pose.
 
-const START = clampToFloor({ x: 120, y: 505 })
+const START = clampToFloor({ x: 120, y: 512 })
+
+// #39 delight: a base legibility bump. The sprite is authored at ~9px radius; ×1.7 makes its pose +
+// face actually readable at native office size (it was a ~18px speck). Composes with the v2
+// readability counter-scale (which only adds MORE when the office docks small). Scaling is about the
+// sprite's local origin (0,0) = floor contact, so feet stay planted.
+const PET_BASE_SCALE = 1.7
 
 // Sample a floor point in the lower office band (walkway/lounge) so the pet stays low and out of the
-// desk rows. clampToFloor snaps to a floor zone and pushes off any furniture.
+// desk rows. Band tightened slightly (y 400–525) so the larger pet can't reach up into desks.
 function randomFloorTarget() {
-  const x = 40 + Math.random() * 720
-  const y = 380 + Math.random() * 150
+  const x = 50 + Math.random() * 700
+  const y = 400 + Math.random() * 125
   return clampToFloor({ x, y })
 }
 
@@ -67,6 +73,15 @@ export default function OfficePet() {
   const baseMode = derivePetState({ mood, blockedCount })
   const mode = resolvePetMode({ base: baseMode, alert, celebrate })
 
+  // #39 delight: click-to-pet — a purely cosmetic, user-initiated ♥ beat (no mode/state change, never
+  // affects the honest reading). Auto-clears after 1s.
+  const [petted, setPetted] = useState(false)
+  useEffect(() => {
+    if (!petted) return
+    const t = setTimeout(() => setPetted(false), 1000)
+    return () => clearTimeout(t)
+  }, [petted])
+
   const [pos, setPos] = useState(START)
   const [facing, setFacing] = useState(1)
   const posRef = useRef(START)
@@ -91,23 +106,42 @@ export default function OfficePet() {
   // dog bobs bigger). reduced-motion off.
   const hop = grammar.bob && (mode === PET_MODES.EXCITED || mode === PET_MODES.CELEBRATE) && !reducedMotion
     ? { animation: `${grammar.bobKeyframe} 0.6s ease-in-out infinite` } : undefined
-  // v2: keep the pet legible when the office docks small without faking size (partial √ counter-scale)
-  const petScale = petReadabilityScale(sceneScale)
-  // v2: a gentle 220ms fade-in on every mode change (keyed remount) so poses cross instead of snapping
-  const fadeIn = reducedMotion ? undefined : { animation: 'pet-fade-in 0.22s ease-out' }
+  // v2: keep the pet legible when the office docks small without faking size (partial √ counter-scale),
+  // composed with the base legibility bump.
+  const petScale = petReadabilityScale(sceneScale) * PET_BASE_SCALE
+  // a squash-stretch "pop" on every mode change (keyed remount) so honest state changes are FELT, not
+  // just faded. reduced-motion → instant swap.
+  const pop = reducedMotion ? undefined : { animation: 'pet-pop 0.3s ease-out' }
+  // #39 delight: a brief celebrate spotlight — a few ✦ rise off the pet on a REAL deploy/eureka. Once
+  // per event (rides the celebrate transient), reduced-motion suppressed.
+  const showConfetti = mode === PET_MODES.CELEBRATE && !reducedMotion
 
   return (
     <g
       data-office-pet={mode}
       data-pet-type={petType}
+      data-petted={petted ? '1' : undefined}
       transform={`translate(${pos.x}, ${pos.y})`}
-      style={reducedMotion ? undefined : { transition: `transform ${glideMs}ms ${grammar.easing}` }}
-      pointerEvents="none"
+      style={reducedMotion ? { cursor: 'pointer' } : { transition: `transform ${glideMs}ms ${grammar.easing}`, cursor: 'pointer' }}
+      pointerEvents="auto"
+      onClick={() => setPetted(true)}
     >
       <g transform={`scale(${facing * petScale}, ${petScale})`} style={hop}>
-        <g key={mode} style={fadeIn}>
+        <g key={mode} style={pop}>
           <PetSprite type={petType} mode={mode} reducedMotion={reducedMotion} />
         </g>
+        {showConfetti && (
+          <g pointerEvents="none" aria-hidden="true">
+            {[-6, 0, 6].map((dx, i) => (
+              <text key={i} x={dx} y={-9} fontSize="5" textAnchor="middle" fill="#E0A800"
+                style={{ animation: `pet-confetti 1.2s ease-out ${i * 0.14}s both` }}>✦</text>
+            ))}
+          </g>
+        )}
+        {petted && (
+          <text x={0} y={-9} fontSize="6" textAnchor="middle" fill="#E2588B" aria-hidden="true"
+            style={reducedMotion ? undefined : { animation: 'pet-heart 1s ease-out both' }}>♥</text>
+        )}
       </g>
     </g>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -61,9 +61,23 @@ html, body, #root {
   0%, 100% { transform: translateY(0); }
   50%      { transform: translateY(-2.5px); }
 }
-/* Office pet (v2): a 220ms fade-in on each mode change (keyed remount) so poses cross-fade instead of
-   snapping. reducedMotion skips it (instant swap). */
-@keyframes pet-fade-in {
-  0%   { opacity: 0; }
-  100% { opacity: 1; }
+/* Office pet: a squash-stretch "pop" on each mode change (keyed remount) so honest state changes are
+   FELT, not just faded. reducedMotion skips it (instant swap). transform-origin is the sprite's local
+   origin (feet), so it pops up in place. */
+@keyframes pet-pop {
+  0%   { opacity: 0; transform: scale(0.8); }
+  60%  { opacity: 1; transform: scale(1.07); }
+  100% { opacity: 1; transform: scale(1); }
+}
+/* #39 delight: celebrate confetti — a ✦ rises and fades off the pet on a real deploy/eureka. */
+@keyframes pet-confetti {
+  0%   { opacity: 0; transform: translateY(2px); }
+  20%  { opacity: 0.95; }
+  100% { opacity: 0; transform: translateY(-11px); }
+}
+/* #39 delight: click-to-pet ♥ floats up and fades. */
+@keyframes pet-heart {
+  0%   { opacity: 0; transform: translateY(2px) scale(0.7); }
+  25%  { opacity: 1; transform: translateY(-1px) scale(1); }
+  100% { opacity: 0; transform: translateY(-9px) scale(1); }
 }


### PR DESCRIPTION
Extends #39. A 4-expert panel judged the shipped pet "tasteful wallpaper" against the owner goal of an *obviously* interesting pet (live-measured: ~18px speck, subtle state diffs). Guardian reframe: **push delight INTO the signal, novelty OFF the timer** — so every addition here rides a real signal and respects calm-tech.

- **Bigger pet** — `PET_BASE_SCALE` 1.7 (~18px → ~30px, pose/face readable); composes with the v2 readability counter-scale; wander band tightened to keep the larger, now-clickable pet off the desks and off the coffee-machine tea-break click target.
- **Deploy/eureka spotlight** — a few ✦ confetti rise off the pet on the REAL celebrate event (once per event; reduced-motion suppressed).
- **Click-to-pet** — a cosmetic ♥ beat (pointerEvents auto + 1s transient); never changes the mode or the honest reading.
- **Mode pop** — a squash-stretch `pet-pop` on mode change (felt, not just faded); reduced-motion → instant.

**Honesty/calm-tech intact:** all delight code is downstream of `mode`; hide-on-blocker untouched; reduced-motion suppresses every new motion; no fake narrative. Protected Surfaces untouched.

**Evidence:** suite **1328 passed**; build clean. Reviewer → PASS (2 LOW fixed: pet off the coffee-machine click target + aria-hidden wrapper). DEV live-verified: pet ~30px; `pet-pop` on mode change; click→♥; celebrate→confetti.

Deferred (panel, open): run-to-blocked-desk; distinct vacuum silhouettes; ⚙ settings-popover button consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
