### PR TITLE
hotfix: ControlPanel crash on render (re-export-only left helpers undefined)

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -8,8 +8,12 @@ import { PET_TYPES } from '../systems/petState.js'
 const statusOptions = ['idle', 'working', 'blocked', 'done']
 
 // Pure label/format helpers were extracted to controlPanelLabels.js (testable without this JSX
-// module). Re-exported here for back-compat with existing importers (NarrowRoster, tests).
-export { taskChipLabel, blockedReasonLabel, formatTokens, agentLineLabel, shouldShowWatchdogDiag } from './controlPanelLabels.js'
+// module). IMPORT them for this component's own render use, AND re-export for back-compat with
+// existing importers (NarrowRoster, tests). NOTE: `export { x } from './m'` alone re-exports without
+// binding x into THIS module's scope — the component's internal calls would then crash with
+// "x is not defined" (regression caught only by actually loading the page).
+import { taskChipLabel, blockedReasonLabel, formatTokens, agentLineLabel, shouldShowWatchdogDiag } from './controlPanelLabels.js'
+export { taskChipLabel, blockedReasonLabel, formatTokens, agentLineLabel, shouldShowWatchdogDiag }
 
 // #39 types: emoji shown on the "change pet" button per current skin.
 const PET_TYPE_EMOJI = { cat: '🐈', vacuum: '🤖', dog: '🐕' }


### PR DESCRIPTION
hotfix: ControlPanel crashed on render — re-export-only left helpers undefined in scope

PR #70 moved the pure label helpers to controlPanelLabels.js and used
`export { ... } from ./controlPanelLabels.js`. That re-exports them to OTHER modules but
does NOT bind them into ControlPanel`s own scope — and the component body calls
shouldShowWatchdogDiag / taskChipLabel / blockedReasonLabel / formatTokens / agentLineLabel
at render. Result: "shouldShowWatchdogDiag is not defined" → ControlPanel threw → the whole
app fell back to the ErrorBoundary ("Something went wrong") on EVERY load.

Fix: import the helpers (binds them locally) AND re-export them.

Why CI/tests/build all stayed green: the suite runs in node with no jsdom, so NOTHING
renders ControlPanel; the build does not execute render. The crash was only observable by
actually loading the page (caught via a headless-Playwright screenshot — preview_screenshot
hangs here). Verified fixed: page renders the office svg, 0 console errors.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
