### PR TITLE
docs(#39): pet reference — 6 types + mode emote

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-08T11:40:00Z
-- **Update Sequence**: 44
+- **Last Updated**: 2026-06-08T12:30:00Z
+- **Update Sequence**: 45
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -132,6 +132,12 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-feat-pet-legibility-and-more-types-2026-06-08 (#39 — mode emote + 3 more skins)
+
+- **PR #74 (legibility)**: a TYPE-INDEPENDENT mode emote glyph floats above the pet (hide ⚠ · nap 💤 · excited ⚡ · alert ❗; wander/celebrate none) so the state reads at a glance for ANY skin — owner feedback that the subtle poses were unreadable. Consolidated the scattered per-sprite z/! glyphs into one place. Pure `modeEmote` (+3 tests).
+- **PR #75 (more types)**: 3 → **6 skins** — added 🐇 rabbit, 🐦 bird, 🐹 hamster (cosmetic; per-type motion grammar; same honest mode logic). ControlPanel ⚙ radiogroup + en/zh-TW labels.
+- **Caught the load-the-page lesson in action**: both verified via headless-Playwright screenshots (all skins render, emotes distinct, 0 console errors) — not just green tests. Suite **1341 passed**; build clean. Spec reference table updated to 6 types + emote column.
 
 ### Ship-hotfix-controlpanel-render-crash-2026-06-08 (crash shipped green, caught by ACTUALLY loading the page)
 

--- a/docs/specs/office-pet-barometer.md
+++ b/docs/specs/office-pet-barometer.md
@@ -26,17 +26,19 @@ movement system.
 ## Complete state & signal reference (the canonical map)
 
 **6 pet modes** — 4 persistent (from the honest base table) + 2 transient event-edge beats.
-**3 cosmetic types** (cat · robot-vacuum · dog) — same modes, different sprite + motion grammar.
+**6 cosmetic types** (cat · robot-vacuum · dog · rabbit · bird · hamster) — same modes, different
+sprite + motion grammar. A **type-independent emote glyph** above the pet makes the mode legible at a
+glance for ANY skin (the poses alone are subtle at ~30px).
 
-| Mode | Kind | Real signal that triggers it | Per-type look |
-|------|------|------------------------------|---------------|
-| `hide` | base | any agent `blocked` **OR** mood `stuck`/`frustrated` | cat: crouched, ears down · vacuum: tilted + dim · dog: crouched |
-| `nap` | base | mood `idle` (and nobody blocked) | cat/dog: curled + rising "z" · vacuum: docked + dim |
-| `wander` | base | mood `normal` (steady, default) | cat/dog: amble · vacuum: glide + sweep trail |
-| `excited` | base | mood `smooth`/`rushing`/`intense` | cat/dog: trot, tail up + hop · vacuum: + dust puff |
-| `alert` | transient (~2.5s) | blockedCount **rose** (a NEW blocker) → also RUNS to that desk; settles into `hide` | ears up + `!` (vacuum: red LED + `!`) |
-| `celebrate` | transient (~2.5s) | real `eureka`/`deploy-success` event **OR** a blocker just cleared (relief) — only when not hiding | hop + ✦ confetti |
-| _(click-♥)_ | cosmetic overlay | user clicks the pet (calm modes only) — NOT a real signal | a ♥ floats up |
+| Mode | Kind | Real signal that triggers it | Emote | Pose / look |
+|------|------|------------------------------|-------|-------------|
+| `hide` | base | any agent `blocked` **OR** mood `stuck`/`frustrated` | ⚠ | crouched low (vacuum: tilted + dim) |
+| `nap` | base | mood `idle` (and nobody blocked) | 💤 | curled (vacuum: docked + dim) |
+| `wander` | base | mood `normal` (steady, default) | — | amble (vacuum: glide + sweep trail) |
+| `excited` | base | mood `smooth`/`rushing`/`intense` | ⚡ | trot/tail-up + hop (vacuum: + dust puff) |
+| `alert` | transient (~2.5s) | blockedCount **rose** (a NEW blocker) → also RUNS to that desk; settles into `hide` | ❗ | ears up |
+| `celebrate` | transient (~2.5s) | real `eureka`/`deploy-success` event **OR** a blocker just cleared (relief) — only when not hiding | — | hop + ✦ confetti |
+| _(click-♥)_ | cosmetic overlay | user clicks the pet (calm modes only) — NOT a real signal | ♥ | — |
 
 ### Signal coverage — what maps, and what deliberately does NOT
 


### PR DESCRIPTION
Keeps the canonical pet reference table accurate after PR #74 (mode emote) + #75 (6 types). Doc/SSoT only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)