### PR TITLE
chore(tests): strip UTF-8 BOM from socialTargetOverride.test.js (#131 follow-up)

### DIFF
--- a/tests/socialTargetOverride.test.js
+++ b/tests/socialTargetOverride.test.js
@@ -1,4 +1,4 @@
-﻿import { describe, it, expect, vi, afterEach } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import * as movementSystem from '../src/systems/movementSystem.js'
 
 describe('getTargetForBehavior socialTargetOverride', () => {


### PR DESCRIPTION
Follow-up to #131 (merged). The external contribution carried a leading UTF-8 BOM on `tests/socialTargetOverride.test.js`; this strips it so the file is byte-clean and consistent with every other test.

**No behavior change** — vitest parsed it fine either way (#131's CI was green). Hygiene only; 1 byte-sequence removed from line 1.

Verify: `npx vitest run tests/socialTargetOverride.test.js` → 2 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)