### PR TITLE
refactor: extract ControlPanel pure label helpers to a testable module

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T10:50:00Z
-- **Update Sequence**: 42
+- **Last Updated**: 2026-06-08T11:10:00Z
+- **Update Sequence**: 43
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -139,6 +139,7 @@
 - **PR #68 (deflake)**: seeded the `avoidOverlap` fan-out RNG (mulberry32) in `tests/agentSeparationInvariants.test.js` — kills the intermittent `~15 < 20` CI failure that hit ~3 PRs (`avoidOverlap` uses `Math.random` for push direction). Deterministic 5/5.
 - **PR #69 (refactor/polish)**: new `useTransientFlag(ms)` hook (timer owned by the flag + fire-nonce) STRUCTURALLY kills the recurring "stuck transient" bug class — celebrate/alert/petted migrated onto it. Run-to-desk de-raced (documented invariant: alert is non-mobile → wander interval cleared → sole pos writer). Polish: relief celebrate beat on blocker-clear (honest); confetti deduped to one channel (removed per-sprite ✦); click-♥ gated to calm base modes; vacuum hide tilt deepened.
 - **Review**: acx-reviewer → PASS (honesty/de-race/dedup all hold; hide-on-blocker untouched). Known gap (env limitation): no jsdom → the hook's effect behavior can't be unit-tested here; verified LIVE (alert fires + auto-clears, no stuck). Suite **1331 passed**; build clean.
+- **PR #70 (ControlPanel split)**: extracted the pure label helpers (taskChipLabel/blockedReasonLabel/formatTokens/agentLineLabel/shouldShowWatchdogDiag) out of the ~460-line ControlPanel.jsx into a testable `controlPanelLabels.js` (re-exported for back-compat); +7 tests for previously-untested formatters. Completes the engineering-retro top-3 debt items.
 - **Retro priority signal (recorded)**: user + product both named **blocked-reason tags (#29)** the highest-user-value next item; the pet is now feature-complete and should be FROZEN.
 
 ### Ship-feat-controlpanel-settings-popover-2026-06-08 (UX — ⚙ settings popover consolidates the control bar)

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -1,61 +1,15 @@
 import React, { useState, useEffect } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useOfficeStore, STATUS_COLORS } from '../systems/store'
-import { classifyTask } from '../systems/classify'
 import { behaviorLabel, charName, t, setLocale, availableLocales, useLocale, eventName } from '../i18n'
 import { requestNotificationPermission, getNotificationState } from '../inference/desktopNotifier'
 import { PET_TYPES } from '../systems/petState.js'
 
 const statusOptions = ['idle', 'working', 'blocked', 'done']
 
