### PR TITLE
feat(#39): type-independent mode emote — pet states legible at a glance

### DIFF
--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor } from '../systems/movementSystem.js'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, PET_MODES } from '../systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, modeEmote, PET_MODES } from '../systems/petState.js'
 import PetSprite from './petSprites.jsx'
 import { useTransientFlag } from './useTransientFlag.js'
 
@@ -151,6 +151,14 @@ export default function OfficePet() {
         <g key={mode} style={pop}>
           <PetSprite type={petType} mode={mode} reducedMotion={reducedMotion} />
         </g>
+        {/* Type-independent mode emote — makes the state legible at a glance for ANY skin (the poses
+            alone are subtle at ~30px). Static (no animation). Counter-flipped so the glyph reads
+            upright whichever way the pet faces. */}
+        {modeEmote(mode) && (
+          <g transform={`scale(${facing}, 1)`} pointerEvents="none" aria-hidden="true">
+            <text x={0} y={-12} fontSize="6" textAnchor="middle" opacity="0.92">{modeEmote(mode)}</text>
+          </g>
+        )}
         {showConfetti && (
           <g pointerEvents="none" aria-hidden="true">
             {[-6, 0, 6].map((dx, i) => (

--- a/src/components/petSprites.jsx
+++ b/src/components/petSprites.jsx
@@ -18,10 +18,7 @@ function CatSprite({ mode, reducedMotion }) {
         <circle cx={-6} cy={-1} r={3.6} fill={fur} />
         <path d="M -8.6 -3 l 1.4 -2.2 l 1.4 2.2 Z" fill={fur} />
         <path d="M -7.4 -1.2 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
-        <path d="M 8 0 q 5 0 4 -4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />
-        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
-          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
-      </g>
+        <path d="M 8 0 q 5 0 4 -4" stroke={fur} strokeWidth="2.4" fill="none" strokeLinecap="round" />      </g>
     )
   }
   if (mode === PET_MODES.HIDE) {
@@ -47,9 +44,7 @@ function CatSprite({ mode, reducedMotion }) {
         <path d="M -0.6 -6.4 l -0.4 -3.4 l 2.2 1.8 Z" fill={fur} />
         <path d="M 4.6 -6.4 l 0.4 -3.4 l -2.2 1.8 Z" fill={fur} />
         <circle cx={0.6} cy={-4.2} r={1} fill={dark} />
-        <circle cx={3.4} cy={-4.2} r={1} fill={dark} />
-        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
-      </g>
+        <circle cx={3.4} cy={-4.2} r={1} fill={dark} />      </g>
     )
   }
   if (mode === PET_MODES.CELEBRATE) {
@@ -132,9 +127,7 @@ function VacuumSprite({ mode, reducedMotion }) {
       </g>
       {/* status LED */}
       <circle cx={0} cy={0} r={1.5} fill={led} opacity={mode === PET_MODES.HIDE ? 0.6 : 0.95}
-        style={blink ? { animation: 'pet-snooze 0.8s steps(2,end) infinite' } : undefined} />
-      {mode === PET_MODES.ALERT && <text x={6} y={-5} fontSize="6" fill="#D98324" opacity="0.9">!</text>}
-    </g>
+        style={blink ? { animation: 'pet-snooze 0.8s steps(2,end) infinite' } : undefined} />    </g>
   )
 }
 
@@ -149,10 +142,7 @@ function DogSprite({ mode, reducedMotion }) {
         <circle cx={-6.5} cy={-0.5} r={3.8} fill={fur} />
         <path d="M -9.4 -1.6 q -2 1 -1 3.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />{/* floppy ear */}
         <path d="M -7.6 -0.6 q 1 0.8 2 0" stroke={dark} strokeWidth="0.5" fill="none" />
-        <path d="M 8.4 0.4 q 4.4 0 3.6 -3.4" stroke={fur} strokeWidth="2.6" fill="none" strokeLinecap="round" />
-        <text x={4} y={-7} fontSize="5" fill={dark} opacity="0.7"
-          style={reducedMotion ? undefined : { animation: 'pet-snooze 2.4s ease-in-out infinite' }}>z</text>
-      </g>
+        <path d="M 8.4 0.4 q 4.4 0 3.6 -3.4" stroke={fur} strokeWidth="2.6" fill="none" strokeLinecap="round" />      </g>
     )
   }
   if (mode === PET_MODES.HIDE) {
@@ -178,9 +168,7 @@ function DogSprite({ mode, reducedMotion }) {
         <path d="M -1.4 -5.4 q -2.4 -0.6 -2.6 2.4" stroke={dark} strokeWidth="2" fill="none" strokeLinecap="round" />{/* perked floppy ear */}
         <circle cx={0.8} cy={-4.2} r={1} fill={dark} />
         <circle cx={3.6} cy={-4.2} r={1} fill={dark} />
-        <ellipse cx={4} cy={-2.6} rx={1.4} ry={1} fill={dark} />
-        <text x={7} y={-6} fontSize="6" fill="#D98324" opacity="0.9">!</text>
-      </g>
+        <ellipse cx={4} cy={-2.6} rx={1.4} ry={1} fill={dark} />      </g>
     )
   }
   if (mode === PET_MODES.CELEBRATE) {

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -16,6 +16,21 @@ export const PET_MODES = Object.freeze({
   CELEBRATE: 'celebrate', // a real positive event (eureka / deploy-success) — only when not hiding
 })
 
+// A clear, TYPE-INDEPENDENT emote glyph floated above the pet per mode, so the state is legible at a
+// glance for ANY skin (the poses alone are subtle at ~30px). `wander` (neutral default) shows none;
+// `celebrate` shows none here because its rising ✦ confetti IS the indicator. Pure → testable.
+export const MODE_EMOTE = Object.freeze({
+  hide: '⚠',       // something needs a human / rough patch
+  nap: '💤',       // resting
+  excited: '⚡',   // momentum
+  alert: '❗',     // a NEW blocker — go look
+  wander: null,
+  celebrate: null, // the confetti is the tell
+})
+export function modeEmote(mode) {
+  return MODE_EMOTE[mode] || null
+}
+
 // mood enum (constants.VALID_MOODS): normal · rushing · frustrated · stuck · smooth · intense · idle
 const MOOD_TO_PET = Object.freeze({
   stuck: 'hide',

--- a/tests/petState.test.js
+++ b/tests/petState.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from 'vitest'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, nextPetType, runTarget, PET_TYPES, PET_MODES } from '../src/systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, nextPetType, runTarget, modeEmote, PET_TYPES, PET_MODES } from '../src/systems/petState.js'
 // Static import (hoisted above the window shim below) so the store + i18n initialize while `window`
 // is still undefined — matching the repo's node test env. The shim then provides localStorage so the
 // toggle's persistence path runs. (Same approach as weatherEffectsToggle.test.js.)
@@ -95,6 +95,24 @@ describe('runTarget (#39 — pet points at the blocked desk)', () => {
     expect(runTarget(undefined)).toBeNull()
     expect(runTarget({ x: NaN, y: 1 })).toBeNull()
     expect(runTarget({ x: 1 })).toBeNull()
+  })
+})
+
+describe('modeEmote (#39 — type-independent legibility glyph)', () => {
+  it('gives a distinct glyph to each non-neutral mode; none for wander/celebrate', () => {
+    expect(modeEmote(PET_MODES.HIDE)).toBe('⚠')
+    expect(modeEmote(PET_MODES.NAP)).toBe('💤')
+    expect(modeEmote(PET_MODES.EXCITED)).toBe('⚡')
+    expect(modeEmote(PET_MODES.ALERT)).toBe('❗')
+    expect(modeEmote(PET_MODES.WANDER)).toBeNull()      // neutral default — no glyph
+    expect(modeEmote(PET_MODES.CELEBRATE)).toBeNull()   // the ✦ confetti is the tell
+  })
+  it('all four glyphs are distinct (legibility)', () => {
+    const g = [PET_MODES.HIDE, PET_MODES.NAP, PET_MODES.EXCITED, PET_MODES.ALERT].map(modeEmote)
+    expect(new Set(g).size).toBe(4)
+  })
+  it('unknown mode → null', () => {
+    expect(modeEmote('bogus')).toBeNull()
   })
 })
 


### PR DESCRIPTION
Owner feedback: the mapped states are too hard to tell apart (the poses differ only subtly at ~30px). Adds a clear **type-independent emote glyph** floated above the pet per mode — so the state reads instantly for ANY skin: **hide ⚠ · nap 💤 · excited ⚡ · alert ❗**; wander = none (neutral), celebrate = none (the ✦ confetti is the tell). Counter-flipped so it stays upright whichever way the pet faces.

Consolidates the scattered per-sprite `z`/`!` glyphs (removed from cat/dog/vacuum) into one place. Pure `modeEmote` map, unit-tested (+3, glyphs asserted distinct). Suite 1341 green; build clean. **DEV live-verified via headless screenshot** (the load-the-page lesson): nap shows 💤, excited shows ⚡ — instantly distinguishable; 0 console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)