### PR TITLE
refactor(#39): useTransientFlag hook, de-race run-to-desk, retro polish

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T10:05:00Z
-- **Update Sequence**: 41
+- **Last Updated**: 2026-06-08T10:50:00Z
+- **Update Sequence**: 42
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,14 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-retro-cleanup-pet-2026-06-08 (debt cleanup + polish from the 4-perspective retro)
+
+- A 4-perspective retro (engineering · game-design · user · product) reviewed the day's pet work. Acted on the findings (debt + flaw fixes; NO feature cuts, per owner). Two PRs:
+- **PR #68 (deflake)**: seeded the `avoidOverlap` fan-out RNG (mulberry32) in `tests/agentSeparationInvariants.test.js` — kills the intermittent `~15 < 20` CI failure that hit ~3 PRs (`avoidOverlap` uses `Math.random` for push direction). Deterministic 5/5.
+- **PR #69 (refactor/polish)**: new `useTransientFlag(ms)` hook (timer owned by the flag + fire-nonce) STRUCTURALLY kills the recurring "stuck transient" bug class — celebrate/alert/petted migrated onto it. Run-to-desk de-raced (documented invariant: alert is non-mobile → wander interval cleared → sole pos writer). Polish: relief celebrate beat on blocker-clear (honest); confetti deduped to one channel (removed per-sprite ✦); click-♥ gated to calm base modes; vacuum hide tilt deepened.
+- **Review**: acx-reviewer → PASS (honesty/de-race/dedup all hold; hide-on-blocker untouched). Known gap (env limitation): no jsdom → the hook's effect behavior can't be unit-tested here; verified LIVE (alert fires + auto-clears, no stuck). Suite **1331 passed**; build clean.
+- **Retro priority signal (recorded)**: user + product both named **blocked-reason tags (#29)** the highest-user-value next item; the pet is now feature-complete and should be FROZEN.
 
 ### Ship-feat-controlpanel-settings-popover-2026-06-08 (UX — ⚙ settings popover consolidates the control bar)
 

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -3,6 +3,7 @@ import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor } from '../systems/movementSystem.js'
 import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, PET_MODES } from '../systems/petState.js'
 import PetSprite from './petSprites.jsx'
+import { useTransientFlag } from './useTransientFlag.js'
 
 // ─── Office pet — a signal-driven barometer (#39 / AVO-121) ─────────────────────────────────────
 // A small ambient cat whose MODE is an honest readout of real aggregate office state (see
@@ -50,34 +51,26 @@ export default function OfficePet() {
   // logic is type-independent; only the FEEL changes.
   const grammar = petMotionGrammar(petType)
 
-  // ── Two transient event-edge overlays (v2), each a short pose beat over the honest base mode ──
-  // celebrate: a real positive event (eureka/deploy-success) — reuses officeLife's event surface.
-  const [celebrate, setCelebrate] = useState(false)
+  // ── Transient event-edge beats over the honest base mode. All three use useTransientFlag, whose
+  //    auto-clear timer is owned by the flag itself — structurally immune to the "stuck transient"
+  //    bug class these beats hit (and patched locally) three times before. ──
+  // celebrate: a real positive event — a deploy/eureka, OR a blocker just CLEARED (the "relieved"
+  // beat the pet was missing after a run-to-desk). Both are honest positive signals.
+  const [celebrate, fireCelebrate] = useTransientFlag(2500)
   useEffect(() => {
-    if (activeEventId === 'eureka' || activeEventId === 'deploy-success') {
-      setCelebrate(true)
-      const t = setTimeout(() => setCelebrate(false), 2500)
-      return () => clearTimeout(t)
-    }
-    setCelebrate(false) // event cleared early → drop it so it can't stick (cleanup cancels the reset)
-  }, [activeEventId])
+    if (activeEventId === 'eureka' || activeEventId === 'deploy-success') fireCelebrate()
+  }, [activeEventId, fireCelebrate])
 