-// Collapse a raw tool/task name into the same short chip the character's
-// TaskLabel (AVO-103) shows, so the control panel never displays the ugly
-// `mcp__Server__tool` wire form while the SVG label above the head shows the
-// collapsed `Server::tool`. Built-ins stay short (`Bash`), MCP tools collapse
-// to `server::tool`, unknowns are truncated. Returns null for an empty task so
-// callers can fall back to the localized status label.
-export function taskChipLabel(task) {
-  if (!task) return null
-  return classifyTask(task).visualLabel
-}
-
-// AVO-110 (lightweight): for a blocked agent the human `label` carries the
-// failure reason the hook detected ("❌ npm test failed"), which is far more
-// useful at a glance than the bare tool name (`Bash`). Surface it — truncated
-// for the compact status bar — so the persistent status line answers "why is
-// this agent stuck?" without needing to open the inspector. Returns null for
-// any non-blocked / label-less agent so callers fall back to the tool chip.
-const BLOCKED_REASON_CAP = 28
-export function blockedReasonLabel(ext) {
-  if (!ext || ext.status !== 'blocked' || !ext.label) return null
-  const l = ext.label
-  return l.length > BLOCKED_REASON_CAP ? l.slice(0, BLOCKED_REASON_CAP - 1) + '…' : l
-}
-
-// AVO-108: compact token formatter — 604937 → "605k", 1240000 → "1.2M", 842 → "842".
-export function formatTokens(n) {
-  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return '0'
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M'
-  if (n >= 1_000) return Math.round(n / 1_000) + 'k'
-  return String(Math.round(n))
-}
-
-// The single label a ControlPanel agent row shows: blocked reason wins, then the
-// collapsed tool chip, then the localized status word. `t` is the i18n lookup.
-export function agentLineLabel(ext, t) {
-  if (!ext) return null
-  return blockedReasonLabel(ext)
-    || taskChipLabel(ext.task)
-    || t(`statusLabels.${ext.status}`, ext.status)
-}
-
-// #28 — DEV-only diagnostics gate for the RAF-watchdog restart counter. Shown only in dev builds AND
-// only once a stall has actually happened (count > 0), so it's invisible at rest and zero-cost in
-// production (`import.meta.env.DEV` is a compile-time constant → the render branch is dead-code-
-// eliminated from the prod bundle). Pure so it can be unit-tested without a DOM.
-export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV) {
-  return !!isDev && typeof count === 'number' && count > 0
-}
+// Pure label/format helpers were extracted to controlPanelLabels.js (testable without this JSX
+// module). Re-exported here for back-compat with existing importers (NarrowRoster, tests).
+export { taskChipLabel, blockedReasonLabel, formatTokens, agentLineLabel, shouldShowWatchdogDiag } from './controlPanelLabels.js'
 
 // #39 types: emoji shown on the "change pet" button per current skin.
 const PET_TYPE_EMOJI = { cat: '🐈', vacuum: '🤖', dog: '🐕' }

--- a/src/components/controlPanelLabels.js
+++ b/src/components/controlPanelLabels.js
@@ -1,0 +1,48 @@
+// Pure label/format helpers used by ControlPanel (and NarrowRoster). Extracted out of the
+// ControlPanel.jsx god-component so they're unit-testable WITHOUT importing the React/JSX module
+// (engineering-retro debt cleanup). No React here — plain functions of plain data.
+import { classifyTask } from '../systems/classify'
+
+// Collapse a raw tool/task name into the same short chip the character's TaskLabel (AVO-103) shows,
+// so the panel never displays the ugly `mcp__Server__tool` wire form. Built-ins stay short (`Bash`),
+// MCP tools collapse to `server::tool`, unknowns are truncated. Returns null for an empty task so
+// callers can fall back to the localized status label.
+export function taskChipLabel(task) {
+  if (!task) return null
+  return classifyTask(task).visualLabel
+}
+
+// AVO-110: for a blocked agent the human `label` carries the failure reason the hook detected
+// ("❌ npm test failed"), far more useful at a glance than the bare tool name. Surface it — truncated
+// for the compact status bar. Returns null for any non-blocked / label-less agent.
+const BLOCKED_REASON_CAP = 28
+export function blockedReasonLabel(ext) {
+  if (!ext || ext.status !== 'blocked' || !ext.label) return null
+  const l = ext.label
+  return l.length > BLOCKED_REASON_CAP ? l.slice(0, BLOCKED_REASON_CAP - 1) + '…' : l
+}
+
+// AVO-108: compact token formatter — 604937 → "605k", 1240000 → "1.2M", 842 → "842".
+export function formatTokens(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n) || n < 0) return '0'
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'M'
+  if (n >= 1_000) return Math.round(n / 1_000) + 'k'
+  return String(Math.round(n))
+}
+
+// The single label a ControlPanel agent row shows: blocked reason wins, then the collapsed tool
+// chip, then the localized status word. `t` is the i18n lookup.
+export function agentLineLabel(ext, t) {
+  if (!ext) return null
+  return blockedReasonLabel(ext)
+    || taskChipLabel(ext.task)
+    || t(`statusLabels.${ext.status}`, ext.status)
+}
+
+// #28 — DEV-only diagnostics gate for the RAF-watchdog restart counter. Shown only in dev builds AND
+// only once a stall has happened (count > 0), so it's invisible at rest and zero-cost in production
+// (`import.meta.env.DEV` is a compile-time constant → the render branch is dead-code-eliminated from
+// the prod bundle). Pure so it can be unit-tested without a DOM.
+export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV) {
+  return !!isDev && typeof count === 'number' && count > 0
+}

