### PR TITLE
feat(#39): pet runs to the blocked desk + distinct robot-vacuum silhouettes

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T08:40:00Z
-- **Update Sequence**: 39
+- **Last Updated**: 2026-06-08T09:20:00Z
+- **Update Sequence**: 40
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-office-pet-run-vacuum-2026-06-08 (#39 — run-to-blocked-desk + distinct vacuum silhouettes)
+
+- PR #66 (branch `feat/office-pet-run-vacuum`), feature (extends #39). Two panel-recommended honest-signal upgrades.
+- **Run-to-blocked-desk**: on a new-blocker edge the pet trots to stand just below a blocked agent's desk → POINTS AT a real blocker (motion = information). Pure `runTarget(pos)` + a primitive `blockedAgentPos` selector reading the store's already-published `agent.position` **read-only** — NO HOME_POSITIONS / movementSystem coupling (Protected Surfaces untouched; `clampToFloor` was already imported). Honesty held (alert still settles to hide; always a REAL blocker — first-found with ≥2).
+- **Vacuum silhouettes**: the robot-vacuum's near-identical LED-only modes now have distinct STATIC silhouettes — nap dock+dim, wander sweep trail, excited dust puff, hide tilt+dim (calm; reduced-motion safe).
+- **Review**: 1 acx-reviewer → PASS (read-only discipline intact, honesty preserved, no loop/race/stale-chase, vacuum RM-safe); 2 LOW advisories (multi-blocker targets first real blocker — comment corrected; RM snap intentional). **Tests**: +2 (`runTarget`); suite **1330 passed**; build clean. DEV live-verified: pet targets the blocked dev desk EXACTLY (240,386 → 240,404 = y+18, dist 0); vacuum node counts differ per mode.
 
 ### Ship-feat-office-pet-delight-2026-06-08 (#39 — delight pack: bigger · deploy spotlight · click-to-pet · mode pop)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -127,9 +127,13 @@ subtle state diffs). Guardian reframe: push delight INTO the signal, novelty OFF
 - All honesty/calm-tech guardrails held (real-signal-only, reduced-motion off, no fake narrative,
   hide-on-blocker sacred). Visual layer — verified live (pet ~30px, pop/confetti/♥). Reviewer PASS.
 
-> **Deferred to follow-ups** (panel, still open): the pet running to the actually-blocked desk
-> (read-only `agent.position`); distinct robot-vacuum per-mode silhouettes; ControlPanel button
-> consolidation (⚙ settings popover).
+**Run-to-blocked-desk + vacuum silhouettes (PR #66, shipped)** — on a new-blocker edge the pet trots
+to stand just below a blocked agent's desk so it POINTS AT a real blocker (pure `runTarget`; reads the
+store's published `agent.position` read-only — no HOME_POSITIONS / movement coupling; honesty held,
+alert still settles to hide). The robot-vacuum's near-identical modes got distinct static silhouettes
+(nap dock+dim · wander sweep trail · excited dust puff · hide tilt+dim).
+
+> **Deferred to a follow-up** (panel, still open): ControlPanel button consolidation (⚙ settings popover).
 
 - **Multiple pet types** (PR #64, shipped) — cosmetic skins cat / robot-vacuum / dog via
   `PetSprite({type,mode})` + pure `petMotionGrammar(type)` (own motion grammar per skin) +

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor } from '../systems/movementSystem.js'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, PET_MODES } from '../systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, PET_MODES } from '../systems/petState.js'
 import PetSprite from './petSprites.jsx'
 
 // ─── Office pet — a signal-driven barometer (#39 / AVO-121) ─────────────────────────────────────
@@ -35,6 +35,14 @@ export default function OfficePet() {
   // live blocked count — primitive, so the pet re-renders only when it actually changes.
   const blockedCount = useOfficeStore((s) =>
     Object.values(s.externalStatus).filter((e) => e && e.status === 'blocked').length)
+  // #39: the position of a currently-blocked agent (so the pet can trot over and "point at" it). A
+  // PRIMITIVE "x,y" string → stable re-render; reads the store's already-published agent.position
+  // (read-only — never HOME_POSITIONS / movement internals).
+  const blockedAgentPos = useOfficeStore((s) => {
+    const id = Object.keys(s.externalStatus).find((k) => s.externalStatus[k]?.status === 'blocked')
+    const p = id && s.agents[id]?.position
+    return p && Number.isFinite(p.x) ? `${Math.round(p.x)},${Math.round(p.y)}` : null
+  })
   const activeEventId = useOfficeStore((s) => s.activeEvent?.id || null)
   const sceneScale = useOfficeStore((s) => s.sceneScale)
   const petType = useOfficeStore((s) => s.petType)
@@ -70,6 +78,9 @@ export default function OfficePet() {
     const t = setTimeout(() => setAlert(false), 2500)
     return () => clearTimeout(t)
   }, [alert])
+  // keep the latest blocked-agent position handy for the run-to-desk effect (below, after pos exists)
+  const blockedPosRef = useRef(blockedAgentPos)
+  useEffect(() => { blockedPosRef.current = blockedAgentPos }, [blockedAgentPos])
 
   const baseMode = derivePetState({ mood, blockedCount })
   const mode = resolvePetMode({ base: baseMode, alert, celebrate })
@@ -99,6 +110,22 @@ export default function OfficePet() {
     }, interval)
     return () => clearInterval(id)
   }, [mobile, mode, grammar.cadenceMul])