-  // alert: a NEW blocker just appeared (blockedCount rose) — ears-up "noticing" beat, then it settles
-  // back into hide (base is already hide while blocked). Marks a real new-blocker EDGE, not a feeling.
-  // Two effects so the auto-clear timer is owned by `alert` itself (NOT by blockedCount): a rapidly
-  // oscillating blockedCount would otherwise keep cancelling the reset and leave alert stuck on.
-  const [alert, setAlert] = useState(false)
+  // alert: a NEW blocker appeared (blockedCount rose) — ears-up "noticing" beat that settles back into
+  // hide. A blocker CLEARING (count fell to 0) fires the relief celebrate above.
+  const [alert, fireAlert] = useTransientFlag(2500)
   const prevBlockedRef = useRef(blockedCount)
   useEffect(() => {
-    const rose = blockedCount > prevBlockedRef.current
+    const prev = prevBlockedRef.current
     prevBlockedRef.current = blockedCount
-    if (rose) setAlert(true)
-  }, [blockedCount])
-  useEffect(() => {
-    if (!alert) return
-    const t = setTimeout(() => setAlert(false), 2500)
-    return () => clearTimeout(t)
-  }, [alert])
+    if (blockedCount > prev) fireAlert()
+    else if (blockedCount === 0 && prev > 0) fireCelebrate() // a real blocker cleared → relief
+  }, [blockedCount, fireAlert, fireCelebrate])
   // keep the latest blocked-agent position handy for the run-to-desk effect (below, after pos exists)
   const blockedPosRef = useRef(blockedAgentPos)
   useEffect(() => { blockedPosRef.current = blockedAgentPos }, [blockedAgentPos])