--- a/tests/controlPanelLabels.test.js
+++ b/tests/controlPanelLabels.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { formatTokens, blockedReasonLabel, agentLineLabel, taskChipLabel } from '../src/components/controlPanelLabels.js'
+
+// These pure helpers were extracted out of ControlPanel.jsx (god-component cleanup) so they can be
+// tested without importing the React module. `formatTokens`/`blockedReasonLabel`/`agentLineLabel`
+// had no direct coverage before.
+
+describe('formatTokens (AVO-108)', () => {
+  it('formats by magnitude', () => {
+    expect(formatTokens(842)).toBe('842')
+    expect(formatTokens(604937)).toBe('605k')
+    expect(formatTokens(1_240_000)).toBe('1.2M')
+    expect(formatTokens(1_000_000)).toBe('1M') // strips the .0
+  })
+  it('guards non-numeric / negative → "0"', () => {
+    expect(formatTokens(undefined)).toBe('0')
+    expect(formatTokens(NaN)).toBe('0')
+    expect(formatTokens(-5)).toBe('0')
+    expect(formatTokens('5')).toBe('0')
+  })
+})
+
+describe('blockedReasonLabel (AVO-110)', () => {
+  it('surfaces the blocked agent\'s reason label, truncated at 28', () => {
+    expect(blockedReasonLabel({ status: 'blocked', label: '❌ npm test failed' })).toBe('❌ npm test failed')
+    const long = blockedReasonLabel({ status: 'blocked', label: 'x'.repeat(40) })
+    expect(long).toHaveLength(28)
+    expect(long.endsWith('…')).toBe(true)
+  })
+  it('returns null for non-blocked / label-less agents', () => {
+    expect(blockedReasonLabel({ status: 'working', label: 'whatever' })).toBeNull()
+    expect(blockedReasonLabel({ status: 'blocked' })).toBeNull()
+    expect(blockedReasonLabel(null)).toBeNull()
+  })
+})
+
+describe('agentLineLabel — blocked reason › tool chip › status word', () => {
+  const t = (key, fb) => fb // identity i18n stub
+  it('blocked reason wins', () => {
+    expect(agentLineLabel({ status: 'blocked', label: '❌ failed', task: 'Bash' }, t)).toBe('❌ failed')
+  })
+  it('falls back to the tool chip, then the status word', () => {
+    expect(agentLineLabel({ status: 'working', task: 'Bash' }, t)).toBe(taskChipLabel('Bash'))
+    expect(agentLineLabel({ status: 'working', task: null }, t)).toBe('working')
+  })
+  it('null ext → null', () => {
+    expect(agentLineLabel(null, t)).toBeNull()
+  })
+})

--- a/tests/watchdogDiag.test.js
+++ b/tests/watchdogDiag.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { shouldShowWatchdogDiag } from '../src/components/ControlPanel.jsx'
+import { shouldShowWatchdogDiag } from '../src/components/controlPanelLabels.js'
 
 // #28 — the RAF-watchdog restart counter (store.watchdogRestarts) is surfaced as a DEV-only
 // diagnostic chip, shown only once a stall has actually happened (count > 0). Pure gate so it's


### PR DESCRIPTION
refactor: extract ControlPanel pure label helpers to a testable module

The last engineering-retro debt item: ControlPanel.jsx was a ~460-line god-component that
also exported pure helpers, forcing tests to import the whole JSX module. Move taskChipLabel,
blockedReasonLabel, formatTokens, agentLineLabel, shouldShowWatchdogDiag into a plain
controlPanelLabels.js (no React), re-exported from ControlPanel for back-compat (NarrowRoster
+ existing imports unchanged). Drops the now-unused classifyTask import from ControlPanel.

Adds tests/controlPanelLabels.test.js (+7) covering formatTokens / blockedReasonLabel /
agentLineLabel — previously untested. watchdogDiag.test now imports the pure module.
Suite 1338 passed; build clean. Pure refactor, no behavior change.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
