### PR TITLE
fix(tests): de-flake socialTargetOverride test — pin Math.random (#131 follow-up)

### DIFF
--- a/tests/socialTargetOverride.test.js
+++ b/tests/socialTargetOverride.test.js
@@ -16,7 +16,12 @@ describe('getTargetForBehavior socialTargetOverride', () => {
       pm: pmAgent
     }
 
-    // ارسال آبجکت کامل (مطابق انتظار کد اصلی)
+    // De-flake (#147 follow-up): pin Math.random so the social-approach angle/dist are
+    // deterministic. Without this the target is random AND avoidOverlap can shove it away from the
+    // peer-as-obstacle — ~14% of calls landed outside the box below (e.g. y≈173), making this test
+    // intermittently fail in full-suite runs. Fixed seed (0.5) → target (440,500): a clean point
+    // 60px left of the peer, exactly the "walk up beside them" behavior this test means to assert.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
     const target = movementSystem.getTargetForBehavior('dev', 'chat', agents, pmAgent)
 
     expect(target).toBeDefined()


### PR DESCRIPTION
Follow-up to #131 / #147. The merged external test was **flaky** (~14% per call).

## Root cause
The test asserted the social-chat target lands within a ±100 box of the peer, but `getTargetForBehavior` computes the target from a **random** angle/dist, and `avoidOverlap` can push it *away* from the peer's own (occupied) position. A 5000-call probe measured **697/5000 (~14%) outside the box** — Y dropping to ~173. It passed in isolation and in #131's CI by luck, but **intermittently fails full-suite runs** (caught here at ~1-in-10).

## Fix
Pin `Math.random(0.5)` in test #1 → deterministic target **(440,500)** (a clean "stand beside the peer" point), so the assertion is stable and still validates that an agent **object** override is consumed correctly. `afterEach` already restores the mock. Test #2 (string ID → throws) was already deterministic.

## Verify
- `npx vitest run tests/socialTargetOverride.test.js` → 2 passed.
- Full suite green across repeated runs (deterministic by construction now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)