### PR TITLE
feat(soak): forensic tails on every violation — nightly catches self-diagnose

### DIFF
--- a/scripts/soakInvariants.mjs
+++ b/scripts/soakInvariants.mjs
@@ -36,6 +36,14 @@ export function evaluateSoak(samples) {
   const warnings = { groupStack: [] }
   const push = (kind, entry) => { if (v[kind].length < MAX_VIOLATIONS_PER_KIND) v[kind].push(entry) }
 
+  // Forensic tails: rolling last-N samples per agent, attached to every violation so a
+  // nightly catch self-diagnoses (nightly run #3 caught `res` resting inside the coffee
+  // machine at (67,455) — a single coordinate, mechanism unprovable without the approach
+  // trajectory; never again). Compact: {t,x,y,m,g,o} with rounded coords.
+  const TAIL_LEN = 15
+  const tails = {}       // id -> ring of last TAIL_LEN compact samples
+  const tailOf = (id) => (tails[id] || []).slice()
+
   const prev = {}        // id -> { x, y, t }
   const restSince = {}   // id -> ms since at rest (continuous)
   const stillMovingSince = {} // id -> ms since (moving && at rest) started
@@ -53,9 +61,15 @@ export function evaluateSoak(samples) {
       const dt = p ? s.t - p.t : Infinity
       const step = p ? Math.hypot(a.x - p.x, a.y - p.y) : 0
 
+      // Roll the forensic tail BEFORE any violation can fire this sample, so the tail
+      // includes the violating sample itself.
+      const tail = tails[id] || (tails[id] = [])
+      tail.push({ t: Math.round(s.t / 100) / 10, x: Math.round(a.x), y: Math.round(a.y), m: a.moving ? 1 : 0, g: a.group ? 1 : 0, o: a.offFloor ? 1 : 0 })
+      if (tail.length > TAIL_LEN) tail.shift()
+
       // I2 — teleport: a super-walk-speed jump between two healthy samples.
       if (p && dt < SAMPLE_GAP_SKIP_MS && step > TELEPORT_STEP_PX) {
-        push('teleport', { id, tSec: Math.round(s.t / 1000), step: Math.round(step), from: `${Math.round(p.x)},${Math.round(p.y)}`, to: `${Math.round(a.x)},${Math.round(a.y)}` })
+        push('teleport', { id, tSec: Math.round(s.t / 1000), step: Math.round(step), from: `${Math.round(p.x)},${Math.round(p.y)}`, to: `${Math.round(a.x)},${Math.round(a.y)}`, tail: tailOf(id) })
       }
 
       const resting = p ? step < REST_STEP_PX : false
@@ -72,7 +86,7 @@ export function evaluateSoak(samples) {
       if (a.moving && resting) {
         if (!stillMovingSince[id]) stillMovingSince[id] = p.t
         if (s.t - stillMovingSince[id] >= FROZEN_WALKER_MS) {
-          push('frozenWalker', { id, tSec: Math.round(s.t / 1000), at: `${Math.round(a.x)},${Math.round(a.y)}`, stillForSec: Math.round((s.t - stillMovingSince[id]) / 1000) })
+          push('frozenWalker', { id, tSec: Math.round(s.t / 1000), at: `${Math.round(a.x)},${Math.round(a.y)}`, stillForSec: Math.round((s.t - stillMovingSince[id]) / 1000), tail: tailOf(id) })
           stillMovingSince[id] = s.t // re-arm so one long freeze reports ~once/90s, not per sample
         }
       } else {
@@ -83,7 +97,7 @@ export function evaluateSoak(samples) {
       const bad = resting && !!a.offFloor
       if (bad && restSince[id] && s.t - restSince[id] >= OFF_FLOOR_SUSTAIN_MS) {
         if (!offFloorFired[id]) {
-          push('offFloorRest', { id, tSec: Math.round(s.t / 1000), at: `${Math.round(a.x)},${Math.round(a.y)}` })
+          push('offFloorRest', { id, tSec: Math.round(s.t / 1000), at: `${Math.round(a.x)},${Math.round(a.y)}`, tail: tailOf(id) })
           offFloorFired[id] = true
         }
         offFloorSince[id] = s.t
@@ -108,7 +122,7 @@ export function evaluateSoak(samples) {
           if (!pairClose[k]) pairClose[k] = { since: s.t, fired: false }
           if (!pairClose[k].fired && s.t - pairClose[k].since >= STACK_SUSTAIN_MS) {
             pairClose[k].fired = true
-            const entry = { pair: k, tSec: Math.round(s.t / 1000), dist: Math.round(d), at: `${Math.round(a.x)},${Math.round(a.y)}`, group: !!(a.group || b.group) }
+            const entry = { pair: k, tSec: Math.round(s.t / 1000), dist: Math.round(d), at: `${Math.round(a.x)},${Math.round(a.y)}`, group: !!(a.group || b.group), tailA: tailOf(A), tailB: tailOf(B) }
             if (entry.group) {
               if (warnings.groupStack.length < MAX_VIOLATIONS_PER_KIND) warnings.groupStack.push(entry)
             } else {

--- a/tests/soakInvariants.test.js
+++ b/tests/soakInvariants.test.js
@@ -124,4 +124,17 @@ describe('planted violations are caught', () => {
     const s = timeline(4000, 250, { dev: walk(100, 300, 60, 0, { offFloor: true }) })
     expect(evaluateSoak(s).violations.offFloorRest).toHaveLength(0)
   })
+
+  it('every violation carries a forensic tail (approach trajectory, self-diagnosing)', () => {
+    const s = timeline(8000, 250, { dev: still(95, 100, { offFloor: true }) })
+    const tail = evaluateSoak(s).violations.offFloorRest[0].tail
+    expect(Array.isArray(tail)).toBe(true)
+    expect(tail.length).toBeGreaterThanOrEqual(8)
+    expect(tail[tail.length - 1]).toMatchObject({ x: 95, y: 100, o: 1 })
+
+    const stack = timeline(STACK_SUSTAIN_MS * 4, 250, { pm: still(240, 386), dev: still(240, 396) })
+    const sv = evaluateSoak(stack).violations.sustainedStack[0]
+    expect(sv.tailA.length).toBeGreaterThanOrEqual(8)
+    expect(sv.tailB.length).toBeGreaterThanOrEqual(8)
+  })
 })


### PR DESCRIPTION
Nightly run #3 caught res resting INSIDE the coffee machine's east edge at (67,455) — real catch, but a single coordinate: every planned position is clamp-validated, so the mechanism (likely force-unstick parking a walker at an unvalidated mid-leg interpolation point) is unprovable without the approach trajectory. Every violation now carries the involved agents' last 15 samples (compact {t,x,y,m,g,o}); the next catch shows HOW, not just WHERE. Tests 1897→1898.

🤖 Generated with [Claude Code](https://claude.com/claude-code)