### PR TITLE
Reduce visual noise: gate RAF dev-diagnostic + calm ambient walking

### DIFF
--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -15,8 +15,8 @@ const statusOptions = ['idle', 'working', 'blocked', 'done']
 // existing importers (NarrowRoster, tests). NOTE: `export { x } from './m'` alone re-exports without
 // binding x into THIS module's scope — the component's internal calls would then crash with
 // "x is not defined" (regression caught only by actually loading the page).
-import { taskChipLabel, blockedReasonLabel, blockedReasonGlyph, formatTokens, agentLineLabel, shouldShowWatchdogDiag, healthDotState } from './controlPanelLabels.js'
-export { taskChipLabel, blockedReasonLabel, blockedReasonGlyph, formatTokens, agentLineLabel, shouldShowWatchdogDiag, healthDotState }
+import { taskChipLabel, blockedReasonLabel, blockedReasonGlyph, formatTokens, agentLineLabel, shouldShowWatchdogDiag, isRafDebugEnabled, healthDotState } from './controlPanelLabels.js'
+export { taskChipLabel, blockedReasonLabel, blockedReasonGlyph, formatTokens, agentLineLabel, shouldShowWatchdogDiag, isRafDebugEnabled, healthDotState }
 
 // #39 types: emoji shown on the "change pet" button per current skin.
 const PET_TYPE_EMOJI = { cat: '🐈', vacuum: '🤖', dog: '🐕', rabbit: '🐇', bird: '🐦', hamster: '🐹' }
@@ -82,8 +82,8 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const theme = useOfficeStore((s) => s.theme)              // AVO-123
   const setTheme = useOfficeStore((s) => s.setTheme)
   const mood = useOfficeStore((s) => s.mood)                // AVO-115 share card hero
-  // #28: RAF-watchdog stall counter — surfaced as a DEV-only diagnostic chip (see render). Cheap
-  // primitive subscription; re-renders only when a stall actually bumps the count (rare).
+  // #28: RAF-watchdog stall counter — surfaced as an opt-in DEV diagnostic chip (see render; off by
+  // default, `?debug=raf`). Cheap primitive subscription; re-renders only when a stall bumps the count.
   const watchdogRestarts = useOfficeStore((s) => s.watchdogRestarts)
   const triggerWorkflow = useOfficeStore((s) => s.triggerWorkflow)
   const activeEvent = useOfficeStore(useShallow((s) => s.activeEvent))
@@ -455,15 +455,17 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         </div>
       </div>
 