+
+  // #39: on a new blocker (alert turns true), trot over and stand just below that agent's desk so the
+  // pet POINTS AT the real blocker (motion = information; the honest beat made legible). Reads the
+  // store's published agent.position only — no movement-system / HOME_POSITIONS coupling.
+  useEffect(() => {
+    if (!alert || !officePet) return
+    const raw = blockedPosRef.current
+    if (!raw) return
+    const [bx, by] = raw.split(',').map(Number)
+    const rt = runTarget({ x: bx, y: by })
+    if (!rt) return
+    const dest = clampToFloor(rt)
+    setFacing(dest.x >= posRef.current.x ? 1 : -1)
+    posRef.current = dest
+    setPos(dest)
+  }, [alert, officePet])
 
   if (!officePet) return null
 

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -111,9 +111,10 @@ export default function OfficePet() {
     return () => clearInterval(id)
   }, [mobile, mode, grammar.cadenceMul])
 
-  // #39: on a new blocker (alert turns true), trot over and stand just below that agent's desk so the
-  // pet POINTS AT the real blocker (motion = information; the honest beat made legible). Reads the
-  // store's published agent.position only — no movement-system / HOME_POSITIONS coupling.
+  // #39: when a new blocker appears (alert turns true), trot over and stand just below a blocked
+  // agent's desk so the pet POINTS AT a real blocker (motion = information; the honest beat made
+  // legible). With multiple blockers it targets the first one found — still always a REAL blocker, so
+  // honesty holds. Reads the store's published agent.position only — no movement-system / HOME_POSITIONS coupling.
   useEffect(() => {
     if (!alert || !officePet) return
     const raw = blockedPosRef.current

--- a/src/components/petSprites.jsx
+++ b/src/components/petSprites.jsx
@@ -101,14 +101,36 @@ function VacuumSprite({ mode, reducedMotion }) {
     : '#1D9E75'
   const docked = mode === PET_MODES.NAP
   const blink = (mode === PET_MODES.ALERT) && !reducedMotion
+  // Machine grammar for legible per-mode SILHOUETTES (not LED-only): nap docks + dims; wander shows a
+  // sweep trail; excited adds a dust puff; hide tilts + dims (backed off). All static (calm).
+  const tilt = mode === PET_MODES.HIDE ? -12 : 0
+  const dim = (mode === PET_MODES.NAP || mode === PET_MODES.HIDE) ? 0.72 : 1
+  const sweeping = mode === PET_MODES.WANDER || mode === PET_MODES.EXCITED
+  const puffing = mode === PET_MODES.EXCITED
   return (
     <g aria-hidden="true">
       {docked && /* charging dock */ <rect x={-7} y={3} width={14} height={2.4} rx={1} fill="#555" opacity="0.8" />}
-      {/* disc body (flatter ellipse = top-down) */}
-      <ellipse cx={0} cy={1} rx={8} ry={5.4} fill={body} stroke={rim} strokeWidth="0.8" />
-      <ellipse cx={0} cy={0.2} rx={5.4} ry={3.4} fill={top} />
-      {/* front bumper (faces +x; parent flips via scale for direction) */}
-      <path d="M 6 -2 a 6 5.4 0 0 1 0 6" stroke={rim} strokeWidth="1.2" fill="none" opacity="0.7" />
+      {/* motion sweep lines trailing behind (disc faces +x, so the trail is to the left) */}
+      {sweeping && (
+        <g stroke="#9aa1a8" strokeWidth="0.7" opacity="0.5" strokeLinecap="round">
+          <line x1={-9} y1={-1.6} x2={-12.5} y2={-1.6} />
+          <line x1={-9} y1={1.6} x2={-13} y2={1.6} />
+        </g>
+      )}
+      {/* dust puff kicked up when zipping (excited) */}
+      {puffing && (
+        <g fill="#BCB3A8" opacity="0.5">
+          <circle cx={-11} cy={2.6} r={1.4} />
+          <circle cx={-13.2} cy={1.6} r={1} />
+        </g>
+      )}
+      {/* disc body — tilts + dims when hiding (retreating) */}
+      <g transform={tilt ? `rotate(${tilt})` : undefined} opacity={dim}>
+        <ellipse cx={0} cy={1} rx={8} ry={5.4} fill={body} stroke={rim} strokeWidth="0.8" />
+        <ellipse cx={0} cy={0.2} rx={5.4} ry={3.4} fill={top} />
+        {/* front bumper (faces +x; parent flips via scale for direction) */}
+        <path d="M 6 -2 a 6 5.4 0 0 1 0 6" stroke={rim} strokeWidth="1.2" fill="none" opacity="0.7" />
+      </g>
       {/* status LED */}
       <circle cx={0} cy={0} r={1.5} fill={led} opacity={mode === PET_MODES.HIDE ? 0.6 : 0.95}
         style={blink ? { animation: 'pet-snooze 0.8s steps(2,end) infinite' } : undefined} />

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -75,6 +75,16 @@ export function petMotionGrammar(type) {
   return MOTION[type] || MOTION.cat
 }
 
+// runTarget — where the pet should trot to "point at" a blocked agent: just below its desk, on the
+// floor. Makes a real blocker MORE legible (motion = information). Pure → unit-testable; returns null
+// when no position is known. It consumes a position the store ALREADY publishes (agent.position) —
+// the caller must read that read-only, never HOME_POSITIONS / movementSystem internals, and must
+// clampToFloor the result (kept out of here so this stays a pure, dependency-free picker).
+export function runTarget(pos) {
+  if (!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)) return null
+  return { x: pos.x, y: pos.y + 18 }
+}
+
 // petReadabilityScale — keep the pet legible when the office is docked small WITHOUT lying about
 // size. Partial (√) counter-scale of the live sceneScale, floored at 1 and capped at 1.6, so the
 // pet shrinks WITH the room (stays a believable inhabitant, not a HUD sticker) but never becomes an

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, nextPetType, PET_TYPES, PET_MODES } from '../src/systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, nextPetType, runTarget, PET_TYPES, PET_MODES } from '../src/systems/petState.js'
 // Static import (hoisted above the window shim below) so the store + i18n initialize while `window`
 // is still undefined — matching the repo's node test env. The shim then provides localStorage so the
 // toggle's persistence path runs. (Same approach as weatherEffectsToggle.test.js.)
@@ -83,6 +83,18 @@ describe('petReadabilityScale (#39 v2 — legible when docked small, never fakes
     expect(petReadabilityScale(0)).toBe(1)
     expect(petReadabilityScale(-1)).toBe(1)
     expect(petReadabilityScale(NaN)).toBe(1)
+  })
+})
+
+describe('runTarget (#39 — pet points at the blocked desk)', () => {
+  it('returns a floor point just below the blocked agent', () => {
+    expect(runTarget({ x: 300, y: 200 })).toEqual({ x: 300, y: 218 })
+  })
+  it('returns null when no position is known / invalid', () => {
+    expect(runTarget(null)).toBeNull()
+    expect(runTarget(undefined)).toBeNull()
+    expect(runTarget({ x: NaN, y: 1 })).toBeNull()
+    expect(runTarget({ x: 1 })).toBeNull()
   })
 })
 


