### PR TITLE
chore(release): v1.5.1 — card + poke polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ live in `docs/specs/_shipped-log.md`; this file is the high-level story.
 
 Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
+## v1.5.1 — 2026-06-14 — Card + poke polish
+
+### Fixed
+
+- **Share card looks better** — redesigned the postcard into a populated little office
+  (wall + windows, a row of desks with agents, a plant) with fuller weather and tighter
+  spacing, instead of the earlier mostly-empty layout. The data behind it is unchanged.
+- **Poke is shown as a GIF** — the README now demonstrates the poke reaction with a short
+  animation instead of a static frame that didn't read as anything happening.
+
 ## v1.5.0 — 2026-06-14 — Make it yours: share it, poke it, theme it
 
 A more personal release: poke your agents, save the day as a card, re-skin the room. The

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Pixel-art virtual office that visualizes your AI coding agents in real time — Claude Code, Codex, Gemini CLI, or any tool that can POST status. Pure SVG, zero backend, runs locally.",
   "main": "bin/cli.js",
   "bin": {


### PR DESCRIPTION
Patch release: the v1.5.0 share card was redesigned (richer office room) and the README poke demo is now an animated GIF (#154). Bumps version + adds the v1.5.1 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)