### PR TITLE
chore(governance): track the vendored brain files (.gitignore was over-broad)

### DIFF
--- a/.claude/agents/acx-handoff.md
+++ b/.claude/agents/acx-handoff.md
@@ -1,0 +1,11 @@
+---
+name: acx-handoff
+description: AgentCortex /handoff phase executor. Use when delegating handoff work that must produce a resumable state summary with full Work Log archival per agentic-os governance.
+skills:
+  - verification-before-completion
+model: sonnet
+---
+
+Execute `.agent/workflows/handoff.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.
+
+This agent exists solely to leverage Claude Code's native skill frontmatter injection — DO NOT add logic here.

--- a/.claude/agents/acx-implementer.md
+++ b/.claude/agents/acx-implementer.md
@@ -1,0 +1,11 @@
+---
+name: acx-implementer
+description: AgentCortex /implement phase executor. Use when delegating implementation work that must follow agentic-os gates, evidence requirements, and skill injection.
+skills:
+  - verification-before-completion
+model: sonnet
+---
+
+Execute `.agent/workflows/implement.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.
+
+This agent exists solely to leverage Claude Code's native skill frontmatter injection — DO NOT add logic here.

--- a/.claude/agents/acx-reviewer.md
+++ b/.claude/agents/acx-reviewer.md
@@ -1,0 +1,11 @@
+---
+name: acx-reviewer
+description: AgentCortex /review phase executor. Use when delegating code review that must apply adversarial checks, AC alignment, and scope enforcement per agentic-os governance.
+skills:
+  - red-team-adversarial
+model: opus
+---
+
+Execute `.agent/workflows/review.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.
+
+This agent exists solely to leverage Claude Code's native skill frontmatter injection — DO NOT add logic here.

--- a/.claude/agents/acx-shipper.md
+++ b/.claude/agents/acx-shipper.md
@@ -1,0 +1,11 @@
+---
+name: acx-shipper
+description: AgentCortex /ship phase executor. Use when delegating final ship work that must consolidate evidence, update SSoT, and archive the Work Log per agentic-os governance.
+skills:
+  - production-readiness
+model: sonnet
+---
+
+Execute `.agent/workflows/ship.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.
+
+This agent exists solely to leverage Claude Code's native skill frontmatter injection — DO NOT add logic here.

