### PR TITLE
chore(release): v1.3.0 — blocked-reason tags + recurring-failure detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ live in `docs/specs/_shipped-log.md`; this file is the high-level story.
 
 Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
+## v1.3.0 — 2026-06-08 — Blocked-reason tags + recurring-failure detection
+
+The office stopped just saying "stuck" and started saying **stuck on what** — and **stuck again**.
+Two honesty-first observability features built on the real hook signal.
+
+### Added
+
+- **Blocked-reason tags (AVO-110 / #29)** — a blocked agent now shows a small over-head pixel
+  "status-effect" badge: 🧪 the test run failed · 🔨 the build failed · 📦 a dependency install
+  failed · ❔ blocked, cause unknown. The ControlPanel roster row mirrors it as icon + label.
+  **Honest-narrow by design**: a *specific* reason shows only when a single-segment command matches
+  a tight allowlist on a real error and actually launched — anything ambiguous degrades to the
+  neutral ❔ (never a guessed cause). Wording claims only "blocked on the test **run**", never
+  "test failed". Raw error text stays on hover. en + zh-TW.
+- **Recurring-failure detection (AVO-117)** — when the *same kind* of failure recurs across ≥3
+  distinct blocked episodes for one agent within ~10 minutes, the badge gains a quiet ↻ mark and
+  (if notifications are on) fires one desktop notice. It claims only the recurring **pattern**
+  ("tests keep failing"), never a specific root cause; `blocked-unknown` never escalates; and an
+  idle-gap `blocked↔awaiting-approval` flap of a single stuck state can't manufacture a false alarm.
+
+### Notes
+
+- Both reasons flow from the existing Claude Code status hook (`reasonCode` on the event stream),
+  so they light up from your *real* session — a failing `npm test` shows the 🧪 badge live.
+- `permission` / `auth` / `rate-limit` reasons and finer error signatures are intentionally
+  deferred — they need a structured errno/HTTP-status hook field (substring-matching free text
+  would be fabrication). Honesty invariants are covered by the test suite (now 1411 tests).
+
 ## v1.2.0 — 2026-06-05 — Honest living office + responsive fill (UX Vibe Rebalance wave)
 
 Shipped on branch `feat/ux-vibe-rebalance` (pending human PR review + merge). The office

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ dead gutters. Hit **☰** for a vertical roster: who's working, who's blocked, a
 - **Pure SVG pixel art** — 8 hand-drawn characters. No canvas, no GPU, no GB-sized bundle.
 - **Role-aware animations** — same tool, different role, different scene: `qa + Bash` → magnifier, `ops + Bash` → deploy button, `designer + Edit` → whiteboard.
 - **Honest, signal-driven life** — events fire from your *real* session; an agent's status is never faked.
+- **"Stuck on what?" tells** — a blocked agent shows *why*: 🧪 test run · 🔨 build · 📦 install · ❔ unknown, plus a ↻ mark when the same kind keeps failing. Specific only when the signal proves it — never a guessed cause.
 - **Calm by design** — mood-driven weather, idle-gap inference (`working+45s` → thinking), reduced-motion + a11y, and a never-stuck behavior watchdog.
 
 → Full internals (classifier tiers, movement, behavior engine, weather, inference) live in **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
@@ -161,7 +162,7 @@ Full notes in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 ## Tech stack
 
 React 19 + Vite 6 · SVG (no canvas, no GPU) · Zustand · Tailwind CSS v4 · `requestAnimationFrame` · zero backend.
-1276 tests (classifier, inference, store, movement, event honesty). Deep dive → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
+1411 tests (classifier, inference, store, movement, event honesty, blocked-reason + recurring detection). Deep dive → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**.
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-virtual-office",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Pixel-art virtual office that visualizes AI agent activity in real-time. Works with Claude Code, Gemini CLI, Codex, and any tool that can POST status.",
   "main": "bin/cli.js",
   "bin": {


### PR DESCRIPTION
Cuts **v1.3.0** for the two features merged this session:
- AVO-110 blocked-reason tags ([#77](https://github.com/KbWen/agent-virtual-office/pull/77))
- AVO-117 recurring-failure detection ([#78](https://github.com/KbWen/agent-virtual-office/pull/78))

Docs/version only — no code change:
- `package.json` + lock → 1.3.0
- `CHANGELOG.md` → v1.3.0 entry
- `README.md` → "Stuck on what?" tell + test count 1276 → 1411

Suite 1411 green on main; both features load-the-page verified at ship time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)