### PR DESCRIPTION
Extends #39. Two panel-recommended upgrades that put delight INTO the real signal.

### 1. Pet runs to the blocked desk
On a new-blocker edge the pet trots over and stands just below a blocked agent_s desk, so it **points at a real blocker** — motion = information, the honest beat made legible. Uses a pure `runTarget(pos)` + a primitive `blockedAgentPos` selector reading the store_s **already-published `agent.position` read-only** — NO `HOME_POSITIONS` / movementSystem coupling (Protected Surfaces untouched). Honesty held: alert still settles to hide, and it always targets a REAL blocker (first-found with ≥2).

### 2. Distinct robot-vacuum silhouettes
The vacuum_s modes were near-identical (LED-only). Each now has a distinct STATIC silhouette: nap docks + dims, wander shows a sweep trail, excited adds a dust puff, hide tilts + dims (backed off). Calm — no new motion; reduced-motion safe.

**Evidence:** +2 tests (`runTarget`). Suite **1330 passed**; build clean. Reviewer → PASS (read-only discipline intact, honesty preserved, no loop/race/stale-chase). DEV live-verified: pet targets the blocked dev desk EXACTLY (240,386 → pet 240,404 = y+18, dist 0); vacuum node counts now differ per mode.

Deferred (panel, open): ⚙ settings-popover button consolidation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