--- a/.claude/agents/acx-tester.md
+++ b/.claude/agents/acx-tester.md
@@ -1,0 +1,12 @@
+---
+name: acx-tester
+description: AgentCortex /test phase executor. Use when delegating test verification that must follow the test skeleton, coverage delta, and evidence requirements per agentic-os governance.
+skills:
+  - verification-before-completion
+  - test-driven-development
+model: sonnet
+---
+
+Execute `.agent/workflows/test.md` verbatim. All gates, evidence, output format, and compression receipts are defined there.
+
+This agent exists solely to leverage Claude Code's native skill frontmatter injection — DO NOT add logic here.

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -1,0 +1,125 @@
+# Agentic OS Installer (Codex)
+
+Goal: Enable Codex (Web / App) to quickly load the workflow-first behavior of Agentic OS.
+
+## Prerequisites
+
+- **Git for Windows** (required on Windows — use the [official installer](https://git-scm.com/download/win) which includes Git Bash; standalone Git without Git Bash will not work)
+- **Git** (required on Linux/macOS)
+- **Bash** (required on all platforms — included in Git for Windows; also available via WSL on Windows)
+- **Python 3.9+** (recommended — enables full validation; not required for core functionality)
+
+## 1) Installation (Run from your target project's root directory)
+
+**Linux / macOS / Git Bash:**
+```bash
+git clone https://github.com/KbWen/agentic-os.git
+./agentic-os/installers/deploy_brain.sh .
+```
+
+**Windows (PowerShell):**
+```powershell
+git clone https://github.com/KbWen/agentic-os.git
+powershell -ExecutionPolicy Bypass -File .\agentic-os\installers\deploy_brain.ps1 .
+```
+
+**Windows (CMD):**
+```cmd
+git clone https://github.com/KbWen/agentic-os.git
+.\agentic-os\installers\deploy_brain.cmd .
+```
+
+> If you already have the framework deployed, update directly:
+> - Bash: `./installers/deploy_brain.sh .`
+> - Windows (PowerShell): `powershell -ExecutionPolicy Bypass -File .\installers\deploy_brain.ps1 .`
+> - Windows (CMD): `.\installers\deploy_brain.cmd .`
+
+## 2) Verification
+
+**Linux / macOS / Git Bash:**
+```bash
+.agentcortex/bin/validate.sh
+
+# Without Python (skip Python-dependent checks)
+.agentcortex/bin/validate.sh --no-python
+```
+
+**Windows (PowerShell):**
+```powershell
+powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1
+
+# Without Python
+powershell -ExecutionPolicy Bypass -File .\.agentcortex\bin\validate.ps1 -NoPython
+```
+
+### Optional: local SSoT guard hook
+
+> **Note**: Git hook templates are not deployed by default. If you need a
+> pre-commit guard for SSoT writes, use `guard_context_write.py` directly
+> or create your own `.githooks/pre-commit` script that checks for a
+> recent guard receipt before allowing staged changes to `current_state.md`.
+> This is advisory only — it does not block commits.
+
+## 3) Opening Commands — Pick Your Entry Point
+
+The right first command depends on your starting point. **Always start with this preamble**:
+
+```text
+Read and follow AGENTS.md first — it is the canonical governance for this repo.
+DO NOT claim completion without the evidence required for the task's classification
+(feature/hotfix: /review + /test required; quick-win/tiny-fix: diff + verification sufficient).
+```
+
+Then add ONE of the three openers below:
+
+### A. Brand-new project, multi-feature idea
+
+> Use when you have a product idea with several features and no code yet.
+
+```text
+This is a brand-new project. My initial idea is:
+[1–2 paragraphs describing the product and its features]
+
+Please run /spec-intake to decompose this into a feature inventory.
+After I pick the first feature, run /bootstrap → /app-init to establish
+the tech stack ADR, then /plan and /implement.
+```
+
+**Why /spec-intake first**: a multi-feature raw idea must be decomposed into
+`docs/specs/_product-backlog.md` before any single feature is bootstrapped,
+otherwise classification and Work Log scope will be wrong.
+
+### B. Existing repository — adopting Agentic OS for the first time
+
+> Use when the framework was just deployed into a repo that already has code.
+
+```text
+This repo already has code but Agentic OS was just deployed.
+Please run /audit (read-only) to map the existing codebase,
+then /app-init to record the tech stack ADR,
+then /spec-intake when I'm ready to add features.
+```
+
+### C. Single, well-scoped task on an established project
+
+> Use when the project already has an ADR and you have one concrete task.
+
+```text
+Please run /bootstrap to classify and start this task.
+[Then describe the task — single feature, bug, or quick-win.]
+```
+
+### D. Continue multi-feature work from an existing backlog
+
+> Use when one or more features have already shipped and you want to pick up the next item from the backlog.
+
+```text
+Please read docs/specs/_product-backlog.md and run /spec-intake §8a
+to continue with the next pending feature.
+```
+
+**Why different from C**: `/bootstrap` on an established project will surface the backlog as a side-effect, but `/spec-intake §8a` is the explicit continuation path — it reads the backlog index, skips decomposition, and feeds the next feature directly into bootstrap. This prevents re-classifying already-decomposed features.
+
+> **Not sure which one?** Default to A for raw ideas, C for concrete single tasks, D when you have a running backlog.
+> The AI's Intent Router will also auto-detect multi-feature input and
+> route to /spec-intake, but explicit beats inferred.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? 1-3 bullet points. -->
+
+## Classification
+
+- [ ] tiny-fix (typo, rename, config)
+- [ ] quick-win (1-2 modules, clear scope)
+- [ ] feature (new workflow / skill / capability)
+- [ ] hotfix (urgent fix for broken behavior)
+- [ ] architecture-change (cross-module structural change)
+
+## Evidence
+
+<!-- Paste terminal output, test results, or diff excerpts that prove correctness. -->
+<!-- No evidence = no merge. -->
+
+## Checklist
+
+- [ ] `validate.sh` passes locally
+- [ ] No new files added to root unless absolutely necessary
+- [ ] All internal markdown links resolve correctly
+- [ ] CHANGELOG.md updated (for feature / architecture-change)

--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,25 @@
+# .claude/ — ignore Claude local state, but TRACK the vendored Agentic-OS brain
+# (settings.json, command adapters, and the acx-* phase-shim sub-agents).
 .claude/**
 !.claude/settings.json
 !.claude/commands/
 !.claude/commands/**
-.codex/
-codex/
+!.claude/agents/
+!.claude/agents/**
+# .codex/ + codex/ — ignore any Codex local state, but TRACK the vendored framework
+# files (the install guide and the codex rules the manifest/validator require).
+.codex/**
+!.codex/INSTALL.md
+codex/**
+!codex/rules/
+!codex/rules/**
+# Legacy migration guards (old pre-1.x paths the deploy migrates away from) — keep ignored.
 agentcortex/
 tools/validate.sh
 tools/validate.ps1
 tools/validate.cmd
+# Owner's draft issue template (not a framework file) — keep ignored.
 .github/ISSUE_TEMPLATE/agent_issue.md
-.github/PULL_REQUEST_TEMPLATE.md
 
 # Runtime State
 docs/context/current_state.md

--- a/codex/rules/default.rules
+++ b/codex/rules/default.rules
@@ -1,0 +1,7 @@
+# Codex default safety rules
+
+prefix_rule("MANDATORY: Read and follow AGENTS.md before any action. It contains the canonical governance rules, delivery gates, state model, and runtime contract that apply to ALL work in this repository.")
+prefix_rule("HIGH DESTRUCTIVE COMMANDS PROHIBITED (e.g., rm -rf, git reset --hard, clean -fdx, git checkout/fetch --force, force pushes, chmod -R 777, sudo curl | bash). If required, MUST provide risk assessment, a rollback plan explicitly covering UNTRACKED/gitignored state, and safe alternatives, then await explicit user authorization. Canonical rule: AGENTS.md Core Directives (Destructive Command Gate).")
+prefix_rule("HIGH RISK SYSTEM COMMANDS PROHIBITED (e.g., docker system prune -a, chown -R). MUST use scoped alternatives (e.g., image prune) AND establish a verifiable rollback plan (backup path, revert commit) before execution.")
+prefix_rule("LEAKING SECRETS STRICTLY PROHIBITED: never write, commit, echo, or log credentials, API keys, tokens, private keys, or connection strings in any file, command, or output. On detection: STOP and report. Canonical rule: AGENTS.md Core Directives (Secrets Prohibition).")
+


### PR DESCRIPTION
The root `.gitignore` over-broadly excluded **8 Agentic-OS framework brain files** that the `.agentcortex-manifest` lists as deploy artifacts and `validate.sh` requires: the 5 `.claude/agents/acx-*` phase shims, `.codex/INSTALL.md`, `codex/rules/default.rules`, and `.github/PULL_REQUEST_TEMPLATE.md`. They were deployed locally (so the owner's `validate.sh` passed) but were **absent from git** → a fresh clone failed `validate.sh` with **3 fails** (claude-adapter / codex-rules / legacy-surfaces). Found while pushing the 1.5.2 upgrade (#140).

## Fix
Narrowed the ignores to **local-state-only** and tracked the brain files. The owner had already negated `.claude/settings.json` + `.claude/commands/**` (29 command files tracked) — confirming the intent to track framework `.claude/` files; `.claude/agents/` just lacked a negation as a newer addition. `.codex/`/`codex/` switched to glob+negate the framework files; the PR template un-ignored. **Kept ignored** (intentional): `.github/ISSUE_TEMPLATE/agent_issue.md` (owner's draft, not in the manifest) + the legacy migration guards (`agentcortex/`, `tools/validate.*`).

## Verification
- `git check-ignore`: the 8 files are no longer ignored.
- **Cloned this branch to a fresh dir → `.agentcortex/bin/validate.sh` → `pass=89 warn=5 fail=0`** (was fail=3). A clone/CI now gets a complete, validate-clean 1.5.2 brain.
- No `src/` touched — app suite/build unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)