### PR TITLE
feat: consolidate control bar into a ⚙ settings popover

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T09:20:00Z
-- **Update Sequence**: 40
+- **Last Updated**: 2026-06-08T10:05:00Z
+- **Update Sequence**: 41
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-controlpanel-settings-popover-2026-06-08 (UX — ⚙ settings popover consolidates the control bar)
+
+- PR #67 (branch `feat/controlpanel-settings-popover`), feature. UX-panel proposal: the bottom bar had grown to ~10 buttons mixing run-state / cosmetics / dev / help.
+- **Shipped**: a ⚙ settings popover holds weather + office-pet (role=switch), pet-skin (role=radiogroup, new store `setPetType`), notifications, and the Test toggle. Bar now lean: language · pause · roster · Run · ⚙ · info. a11y: aria-haspopup/expanded, role=menu/switch/radiogroup, Esc + click-outside close. i18n: `aria.settings` + `settings.*` in en + zh-TW. No data-path change (same actions + localStorage keys; showTest panel still renders, toggled from the popover).
+- **Review**: 1 acx-reviewer → PASS (no functional regression — every moved control keeps its handler+selector+persistence; no orphaned `cyclePetType` ref; panel mode untouched; i18n parity). LOW advisories: orphaned old aria/notify i18n keys (harmless), focus-management deferred (v1). **Tests**: +1 (`setPetType`); suite **1331 passed**; build clean. DEV live-verified: ⚙ opens/closes (Esc), weather/pet bar buttons gone, popover toggles + skin radio work.
+- This completes ALL panel-recommended pet + UX optimizations (#39 delight pack, run-to-desk, vacuum silhouettes, button consolidation).
 
 ### Ship-feat-office-pet-run-vacuum-2026-06-08 (#39 — run-to-blocked-desk + distinct vacuum silhouettes)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -133,7 +133,11 @@ store's published `agent.position` read-only — no HOME_POSITIONS / movement co
 alert still settles to hide). The robot-vacuum's near-identical modes got distinct static silhouettes
 (nap dock+dim · wander sweep trail · excited dust puff · hide tilt+dim).
 