-      {/* #28: DEV-only RAF-watchdog diagnostic. Invisible until a stall bumps the counter. The gate
+      {/* #28: DEV-only, OPT-IN RAF-watchdog diagnostic. Off by default for everyone — it's a
+          non-actionable internal signal that was just visual noise — and only appears when a dev
+          explicitly opts in via `?debug=raf` (or localStorage `avo.debug.raf=on`). The gate still
           LEADS with the literal `import.meta.env.DEV` so esbuild statically evaluates `false && …` in
           prod and dead-code-eliminates this whole branch (JSX + strings) — true zero prod cost. The
-          pure `shouldShowWatchdogDiag` mirror is kept for unit testing the count>0 logic. */}
+          always-on `console.warn` in AgentCharacter's watchdog remains the default dev signal. */}
       {import.meta.env.DEV && shouldShowWatchdogDiag(watchdogRestarts) && (
         <div
           className="mt-1 text-[10px] text-amber-600 dark:text-amber-400"
           data-watchdog-diag={watchdogRestarts}
-          title="AgentCharacter RAF walk-loop watchdog restarts — a rising count means dropped frames (tab throttling, HMR, or an exception in animate()). DEV-only diagnostic."
+          title="AgentCharacter RAF walk-loop watchdog restarts — a rising count means dropped frames (tab throttling, HMR, or an exception in animate()). Opt-in DEV diagnostic (?debug=raf)."
         >
           ⚠ {watchdogRestarts} RAF watchdog restart{watchdogRestarts === 1 ? '' : 's'} (dev)
         </div>

--- a/src/components/controlPanelLabels.js
+++ b/src/components/controlPanelLabels.js
@@ -101,10 +101,28 @@ export function healthDotState({ statusSource, integrationHealth, externalCount 
   }
 }
 
-// #28 — DEV-only diagnostics gate for the RAF-watchdog restart counter. Shown only in dev builds AND
-// only once a stall has happened (count > 0), so it's invisible at rest and zero-cost in production
+// #28 — opt-in debug flag for the RAF-watchdog diagnostic chip. The chip is non-actionable for
+// everyone except a dev actively chasing a walk-loop stall, so it is OFF by default even in dev and
+// only renders when explicitly opted in: `?debug=raf` in the URL or localStorage `avo.debug.raf=on`
+// (same load-time pattern as `?lang` / `avo.theme`). The watchdog's `console.warn` is unaffected —
+// that remains the always-on dev signal for anyone who opens devtools. Reads window lazily so it
+// stays safe in SSR/test (no window → false).
+export function isRafDebugEnabled(win = typeof window !== 'undefined' ? window : undefined) {
+  if (!win) return false
+  try {
+    const params = new URLSearchParams(win.location?.search || '')
+    if (params.get('debug') === 'raf') return true
+    return win.localStorage?.getItem('avo.debug.raf') === 'on'
+  } catch {
+    return false
+  }
+}
+
+// #28 — DEV-only diagnostics gate for the RAF-watchdog restart counter. Shown only in dev builds, only
+// once a stall has happened (count > 0), AND only when the debug flag is opted in (isRafDebugEnabled),
+// so it's invisible at rest, off-by-default for everyone, and zero-cost in production
 // (`import.meta.env.DEV` is a compile-time constant → the render branch is dead-code-eliminated from
-// the prod bundle). Pure so it can be unit-tested without a DOM.
-export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV) {
-  return !!isDev && typeof count === 'number' && count > 0
+// the prod bundle). `debugEnabled` is injectable for DOM-free unit testing.
+export function shouldShowWatchdogDiag(count, isDev = import.meta.env.DEV, debugEnabled = isRafDebugEnabled()) {
+  return !!isDev && !!debugEnabled && typeof count === 'number' && count > 0
 }

--- a/src/systems/behaviorEngine.js
+++ b/src/systems/behaviorEngine.js
@@ -10,11 +10,18 @@ import { randomBubble } from '../i18n'
 // alone). Solo meeting is removed (officeLife group events still gather agents there —
 // that's the legible, honest channel for meeting-room use); desk durations lengthened so
 // the office reads "alive but calm"; break-room dwells lengthened so visits are SEEN.
-const baseWeights = { work: 65, daily: 12, social: 13, away: 10 }
+// Calm-rhythm round 2 (owner 2026-06-15 "一直看到很多人在走動 / 只有兩個人在座位"): the
+// structural OUT-TRIP rate was still too high — measured category split for an ambient agent
+// was 45% out-trips (idle/normal) and 55% (idle-mood), so with 8 agents independently rolling
+// there was almost always someone in transit. Walk speed/duration are NOT the lever (already
+// long); the fix is to sit more often. `work` raised, trimmed from `away`/`daily`; `social`
+// deliberately PRESERVED (chatting is the "alive/fun" channel, not the clutter). Only ambient
+// weights move — `working` (real-work, R1 honesty) / `done` / `blocked` are untouched.
+const baseWeights = { work: 74, daily: 8, social: 13, away: 5 }
 
 const statusOverrides = {
   working: { work: 82, daily: 8, social: 5, away: 5 },
-  idle: { work: 55, daily: 18, social: 15, away: 12 },
+  idle: { work: 68, daily: 12, social: 14, away: 6 },
   done: { work: 25, daily: 25, social: 30, away: 20 },
   blocked: { work: 10, daily: 10, social: 10, away: 10, frustrated: 60 },
 }
@@ -155,7 +162,11 @@ const moodModifiers = {
   stuck:      { work: 30, daily: 10, social: 10, away: 10, frustrated: 40 },
   smooth:     { work: 30, daily: 20, social: 35, away: 15 },
   intense:    { work: 80, daily: 8,  social: 7,  away: 5 },
-  idle:       { work: 20, daily: 30, social: 20, away: 30 },
+  // Calm-rhythm round 2 (2026-06-15): idle-mood is the quiet-office case the owner watches, and
+  // the old {work:20, away:30, daily:30} turned a bored office into a walkathon (55% out-trips).
+  // Eased toward sitting — still the MOST relaxed/social mood (out-trips stay above `normal`),
+  // just not a clutter of constant transit. `social` kept at 20 (chatting is the charm).
+  idle:       { work: 42, daily: 22, social: 20, away: 16 },
 }
 
 export function getNextBehavior(agentId, status = 'idle', hour = new Date().getHours(), mood = 'normal', teamPulse = 0) {

--- a/tests/teamAffectL2.test.js
+++ b/tests/teamAffectL2.test.js
@@ -23,9 +23,10 @@ describe('behaviorEngine teamPulse lean-in', () => {
   it('teamPulse=0 leaves the distribution at the un-nudged baseline (AC-5: no regression)', () => {
     // Calling with teamPulse 0 must be equivalent to not passing it (the nudge is guarded `>0`).
     const a = workShare(0)
-    // Baseline idle work weight is 55/100 → ~0.55 work share; sanity band only.
-    expect(a.work).toBeGreaterThan(0.45)
-    expect(a.work).toBeLessThan(0.65)
+    // Baseline idle work weight is 68/100 (calm-rhythm round 2, 2026-06-15) → ~0.68 work share;
+    // sanity band only — confirms pulse-0 sits at baseline, NOT nudged up toward the hot ~0.9.
+    expect(a.work).toBeGreaterThan(0.58)
+    expect(a.work).toBeLessThan(0.78)
   })
 
   it('a hot session (teamPulse=1) raises work and lowers casual behaviors (AC-4)', () => {

--- a/tests/watchdogDiag.test.js
+++ b/tests/watchdogDiag.test.js
@@ -1,29 +1,71 @@
 import { describe, it, expect } from 'vitest'
-import { shouldShowWatchdogDiag } from '../src/components/controlPanelLabels.js'
+import { shouldShowWatchdogDiag, isRafDebugEnabled } from '../src/components/controlPanelLabels.js'
 
-// #28 — the RAF-watchdog restart counter (store.watchdogRestarts) is surfaced as a DEV-only
-// diagnostic chip, shown only once a stall has actually happened (count > 0). Pure gate so it's
-// unit-testable without a DOM. `isDev` is passed explicitly here to decouple from the test runner's
-// import.meta.env.DEV.
+// #28 — the RAF-watchdog restart counter (store.watchdogRestarts) is surfaced as an OPT-IN DEV
+// diagnostic chip: shown only in dev, only once a stall has happened (count > 0), AND only when the
+// debug flag is opted in. Off by default for everyone so it never becomes visual noise. Pure gate so
+// it's unit-testable without a DOM — `isDev` and `debugEnabled` are passed explicitly to decouple
+// from the test runner's import.meta.env.DEV and from window.
 describe('shouldShowWatchdogDiag (#28)', () => {
-  it('shows in DEV once a stall has been recorded (count > 0)', () => {
-    expect(shouldShowWatchdogDiag(1, true)).toBe(true)
-    expect(shouldShowWatchdogDiag(7, true)).toBe(true)
+  it('shows in DEV once a stall has been recorded (count > 0) AND debug is opted in', () => {
+    expect(shouldShowWatchdogDiag(1, true, true)).toBe(true)
+    expect(shouldShowWatchdogDiag(7, true, true)).toBe(true)
+  })
+
+  it('stays hidden by default in DEV even with a non-zero count (debug not opted in)', () => {
+    expect(shouldShowWatchdogDiag(5, true, false)).toBe(false)
+    expect(shouldShowWatchdogDiag(1, true, false)).toBe(false)
   })
 
   it('stays hidden in DEV while the count is still 0 (unobtrusive at rest)', () => {
-    expect(shouldShowWatchdogDiag(0, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(0, true, true)).toBe(false)
   })
 
-  it('is never shown in production, even with a non-zero count (zero prod cost)', () => {
-    expect(shouldShowWatchdogDiag(5, false)).toBe(false)
-    expect(shouldShowWatchdogDiag(0, false)).toBe(false)
+  it('is never shown in production, even opted-in with a non-zero count (zero prod cost)', () => {
+    expect(shouldShowWatchdogDiag(5, false, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(0, false, true)).toBe(false)
   })
 
   it('guards against non-numeric / negative counts', () => {
-    expect(shouldShowWatchdogDiag(undefined, true)).toBe(false)
-    expect(shouldShowWatchdogDiag(null, true)).toBe(false)
-    expect(shouldShowWatchdogDiag(-1, true)).toBe(false)
-    expect(shouldShowWatchdogDiag(NaN, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(undefined, true, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(null, true, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(-1, true, true)).toBe(false)
+    expect(shouldShowWatchdogDiag(NaN, true, true)).toBe(false)
+  })
+})
+
+// #28 — the opt-in gate itself: `?debug=raf` in the URL OR localStorage `avo.debug.raf=on`. Safe in
+// SSR/test (no window → false) and resilient to a throwing localStorage.
+describe('isRafDebugEnabled (#28 opt-in)', () => {
+  const mkWin = ({ search = '', stored = null, throws = false } = {}) => ({
+    location: { search },
+    localStorage: { getItem: () => { if (throws) throw new Error('blocked'); return stored } },
+  })
+
+  it('is off when no window is present (SSR / test default)', () => {
+    expect(isRafDebugEnabled(undefined)).toBe(false)
+  })
+
+  it('is off by default with a bare window', () => {
+    expect(isRafDebugEnabled(mkWin())).toBe(false)
+  })
+
+  it('opts in via the ?debug=raf URL param', () => {
+    expect(isRafDebugEnabled(mkWin({ search: '?debug=raf' }))).toBe(true)
+    expect(isRafDebugEnabled(mkWin({ search: '?foo=1&debug=raf&bar=2' }))).toBe(true)
+  })
+
+  it('does not opt in for an unrelated debug value', () => {
+    expect(isRafDebugEnabled(mkWin({ search: '?debug=other' }))).toBe(false)
+  })
+
+  it('opts in via localStorage avo.debug.raf=on', () => {
+    expect(isRafDebugEnabled(mkWin({ stored: 'on' }))).toBe(true)
+    expect(isRafDebugEnabled(mkWin({ stored: 'off' }))).toBe(false)
+  })
+
+  it('never throws when localStorage access is blocked', () => {
+    expect(isRafDebugEnabled(mkWin({ throws: true }))).toBe(false)
+    expect(isRafDebugEnabled(mkWin({ search: '?debug=raf', throws: true }))).toBe(true)
   })
 })


### PR DESCRIPTION
Two independent quick-wins that both reduce on-screen / dev noise. Reviewable as two atomic commits.

## 1. Gate RAF watchdog diagnostic chip behind `?debug=raf` (`f9e1101`)
The DEV-only RAF-watchdog restart counter chip (bottom-left of the control panel) was non-actionable for everyone except a dev actively chasing a walk-loop stall — so it read as constant visual noise. It is now **off by default even in dev** and only renders when explicitly opted in via `?debug=raf` (or `localStorage avo.debug.raf=on`). The always-on `console.warn` is unchanged; prod cost stays zero (`import.meta.env.DEV` dead-code elimination).

## 2. Calm ambient walking — cut out-trip rate ~28% (`3c14b8e`)
Owner round-2 report ("一直看到很多人在走動 / 只有兩個人在座位"): ambient agents left their desks too often. The lever is the **out-trip rate**, not dwell duration (already long, bounded by `WATCHDOG_TIMEOUT`). Raised `work` in `baseWeights` / `idle` override / `moodModifiers.idle`, trimmed `away`+`daily`. `social` is **preserved** (chatting is the alive/fun channel); `working` (real-work, R1 honesty) is **untouched**.

| scenario | out-trip% before | after |
| --- | --- | --- |
| idle / normal | 45.1 | 32.4 |
| idle / idle-mood | 55.1 | 40.3 |
| working (real work) | 18.2 | 17.9 (unchanged) |

## Evidence
- Full suite **2034 tests pass** (95 files).
- RAF gate: 25 unit tests (watchdogDiag + rafWatchdog); live browser confirms chip absent by default, present with the flag, count-gate intact, no console errors.
- Walk rhythm: before/after measured via `getNextBehavior` category split (12k samples/scenario, hour 10 = no hour modifier). `teamAffectL2` pulse-0 baseline band re-anchored to the new idle `work=68`.

Classification: quick-win ×2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)