### PR TITLE
fix(test): deflake hookWriteLock AC-4 on slow CI runners

### DIFF
--- a/tests/hookWriteLock.test.js
+++ b/tests/hookWriteLock.test.js
@@ -222,8 +222,23 @@ const { acquireStatusLock, releaseStatusLock } = require('${hookPath}')
 const fs = require('fs')
 const CYCLES = ${CYCLES}
 const FILE   = '${counterFilePath}'
+// CI-flake lesson (2026-06-10, PR #89): production semantics allow acquire to give up
+// after its ~250ms budget and PROCEED UNLOCKED (liveness over consistency). On a 2-core
+// CI runner, 6 workers x 15 cycles exhausts that budget for some worker -> it wrote
+// UNLOCKED -> torn read ("Unexpected end of JSON input") / lost update -> exact-90
+// assertion failed. The property under test is "writes made WHILE HOLDING the lock
+// never lose updates", so the TEST worker retries until it actually holds the lock
+// (10s overall deadline); production keeps its bounded-fallback behavior untouched.
+function acquireOrRetry(deadlineMs) {
+  const deadline = Date.now() + deadlineMs
+  for (;;) {
+    const lock = acquireStatusLock()
+    if (lock.ok) return lock
+    if (Date.now() > deadline) throw new Error('worker: lock not acquired within deadline')
+  }
+}
 for (let i = 0; i < CYCLES; i++) {
-  const lock = acquireStatusLock()
+  const lock = acquireOrRetry(10_000)
   try {
     const data = JSON.parse(fs.readFileSync(FILE, 'utf-8'))
     data.n += 1


### PR DESCRIPTION
## Summary
The W1 PR (#89) ran red on `test (20)`/`test (22)`: `hookWriteLock` AC-4 failed with a torn read (`Unexpected end of JSON input`). Root cause is a TEST design flaw, not a lock bug: production semantics deliberately let `acquireStatusLock` give up after its ~250ms budget and proceed unlocked (liveness over consistency). On a 2-core CI runner, 6 workers × 15 cycles exhausts that budget for some worker → it writes UNLOCKED → torn/lost update → the exact-90 assertion fails. Local fast machines never exhaust the budget, which is why this passed 3× review runs + 4× local runs.

### Fix
Test workers now **retry until they actually hold the lock** (10s overall deadline) — the property under test is *lock-held writes never lose updates*, not *the budget is always sufficient*. Production behavior untouched (zero non-test changes).

### Evidence
- 5× consecutive local runs green; full suite 1543/1543.
- This also explains the "flake watch" single failure recorded in #89''s work log (first post-`npm ci` run under AV-scan I/O load = same budget-exhaustion mechanism).

### Process note
PR #89 merged while red because the `test` jobs aren''t required status checks on `main` — recommend enabling required checks (repo settings, owner action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)