@@ -86,13 +79,8 @@ export default function OfficePet() {
   const mode = resolvePetMode({ base: baseMode, alert, celebrate })
 
   // #39 delight: click-to-pet — a purely cosmetic, user-initiated ♥ beat (no mode/state change, never
-  // affects the honest reading). Auto-clears after 1s.
-  const [petted, setPetted] = useState(false)
-  useEffect(() => {
-    if (!petted) return
-    const t = setTimeout(() => setPetted(false), 1000)
-    return () => clearTimeout(t)
-  }, [petted])
+  // affects the honest reading). Gated in render so it can't co-occur with a real-signal beat.
+  const [petted, firePetted] = useTransientFlag(1000)
 
   const [pos, setPos] = useState(START)
   const [facing, setFacing] = useState(1)
@@ -115,6 +103,9 @@ export default function OfficePet() {
   // agent's desk so the pet POINTS AT a real blocker (motion = information; the honest beat made
   // legible). With multiple blockers it targets the first one found — still always a REAL blocker, so
   // honesty holds. Reads the store's published agent.position only — no movement-system / HOME_POSITIONS coupling.
+  // De-race: this fires only while `alert` is true, and `petIsMobile(ALERT)` is false → the wander
+  // interval effect above has already cleared its timer (its `mobile` guard), so this is the SOLE
+  // writer of `pos`/`posRef` during the beat — no contention with the random-wander setInterval.
   useEffect(() => {
     if (!alert || !officePet) return
     const raw = blockedPosRef.current
@@ -154,7 +145,7 @@ export default function OfficePet() {
       transform={`translate(${pos.x}, ${pos.y})`}
       style={reducedMotion ? { cursor: 'pointer' } : { transition: `transform ${glideMs}ms ${grammar.easing}`, cursor: 'pointer' }}
       pointerEvents="auto"
-      onClick={() => setPetted(true)}
+      onClick={firePetted}
     >
       <g transform={`scale(${facing * petScale}, ${petScale})`} style={hop}>
         <g key={mode} style={pop}>
@@ -168,7 +159,9 @@ export default function OfficePet() {
             ))}
           </g>
         )}
-        {petted && (
+        {/* click-♥ shows ONLY in a calm/neutral base mode so it can never compete with — or visually
+            contradict — a real-signal beat (a ♥ over a hiding/alerting pet would read dishonestly). */}
+        {petted && (mode === PET_MODES.WANDER || mode === PET_MODES.NAP || mode === PET_MODES.EXCITED) && (
           <text x={0} y={-9} fontSize="6" textAnchor="middle" fill="#E2588B" aria-hidden="true"
             style={reducedMotion ? undefined : { animation: 'pet-heart 1s ease-out both' }}>♥</text>
         )}

--- a/src/components/petSprites.jsx
+++ b/src/components/petSprites.jsx
@@ -65,7 +65,6 @@ function CatSprite({ mode, reducedMotion }) {
         <path d="M 8.8 -5 l 0.6 -3 l -2.4 1.6 Z" fill={fur} />
         <path d="M 4 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
         <path d="M 6.8 -2.4 q 0.8 0.7 1.6 0" stroke={dark} strokeWidth="0.6" fill="none" />
-        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
       </g>
     )
   }
@@ -103,8 +102,8 @@ function VacuumSprite({ mode, reducedMotion }) {
   const blink = (mode === PET_MODES.ALERT) && !reducedMotion
   // Machine grammar for legible per-mode SILHOUETTES (not LED-only): nap docks + dims; wander shows a
   // sweep trail; excited adds a dust puff; hide tilts + dims (backed off). All static (calm).
-  const tilt = mode === PET_MODES.HIDE ? -12 : 0
-  const dim = (mode === PET_MODES.NAP || mode === PET_MODES.HIDE) ? 0.72 : 1
+  const tilt = mode === PET_MODES.HIDE ? -18 : 0 // more visible "backed off" lean (game-feel polish)
+  const dim = (mode === PET_MODES.NAP || mode === PET_MODES.HIDE) ? 0.66 : 1
   const sweeping = mode === PET_MODES.WANDER || mode === PET_MODES.EXCITED
   const puffing = mode === PET_MODES.EXCITED
   return (
@@ -135,7 +134,6 @@ function VacuumSprite({ mode, reducedMotion }) {
       <circle cx={0} cy={0} r={1.5} fill={led} opacity={mode === PET_MODES.HIDE ? 0.6 : 0.95}
         style={blink ? { animation: 'pet-snooze 0.8s steps(2,end) infinite' } : undefined} />
       {mode === PET_MODES.ALERT && <text x={6} y={-5} fontSize="6" fill="#D98324" opacity="0.9">!</text>}
-      {mode === PET_MODES.CELEBRATE && <text x={7} y={-5} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>}
     </g>
   )
 }
@@ -196,9 +194,7 @@ function DogSprite({ mode, reducedMotion }) {
         <circle cx={6} cy={-2} r={4.2} fill={fur} />
         <path d="M 3 -3.6 q -2.2 1 -1.2 3.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />
         <ellipse cx={8.6} cy={-1.4} rx={1.6} ry={1.1} fill={dark} />
-        <path d="M 8.4 -0.4 l 0 2" stroke="#D9536B" strokeWidth="1" strokeLinecap="round" />{/* tongue */}
-        <text x={9} y={-6} fontSize="6" fill="#E0A800" opacity="0.95">✦</text>
-      </g>
+        <path d="M 8.4 -0.4 l 0 2" stroke="#D9536B" strokeWidth="1" strokeLinecap="round" />{/* tongue */}      </g>
     )
   }
   const excited = mode === PET_MODES.EXCITED

--- a/src/components/useTransientFlag.js
+++ b/src/components/useTransientFlag.js
@@ -1,0 +1,20 @@
+import { useState, useEffect, useCallback } from 'react'
+
+// useTransientFlag(ms) → [active, fire]
+//
+// A boolean that, once `fire()`d, stays true for `ms` then auto-clears. The clear timer is owned by
+// the flag itself (one effect keyed on the flag + a fire-nonce), so re-firing or unrelated re-renders
+// can NEVER leave it stuck on — that's the recurring "stuck transient" bug class the office pet hit
+// three times (celebrate/alert/petted) and patched locally each time. Firing again while active
+// RESTARTS the window (the nonce changes → the effect re-runs, clearing the old timeout first).
+export function useTransientFlag(ms) {
+  const [active, setActive] = useState(false)
+  const [nonce, setNonce] = useState(0)
+  const fire = useCallback(() => { setActive(true); setNonce((n) => n + 1) }, [])
+  useEffect(() => {
+    if (!active) return
+    const t = setTimeout(() => setActive(false), ms)
+    return () => clearTimeout(t)
+  }, [active, nonce, ms])
+  return [active, fire]
+}


### PR DESCRIPTION
Acts on the 4-perspective retro (engineering + game-design findings). Debt cleanup + flaw fixes — **no feature cuts** (per owner).

### Debt (engineering retro)
- **`useTransientFlag(ms)` hook** — the auto-clear timer is owned by the flag itself (flag + fire-nonce), STRUCTURALLY killing the recurring "stuck transient" bug class. celebrate / alert / petted all migrate onto it (were 3 bespoke useState+useEffect+setTimeout blocks patched locally each time).
- **run-to-desk de-raced** — documented + relies on the enforced invariant that alert is non-mobile, so the wander interval is already cleared → the run effect is the sole `pos` writer.

### Polish (game-design retro)
- **Relief beat** — a blocker CLEARING (`blockedCount` → 0) fires the celebrate beat: the honest "I checked, now relieved" arc the run-to-desk lacked.
- **Confetti deduped** to ONE channel (removed the per-sprite ✦; the rising overlay stays).
- **click-♥ gated** to calm base modes so it can never co-occur with / contradict a real-signal beat.
- **Vacuum hide** pose: deeper tilt + dim so "backed off" reads at the larger pet size.

**Evidence:** suite **1331 passed**; build clean. Reviewer → PASS (honesty/de-race/dedup hold; hide-on-blocker untouched). DEV live-verified: alert fires + auto-clears (no stuck); ♥ shows in wander, gated off during hide. Known gap: no jsdom in this env → the hook effect cannot be unit-tested here (repo uses pure-logic + live verification); behavior verified live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