-> **Deferred to a follow-up** (panel, still open): ControlPanel button consolidation (⚙ settings popover).
+**ControlPanel ⚙ consolidation (PR #67, shipped)** — the bottom bar (~10 buttons) was decluttered: the
+cosmetic toggles (weather, pet, pet-skin), notifications, and the dev Test panel moved into a new ⚙
+settings popover (role=menu/switch/radiogroup; Esc + click-outside; en/zh-TW). Bar now: language ·
+pause · roster · Run · ⚙ · info. New store `setPetType` for the skin radiogroup. All panel-recommended
+pet/UX optimizations are now shipped.
 
 - **Multiple pet types** (PR #64, shipped) — cosmetic skins cat / robot-vacuum / dog via
   `PetSprite({type,mode})` + pure `petMotionGrammar(type)` (own motion grammar per skin) +

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -4,6 +4,7 @@ import { useOfficeStore, STATUS_COLORS } from '../systems/store'
 import { classifyTask } from '../systems/classify'
 import { behaviorLabel, charName, t, setLocale, availableLocales, useLocale, eventName } from '../i18n'
 import { requestNotificationPermission, getNotificationState } from '../inference/desktopNotifier'
+import { PET_TYPES } from '../systems/petState.js'
 
 const statusOptions = ['idle', 'working', 'blocked', 'done']
 
@@ -74,7 +75,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const officePet = useOfficeStore((s) => s.officePet)
   const toggleOfficePet = useOfficeStore((s) => s.toggleOfficePet)
   const petType = useOfficeStore((s) => s.petType)
-  const cyclePetType = useOfficeStore((s) => s.cyclePetType)
+  const setPetType = useOfficeStore((s) => s.setPetType)
   // #28: RAF-watchdog stall counter — surfaced as a DEV-only diagnostic chip (see render). Cheap
   // primitive subscription; re-renders only when a stall actually bumps the count (rare).
   const watchdogRestarts = useOfficeStore((s) => s.watchdogRestarts)
@@ -101,6 +102,18 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   )
 
   const [showTest, setShowTest] = useState(false)
+  // #39 consolidation: a ⚙ settings popover holds the cosmetic toggles + notify + dev test, so the
+  // bottom bar stays lean (pause · view · lang · run · ⚙).
+  const [showSettings, setShowSettings] = useState(false)
+  const settingsRef = React.useRef(null)
+  useEffect(() => {
+    if (!showSettings) return
+    const onKey = (e) => { if (e.key === 'Escape') setShowSettings(false) }
+    const onDown = (e) => { if (settingsRef.current && !settingsRef.current.contains(e.target)) setShowSettings(false) }
+    document.addEventListener('keydown', onKey)
+    document.addEventListener('mousedown', onDown)
+    return () => { document.removeEventListener('keydown', onKey); document.removeEventListener('mousedown', onDown) }
+  }, [showSettings])
   const [showInfo, setShowInfo] = useState(() => {
     if (typeof window === 'undefined') return false
     return !localStorage.getItem('office-onboarded')
@@ -231,6 +244,65 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         </div>
       )}
 
+      {/* #39 consolidation: ⚙ settings popover — cosmetic toggles + notifications + dev test, grouped
+          off the bar. Esc / click-outside close (see effect). */}
+      {showSettings && (
+        <div
+          ref={settingsRef}
+          role="menu"
+          aria-label={t('aria.settings', 'Settings')}
+          className="absolute bottom-full right-2 mb-2 w-60 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg p-2 text-xs z-50"
+        >
+          {/* Weather */}
+          <button role="switch" aria-checked={weatherEffects} onClick={toggleWeatherEffects}
+            className="w-full flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/60 text-gray-700 dark:text-gray-200">
+            <span>{t('settings.weather', 'Weather animations')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${weatherEffects ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>{weatherEffects ? t('settings.on', 'On') : t('settings.off', 'Off')}</span>
+          </button>
+          {/* Office pet */}
+          <button role="switch" aria-checked={officePet} onClick={toggleOfficePet}
+            className="w-full flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/60 text-gray-700 dark:text-gray-200">
+            <span>{t('settings.pet', 'Office pet')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${officePet ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300' : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>{officePet ? t('settings.on', 'On') : t('settings.off', 'Off')}</span>
+          </button>
+          {/* Pet skin — only meaningful while the pet is shown */}
+          {officePet && (
+            <div className="px-2 py-1.5 flex items-center justify-between">
+              <span className="text-gray-700 dark:text-gray-200">{t('settings.petSkin', 'Pet skin')}</span>
+              <div role="radiogroup" aria-label={t('settings.petSkin', 'Pet skin')} className="flex gap-1">
+                {PET_TYPES.map((tp) => (
+                  <button key={tp} role="radio" aria-checked={petType === tp} onClick={() => setPetType(tp)}
+                    title={t(`settings.skin.${tp}`, tp)} aria-label={t(`settings.skin.${tp}`, tp)}
+                    className={`px-1.5 py-0.5 rounded border text-[12px] ${petType === tp ? 'bg-amber-100 border-amber-400 dark:bg-amber-900 dark:border-amber-500' : 'border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700'}`}>
+                    {PET_TYPE_EMOJI[tp]}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="border-t border-gray-100 dark:border-gray-700 my-1" />
+          {/* Desktop notifications */}
+          {notifyState !== 'unsupported' && (
+            <div className="w-full flex items-center justify-between px-2 py-1.5 text-gray-700 dark:text-gray-200">
+              <span>{t('settings.notifications', 'Desktop notifications')}</span>
+              {notifyState === 'granted'
+                ? <span className="px-1.5 py-0.5 rounded text-[10px] bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">{t('settings.on', 'On')}</span>
+                : notifyState === 'denied'
+                  ? <span className="px-1.5 py-0.5 rounded text-[10px] bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">{t('settings.blocked', 'Blocked')}</span>
+                  : <button onClick={handleRequestNotify} className="px-1.5 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-[10px] hover:bg-gray-100 dark:hover:bg-gray-700">{t('settings.enable', 'Enable')}</button>}
+            </div>
+          )}
+          {/* Dev test panel toggle */}
+          <button role="switch" aria-checked={showTest} onClick={() => setShowTest((v) => !v)}
+            className="w-full flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700/60 text-gray-700 dark:text-gray-200">
+            <span>{t('settings.testPanel', 'Test panel')}</span>
+            <span className={`px-1.5 py-0.5 rounded text-[10px] font-medium ${showTest ? 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300' : 'bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>{showTest ? t('settings.on', 'On') : t('settings.off', 'Off')}</span>
+          </button>
+          {/* Triangle pointer (right-anchored) */}
+          <div className="absolute top-full right-3 w-0 h-0 border-l-[6px] border-r-[6px] border-t-[6px] border-l-transparent border-r-transparent border-t-white dark:border-t-gray-800" />
+        </div>
+      )}
+
       <div className="flex items-center gap-3">
         <div className="text-gray-500 dark:text-gray-400 font-mono min-w-[42px]">
           {String(hour).padStart(2, '0')}:{String(minute).padStart(2, '0')}
@@ -301,28 +373,6 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         </div>
 
         <div className="flex items-center gap-1.5 shrink-0">
-          {/* Notification permission toggle (#8). 'default' = ask, 'granted' = on,
-              'denied' = blocked, 'unsupported' = no API. Clicking when 'default'
-              triggers requestPermission within a user-gesture (modern browsers
-              require this). After 'granted' / 'denied', the button is a non-action
-              status indicator. */}
-          {notifyState !== 'unsupported' && (
-            <button
-              onClick={handleRequestNotify}
-              disabled={notifyState === 'granted' || notifyState === 'denied'}
-              className={`px-2 py-1 rounded border transition-colors text-[10px] ${
-                notifyState === 'granted'
-                  ? 'border-emerald-400 text-emerald-600 dark:text-emerald-300 bg-emerald-50 dark:bg-emerald-900/30 cursor-default'
-                  : notifyState === 'denied'
-                    ? 'border-red-400 text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-900/30 cursor-default'
-                    : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
-              }`}
-              title={t(`notify.tooltip.${notifyState}`, notifyState === 'granted' ? 'Notifications on' : notifyState === 'denied' ? 'Notifications blocked' : 'Enable notifications')}
-              aria-label={t(`notify.aria.${notifyState}`, notifyState === 'granted' ? 'Notifications enabled' : notifyState === 'denied' ? 'Notifications denied' : 'Enable desktop notifications')}
-            >
-              {notifyState === 'granted' ? '🔔' : notifyState === 'denied' ? '🔕' : '🔔'}
-            </button>
-          )}
           <button onClick={cycleLang} className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-300 text-[10px]" title={`${t('aria.switchLang', 'Switch language')} (L)`} aria-label={t('aria.switchLang', 'Switch language')}>
             {nextLangLabel}
           </button>
@@ -338,47 +388,20 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
           >
             ☰
           </button>
-          {/* #45: weather-animation toggle. ON = animated rain/clouds; OFF = static weather
-              (CPU-friendly for low-end devices / IDE webviews). Persisted per user. */}
-          <button
-            onClick={toggleWeatherEffects}
-            className={`px-2 py-1 rounded border transition-colors ${weatherEffects ? 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800' : 'bg-amber-100 border-amber-400 text-amber-700 dark:bg-amber-900 dark:text-amber-300'}`}
-            title={weatherEffects ? t('aria.weatherOff', 'Disable weather animations') : t('aria.weatherOn', 'Enable weather animations')}
-            aria-label={weatherEffects ? t('aria.weatherOff', 'Disable weather animations') : t('aria.weatherOn', 'Enable weather animations')}
-            aria-pressed={!weatherEffects}
-          >
-            {weatherEffects ? '🌧' : '🌤'}
-          </button>
-          {/* #39: office-pet toggle. Persisted; OFF removes the pet entirely. */}
-          <button
-            onClick={toggleOfficePet}
-            className={`px-2 py-1 rounded border transition-colors ${officePet ? 'bg-amber-100 border-amber-400 text-amber-700 dark:bg-amber-900 dark:text-amber-300' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-            title={officePet ? t('aria.petOff', 'Hide office pet') : t('aria.petOn', 'Show office pet')}
-            aria-label={officePet ? t('aria.petOff', 'Hide office pet') : t('aria.petOn', 'Show office pet')}
-            aria-pressed={officePet}
-          >
-            🐾
-          </button>
-          {/* #39 types: cycle the pet skin (cosmetic). Only meaningful while the pet is shown. */}
-          {officePet && (
-            <button
-              onClick={cyclePetType}
-              className="px-2 py-1 rounded border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-              title={t('aria.petType', 'Change pet')}
-              aria-label={t('aria.petType', 'Change pet')}
-            >
-              {PET_TYPE_EMOJI[petType] || PET_TYPE_EMOJI.cat}
-            </button>
-          )}
           <button onClick={triggerWorkflow} className="px-2 py-1 rounded bg-blue-500 text-white hover:bg-blue-600 transition-colors" title={t('aria.runWorkflow', 'Run workflow animation')}>
             {t('ui.run')}
           </button>
+          {/* #39 consolidation: ⚙ settings — cosmetic toggles + notifications + dev test live here so
+              the bar stays lean. */}
           <button
-            onClick={() => setShowTest(!showTest)}
-            className={`px-2 py-1 rounded border transition-colors ${showTest ? 'bg-orange-100 border-orange-400 text-orange-700 dark:bg-orange-900 dark:text-orange-300' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
-            title={t('aria.toggleTest', 'Toggle test controls')}
+            onClick={() => setShowSettings((v) => !v)}
+            className={`px-2 py-1 rounded border transition-colors ${showSettings ? 'bg-gray-200 border-gray-400 text-gray-700 dark:bg-gray-700 dark:text-gray-200' : 'border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+            title={t('aria.settings', 'Settings')}
+            aria-label={t('aria.settings', 'Settings')}
+            aria-haspopup="menu"
+            aria-expanded={showSettings}
           >
-            {t('ui.test')}
+            ⚙
           </button>
           <button
             onClick={() => setShowInfo(!showInfo)}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -293,7 +293,20 @@
     "petOff": "Hide office pet",
     "petOn": "Show office pet",
     "petType": "Change pet",
+    "settings": "Settings",
     "info": "Info"
+  },
+  "settings": {
+    "weather": "Weather animations",
+    "pet": "Office pet",
+    "petSkin": "Pet skin",
+    "notifications": "Desktop notifications",
+    "testPanel": "Test panel",
+    "on": "On",
+    "off": "Off",
+    "blocked": "Blocked",
+    "enable": "Enable",
+    "skin": { "cat": "Cat", "vacuum": "Robot vacuum", "dog": "Dog" }
   },
   "time": {
     "now": "now",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -293,7 +293,20 @@
     "petOff": "隱藏辦公室寵物",
     "petOn": "顯示辦公室寵物",
     "petType": "更換寵物",
+    "settings": "設定",
     "info": "資訊"
+  },
+  "settings": {
+    "weather": "天氣動畫",
+    "pet": "辦公室寵物",
+    "petSkin": "寵物造型",
+    "notifications": "桌面通知",
+    "testPanel": "測試面板",
+    "on": "開",
+    "off": "關",
+    "blocked": "已封鎖",
+    "enable": "啟用",
+    "skin": { "cat": "貓", "vacuum": "掃地機器人", "dog": "狗" }
   },
   "time": {
     "now": "剛剛",

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -626,6 +626,12 @@ export const useOfficeStore = create((set) => ({
     try { if (typeof window !== 'undefined') localStorage.setItem('office-pet-type', next) } catch {}
     return { petType: next }
   }),
+  // #39 types: select a specific skin (settings popover radiogroup). Validated vs PET_TYPES; persisted.
+  setPetType: (type) => set((s) => {
+    if (!PET_TYPES.includes(type) || type === s.petType) return s
+    try { if (typeof window !== 'undefined') localStorage.setItem('office-pet-type', type) } catch {}
+    return { petType: type }
+  }),
   triggerWorkflow: () => set({ showWorkflow: true }),
   endWorkflow: () => set({ showWorkflow: false }),
 

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -139,6 +139,16 @@ describe('store — officePet toggle (#39)', () => {
     expect(localStorage.getItem('office-pet')).toBe('on')
   })
 
+  it('setPetType selects a specific skin + persists; ignores invalid (#39 settings)', () => {
+    localStorage.removeItem('office-pet-type')
+    useOfficeStore.setState({ petType: 'cat' })
+    useOfficeStore.getState().setPetType('dog')
+    expect(useOfficeStore.getState().petType).toBe('dog')
+    expect(localStorage.getItem('office-pet-type')).toBe('dog')
+    useOfficeStore.getState().setPetType('bogus') // ignored
+    expect(useOfficeStore.getState().petType).toBe('dog')
+  })
+
   it('cyclePetType cycles + persists the skin (#39 types)', () => {
     localStorage.removeItem('office-pet-type')
     useOfficeStore.setState({ petType: 'cat' })


### PR DESCRIPTION
UX consolidation. The bottom control bar had grown to ~10 buttons mixing run-state, cosmetics, dev, and help. Per a UX-panel proposal, the rarely-used controls move into a ⚙ settings popover so the bar stays lean.

- **Bar now**: language · pause · roster (☰) · Run · ⚙ · info(?). **Removed from the bar**: weather, office-pet on/off, pet-type, notifications, Test.
- **⚙ popover**: Weather + Office pet as `role=switch` rows; Pet skin as a `role=radiogroup` (cat/vacuum/dog, new store `setPetType`); Desktop notifications; Test panel toggle.
- **a11y**: `aria-haspopup`/`aria-expanded` on ⚙; `role=menu/switch/radiogroup`; **Esc + click-outside** close. i18n: `aria.settings` + a `settings.*` block in en + zh-TW (focus-management deferred to a follow-up).
- **No data-path change**: same store actions + localStorage keys; the `showTest` panel still renders below (now toggled from the popover).

**Evidence:** +1 test (`setPetType` validate/persist). Suite **1331 passed**; build clean. Reviewer → PASS (no functional regression; every moved control keeps its handler+selector+persistence; no orphaned refs; panel mode untouched; i18n parity). DEV live-verified: ⚙ opens/closes (Esc); weather/pet bar buttons gone; popover toggles + skin radio work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
