### PR TITLE
fix(docs): correct stale facts from backward audit (no behavior change)

### DIFF
--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -203,8 +203,8 @@ subagent、回合都會自動更新辦公室 —— 不用手動接線、不用 
 
 ## 技術選型
 
-React 19 + Vite 6 · SVG（不用 canvas、不吃 GPU）· Zustand · Tailwind CSS v4 · `requestAnimationFrame` · 零後端。
-1276 個測試（分類器、推論、store、移動、事件誠實性）。深入細節 → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**。
+React 19 + Vite 8 · SVG（不用 canvas、不吃 GPU）· Zustand · Tailwind CSS v4 · `requestAnimationFrame` · 零後端。
+2000+ 個測試（分類器、推論、store、移動、事件誠實性）。深入細節 → **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)**。
 
 ## 貢獻
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -350,7 +350,7 @@ agent.groupTarget   // { x, y } — AgentCharacter useEffect 監聽此值觸發�
 
 ## 多 Worktree 會話架構
 
-See also: [ADR-002 — Multi-Worktree Session Design](../adr/ADR-002-multi-worktree-session-design.md)
+See also: [ADR-002 — Multi-Worktree Session Design](adr/ADR-002-multi-worktree-session-design.md)
 
 ### 會話文件命名
 

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -111,7 +111,7 @@ Wave A shipped (PR #166). Wave B closes per AC-SEQ (`do|refine|kill` + evidence)
   ≥120s}` is **unreachable** in production — S5 would render nothing; forcing it on a stable-sig
   long task violates S5's own kill-criterion ("never dim a genuine long task"). The honesty goal (a
   frozen agent must not keep showing a confident active ring) is already met earlier + better by
-  idleGapInfer (45s) + the 5-min `expiresAt` (`store.js:992`). The `WATCHDOG_TIMEOUT=120000` the
+  idleGapInfer (45s→thinking) + the 120s staleness sweep (`inferStatus.js` clearExternalStatus). The `WATCHDOG_TIMEOUT=120000` the
   spec cites is the **animation-chain** restart timer (`AgentCharacter.jsx:1251`), not a status
   timer — a spec conflation.
 - **S3 (≤7 status symbols) / S4 (banter) → open, GATED.** Per owner "先A後B": decide after

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -988,7 +988,9 @@ export const useOfficeStore = create((set) => ({
           // working/blocked: 5 min expiry — long-running tool calls (build, test suite, npm install)
           // can take >30s with no hook event between PreToolUse and PostToolUse; a shorter
           // expiry caused the workflow banner to flicker off mid-run and then self-heal.
-          // done: 10s expiry (brief celebration then back to idle)
+          // NOTE: in practice the 120s staleness sweep (inferStatus.js clearExternalStatus) clears a
+          // static external status first, so this 5-min value is a rarely-reached backstop, not the
+          // primary expiry path. done: 10s expiry (brief celebration then back to idle)
           expiresAt: u.status === 'done' ? now + 10000 : now + 300000,
           changedAt: sigChanged ? now : (Number.isFinite(prevExt.changedAt) ? prevExt.changedAt : now),
         }


### PR DESCRIPTION
## What
Corrects stale facts found in the backward audit. **No behavior change.**

## Changes
- `docs/specs/_product-backlog.md` — the S5-kill note cited "5-min `expiresAt`" as the honesty backstop; in practice the **120s staleness sweep** (`inferStatus.js` `clearExternalStatus`) clears a static external status first, so corrected to "120s staleness sweep + idleGapInfer 45s→thinking".
- `src/systems/store.js` — **comment-only** clarification that the 300s working/blocked `expiresAt` is a rarely-reached backstop (the 120s staleness sweep is the primary clear). No logic change.
- `README.zh-TW.md` — `Vite 6`→`Vite 8`, `1276 個測試`→`2000+` (matched EN README / `package.json` `vite ^8` / suite = 2153).
- `docs/ARCHITECTURE.md` — fixed broken relative link `../adr/`→`adr/` (the file lives at `docs/adr/`).

## Deliberately NOT in this PR
- The audit's **honesty finding** (clickable deploy-button/whiteboard fire work-outcome claims bypassing `eventEligible`) — handled via an expert panel + owner decision; separate PR.
- zh README section-parity gap (missing hooks/soak/capture sections vs EN) — larger translation, separate follow-up.

## Verify
- build clean; store-touching tests pass; `git diff --check` clean; comment/docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
