### PR TITLE
fix: honesty + a11y bugs (AVO-171/172/173/175/176/177) + research/audit catalogue

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-15T08:22:58Z
-- **Update Sequence**: 93
+- **Last Updated**: 2026-06-19T05:14:49Z
+- **Update Sequence**: 94
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -163,6 +163,14 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-fix-honesty-a11y-bugs-2026-06-19 (PR #173 — AVO-171/172/173 + AVO-175/176/177 + audit catalogue)
+
+- Shipped 6 internal-audit defects on `fix/avo-171-pet-await-honesty-a11y` (quick-win). **AVO-171 (P1 honesty)**: the office-pet hide-on-blocker guarantee now counts `awaiting-approval` (was: pet could un-hide and CELEBRATE while an agent was stuck at a permission prompt); blocker definition centralised in `petState.js` (`countAttentionBlockers`/`firstAttentionBlockerId`/`BLOCKED_LIKE_STATUSES`) so it can't drift from `desktopNotifier` `BLOCKED_DERIVED`. **AVO-172**: `stopDesktopNotifier` now prunes `recurringNotifiedFor` by its own keys + `_resetDesktopNotifierState` no longer leaks recurring dedupe across tests. **AVO-173**: `idleGapInfer.computeSig` now reads `task` from `externalStatus` (the agents slice never carries it — `store.js` writes only status/behavior/expression), so a tool-busy agent isn't mislabelled `thinking`; the old test used a non-production store shape — production-shape regression added + test-the-test verified. **AVO-175/176/177 (a11y)**: reduced-motion gating (health-dot/activeEvent/connection-hint), keyboard-operable inspector ✕ close, i18n/aria parity (+`aria.showOffice/showList/close` en+zh-TW).
+- Catalogue (`_product-backlog.md`): new Optimization & Charm tier (AVO-163..170, AVO's own terms, no external attribution) + Bugs & Correctness tier (AVO-171..179, file:line-verified) + considered-and-declined ledger; **AVO-162 retracted** to `## Closed` (duplicate of shipped AVO-111 time-of-day lighting, caught same-session). Closed 4 stale GitHub issues (AVO-109/113/119/137) per ADR-006.
+- Verify: full suite **2169 pass** (+11); build clean; CI all green (audit/Semgrep/TruffleHog/pack-smoke/render-smoke/test×2); `validate.sh` text-integrity + backlog↔SSoT consistency PASS; uniform CRLF.
+- Open follow-ups (catalogued, NOT in this PR): AVO-174 (title-inference can inject `blocked` from a browser tab title — scope decision), AVO-178/179 (test debt: movementSystem + honesty-path inference), AVO-163..170 (optimizations).
+- Tests: Pass
 
 ### Ship-feat-dialogue-interaction-layer-waveA-2026-06-15 (PR #166 — voices + reduction + de-fabricate)
 

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -99,6 +99,10 @@ last_updated: 2026-06-15
 > optimization tier above, several are **real defects** — AVO-171 violates a shipped honesty guarantee.
 > HIGH-confidence items were re-verified by reading the cited file:line; lower-confidence ones carry a
 > confirm step. AVO's own terms (no external attribution).
+>
+> **Status (branch `fix/avo-171-pet-await-honesty-a11y`, 2026-06-19):** ✅ FIXED — AVO-171 (pet honesty,
+> +8 tests), AVO-172 (notifier recurring-prune + reset-helper, +1 test), AVO-175/176/177 (a11y). **Open:**
+> AVO-173 (P2 — needs repro), AVO-174 (P3 — read `inferStatus.js` first), AVO-178/179 (test debt).
 
 | # | Defect | Severity | Evidence (file:line) | Fix (small + reversible) | Verified |
 |---|---|---|---|---|---|

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -46,6 +46,86 @@ last_updated: 2026-06-15
 
 ---
 
+## Optimization & Charm Backlog — Existing-Item Tuning (2026-06-19, must earn place)
+
+> A 2026-06-19 internal research + code-audit pass produced these. All are framed in **AVO's own
+> terms** (no external attribution). They are **candidates, NOT commitments** — each must self-justify
+> via the per-visual-feature gate (chill/office-sim panel + automated legibility guard + adversarial
+> verify of MERGED main) before it earns a Feature Inventory row. Owner lean = **optimize existing
+> rhythm/pacing over net-new chrome.** Theme law: chill+fun, honest, REDUCE-not-add. Distinct tier
+> from the committed Feature Inventory — keeps the SSoT "3 open on-mission items" honest. Each row
+> cites the file/lever so a future `/plan` can lift it directly; every "AVO lacks X" was confirmed by
+> a read file:line (after the AVO-162 dup-proposal was caught same-session).
+
+| # | Optimization (testable) | Honesty / R1 guard | REDUCE? | Key file / lever |
+|---|---|---|---|---|
+| AVO-163 | Static idle agents get a phase-desynced **breathing/blink micro-loop** (+ ease-out motion) so they read "alive" with zero new assets. | Fires ONLY in genuine idle; breathe is IDENTICAL regardless of status (never implies progress/emotion); distinct from the existing supervising-breathe / working-pulse rings. | ~ (polish on existing motion) | `AgentCharacter.jsx` `CharacterPixelSprite` (idle body is static today, ~L368-397) |
+| AVO-164 | An all-idle office renders a deliberate **"all quiet / all caught up"** calm state (vs reading dead) → honest permission-to-stop. | No streak, no "agents miss you", no fake activity to fill the screen. | ✅ (reframes empty, adds nothing) | new calm-state branch; not present today |
+| AVO-165 | **Walk-rhythm / out-trip reduction**: trim ambient out-trips so the office reads calmer (owner's recurring "too walk-heavy"). | `statusOverrides.working` (R1) and `social` weight untouched; before/after via `getNextBehavior` category split. | ✅✅ (fewer out-trips) | `behaviorEngine.js:21` `baseWeights{work:74,away:5}` → work↑ / away↓ |
+| AVO-166 | Codify a **"no-fabricated-need" rule** (ban streak / decay-if-you-leave / fake urgency / relationship-memory / unbound decorative channels) into the guardrails — makes the honesty boundary enforceable for every future ambient/pet proposal. | Doc/guardrail only — gates future proposals, fabricates nothing. | ✅ (a guard, not a feature) | `.agent/rules/` guardrails |
+| AVO-167 | Give the **`awaiting-approval` ("waiting on you") state its own ring + name-tag colour** — today it falls back to identity colour and reads like a normal idle agent. | State already inferred from real signals (`idleGapInfer`); new colour must pass the existing contrast guard. | ~ (one colour entry + one ring branch) | `constants.js:82-88` STATUS_COLORS · `AgentCharacter.jsx:1411` ring branch |
+| AVO-168 | **Ambient events rarer + more rewarding**: widen the daily/rare event intervals and give a rare event a slightly bigger juice payload. | Juice stays gated on real signals (`eventEligible`); no new event types added. | ✅ (less churn) | `constants.js:53-54` intervals · `eventJuice.js:15-16` counts |
+| AVO-169 | Show **elapsed-time-in-state** ("blocked for 3m" / "waiting for 3m") in the agent inspector. | Driven only by real `changedAt`; inspector-only (no scene clutter). | ✅ (reuses `formatTimeAgo`) | `AgentInspector.jsx:~200` · `NarrowRoster.jsx:~59` |
+| AVO-170 | **Notification etiquette**: make the OS blocked-alert chime a user preference (don't blind-silence a functional "come back" alert) + audit the 30s-notice vs recurring-pattern paths so one episode can't double-fire unintentionally. | Visual banner unchanged; only fires while tab hidden + permission granted. | ✅ (calmer default, no new surface) | `desktopNotifier.js:94/115` `silent` · `:30` threshold |
+
+> **AC-SEQ:** each resolves to `do | refine | kill` with evidence when picked up. Likely first
+> pickups (owner pacing lean + core status-visibility value): **AVO-165** (walk-rhythm — measure
+> `getNextBehavior` split first) + **AVO-167** (await-you visibility). AVO-168/169/170 are cheap
+> measurable tunes; AVO-163/164 need the chill panel first; AVO-166 is a doc landable anytime.
+>
+> **Considered & declined 2026-06-19** (recorded so they are NOT re-proposed as actionable): auto-apply
+> a calendar season tint (conflicts with AVO-123's deliberate manual opt-in; only ½ the year has
+> tints) · a "stale-feed" glyph on idle agents (marginal; a new visual channel = clutter; unverified
+> write path) · clamping office-pet wander cadence (pet liveliness is user-chosen) · tightening the
+> time-of-day refresh below 60s (lighting changes hourly — no perceptible lag) · a spatial "error
+> corner" zone for blocked agents (**violates R1** — never relocate a real agent; the in-place
+> gate-desk tray AVO-107 is the honest equivalent).
+>
+> **Already-shipped — do NOT re-propose:** background push-ping (#8) · weather (#14) · soundscape
+> (AVO-122) · seasonal tint (AVO-123) · blocked/await-you reasons (AVO-110/148/107) · zen far-view
+> (AVO-137 closed) · time-of-day lighting (AVO-111 — `lighting.js`) · generative backstory/gossip +
+> cost/DAG charts (ADR-006).
+>
+> **Codebase-verified 2026-06-19:** **AVO-162 RETRACTED** — duplicate of shipped AVO-111 (moved to
+> `## Closed`). AVO-138 supervising-breathe / working-pulse rings already exist (AVO-163 must not
+> stack on them). AVO-165 extends the 2026-06-14 walk-rhythm ship (−28% out-trips). AVO-164/166/167/
+> 169/170 confirmed not present; AVO-168 tunes existing constants.
+
+---
+
+## Bugs & Correctness — Internal Audit (2026-06-19)
+
+> A 2026-06-19 AVO-internal code audit (tech-debt + a11y + honesty edge-cases). Unlike the
+> optimization tier above, several are **real defects** — AVO-171 violates a shipped honesty guarantee.
+> HIGH-confidence items were re-verified by reading the cited file:line; lower-confidence ones carry a
+> confirm step. AVO's own terms (no external attribution).
+
+| # | Defect | Severity | Evidence (file:line) | Fix (small + reversible) | Verified |
+|---|---|---|---|---|---|
+| AVO-171 | **Pet hide-on-blocker guarantee misses `awaiting-approval`** — when an agent is stuck at a permission prompt (inferred `awaiting-approval` after 90s blocked), `blockedCount`=0, so the pet un-hides and a concurrent deploy/eureka can fire CELEBRATE/confetti while a real "needs-you" item is pending. | **P1 honesty** | `OfficePet.jsx:52-53` (count) + `:57-58` (point-at) only match `status==='blocked'`; `desktopNotifier.js:44` already treats `awaiting-approval` as blocked-derived | count `awaiting-approval` in both selectors (mirror `BLOCKED_DERIVED`) | ✅ read-verified |
+| AVO-172 | `recurringNotifiedFor` not pruned on agent eviction → a re-spawned same-id agent never gets its recurring-failure OS notification (stale dedupe suppresses it). | P3 | `desktopNotifier.js:204-208` deletes `blockedSince`/`notifiedFor` but not `recurringNotifiedFor` (`:38`) | add `recurringNotifiedFor.delete(agentId)` to the cleanup loop | ✅ read-verified |
+| AVO-173 | `idleGapInfer.computeSig` reads `agents[id].task`, but `task` lives on `externalStatus[id]` (not the agents slice) → a tool-busy agent (Read→Grep→Edit, status stays `working`) may be falsely inferred `working→thinking` after 45s. | P2 | `idleGapInfer.js:89-94` reads `a?.task`; `store.js:802,1017` put `task` on `externalStatus` only | point `computeSig` at `externalStatus[id]?.task` — **CONFIRM FIRST**: repro + reconcile with the SSoT "changedAt co-moves with idleGapInfer" claim | ◐ slice-location confirmed; impact needs a repro |
+| AVO-174 | Title-inference channel can inject `blocked` for `dev` from non-agent signals (a browser tab titled "…failed/blocked") → most-alarming state from the weakest signal, persists 120s. | P3 | `inferStatus.js:651-687` (reported, not personally read) | cap this channel at `thinking`/`working`, never `blocked`; or gate it | ◌ unverified — read before acting |
+| AVO-175 | Reduced-motion gaps: `animate-pulse` ungated on `reducedMotion` at the health-dot + activeEvent pill + connection-hint (HTML layer; the SVG layer is fully gated). | P2 a11y | `ControlPanel.jsx:47,424` · `PixelOffice.jsx:1255` | read `reducedMotion`, conditionally drop `animate-pulse` | ✅ pattern-verified |
+| AVO-176 | Agent inspector ✕ close is a bare SVG `<text onClick>` — no keyboard path, no role/aria (Esc closes, but the visual target is keyboard/AT-invisible). | P2 a11y | `AgentInspector.jsx:150-152` | wrap in `role=button tabIndex=0 aria-label` + Enter/Space keydown | ✅ read-verified |
+| AVO-177 | i18n/AT leaks: `aria-label="working"` hardcoded English (zh-TW AT hears English); `aria.showOffice`/`aria.showList` missing from both locales; ActivityFeed toggle has `title` but no `aria-label`. | P3 a11y | `NarrowRoster.jsx:28,30` · `ControlPanel.jsx:296` · `ActivityFeed.jsx:42-45` | route through `t()` / add the two locale keys / add `aria-label` | ✅ read-verified |
+| AVO-178 | No test coverage for `movementSystem` (`calculatePath`/`lineHitsRect`) — the most complex pure-function cluster, with a documented past fuzz regression; a renderer-less regression is CI-invisible but visually obvious (agents through desks). | P2 debt | `movementSystem.js:281-307,635-673`; no `movementSystem.test.js` | add ~15 pure-function cases (no behavior change) | ✅ glob-verified |
+| AVO-179 | No test coverage for honesty-path inference (`agentRouter` routing, `contextBubble` generation) — a wrong-agent or mis-triggered cross-reaction would be CI-invisible. | P3 debt | `inference/agentRouter.js`, `systems/contextBubble.js` (no tests) | start with the pure mapping / `extractContext` functions | ✅ glob-verified |
+
+> **Minor cleanups (low value — recorded, likely decline):** hour-14 drowsiness fires N sequential
+> `setAgentBehavior` writes vs one `setMultipleAgentGroupEvents` batch (`officeLife.js:812-817`, once/day)
+> · two parallel 60s `setInterval` loops could merge (`officeLife.js:746-753`) · possibly-stale `esbuild`
+> override (`package.json:78`) · PixelOffice 600ms self-heal poll runs in non-panel mode too (`:980`,
+> no-ops so harmless).
+>
+> **Confirmed SAFE (audit reassurance):** clickable-object work-claims fully `eventEligible`-gated · pet
+> CELEBRATE suppressed on real `blocked` (AVO-171 is only the `awaiting-approval` sub-case) · done-counter
+> dedupe airtight · `AGENT_CARRY_FIELDS` drift CI-guarded · blocked↔awaiting flap does not double-notify ·
+> all clocks real (no accelerated/fake time). **Barrel signal:** honesty discipline is strong; AVO-171 is
+> the one materially-visible leak — further auditing yields diminishing returns.
+
+---
+
 ## Closed
 
 > Decided-out items, kept so they are not silently re-proposed. `Cancelled` = won't build. Each
@@ -64,6 +144,7 @@ last_updated: 2026-06-15
 | AVO-137 | Density-layer foundation / zen far-view | Cancelled | 2026-06-15 review | the glance-L1-default motivation already shipped (vibe-rebalance AVO-126/127/128 + declutter bubble-cap PR #81); the only unbuilt remainder was a wall-TV/streamer zen far-view, which is not a target use case |
 | AVO-142 | Drag-to-move agents | Cancelled | ADR-005 (rejected) | position=state honesty; interaction redirected to AVO-158 Poke (shipped) |
 | AVO-144 | Sustained per-frame inter-agent separation | Cancelled | ADR-004 (rejected) | doorway geometry + R1; target-time deconfliction is the mechanism |
+| AVO-162 | Real-clock time-of-day light wash | Cancelled | 2026-06-19 research | DUPLICATE — already shipped as AVO-111 (`src/systems/lighting.js`, 15-keyframe 24h grade, `lightingEnabled` toggle, real-clock `getHours`; AVO-123/125 depend on it; `_shipped-log.md:172`). Proposed in error 2026-06-19; caught same-session by codebase grep. Lesson: grep code + `_shipped-log.md` before proposing "new" candidates (AVO-111 was not in the SSoT Spec Index). |
 
 > **AVO-108 $ remainder cancelled** (ADR-006): the rolling-1h + $ cost + sparkline portion of the
 > token meter is off-mission. AVO-108's honest core (🪙 ctx + model chip, in the inspector per

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -101,8 +101,10 @@ last_updated: 2026-06-15
 > confirm step. AVO's own terms (no external attribution).
 >
 > **Status (branch `fix/avo-171-pet-await-honesty-a11y`, 2026-06-19):** ✅ FIXED — AVO-171 (pet honesty,
-> +8 tests), AVO-172 (notifier recurring-prune + reset-helper, +1 test), AVO-175/176/177 (a11y). **Open:**
-> AVO-173 (P2 — needs repro), AVO-174 (P3 — read `inferStatus.js` first), AVO-178/179 (test debt).
+> +8 tests), AVO-172 (notifier recurring-prune + reset-helper, +1 test), **AVO-173** (idle-gap now reads
+> `task` from externalStatus so a busy tool-using agent isn't mislabelled `thinking`; the old test used a
+> non-production store shape — production-shape regression added + test-the-test verified, +1 test),
+> AVO-175/176/177 (a11y). **Open:** AVO-174 (P3 — read `inferStatus.js` first), AVO-178/179 (test debt).
 
 | # | Defect | Severity | Evidence (file:line) | Fix (small + reversible) | Verified |
 |---|---|---|---|---|---|

--- a/src/components/ActivityFeed.jsx
+++ b/src/components/ActivityFeed.jsx
@@ -43,6 +43,7 @@ export default function ActivityFeed({ mode = 'full' }) {
         onClick={() => setCollapsed(!collapsed)}
         className="w-10 h-10 rounded-full bg-white/90 dark:bg-gray-800/90 backdrop-blur border border-gray-200 dark:border-gray-700 shadow-lg flex items-center justify-center hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors relative"
         title={collapsed ? t('activityFeed.expand', 'Activity Feed') : t('activityFeed.collapse', 'Collapse')}
+        aria-label={collapsed ? t('activityFeed.expand', 'Activity Feed') : t('activityFeed.collapse', 'Collapse')}
       >
         <span className="text-sm">📋</span>
         {collapsed && unreadCount > 0 && (

--- a/src/components/AgentInspector.jsx
+++ b/src/components/AgentInspector.jsx
@@ -147,10 +147,14 @@ export default function AgentInspector() {
         <text x={10} y={18} fontSize="12" fontFamily="monospace" fontWeight="bold" fill="white">
           {name}
         </text>
-        <text x={W - 14} y={18} fontSize="12" fontFamily="monospace" fill="white"
-          style={{ cursor: 'pointer' }} onClick={clearSelectedAgent}>
-          ✕
-        </text>
+        <g role="button" tabIndex={0} aria-label={t('aria.close', 'Close inspector')}
+          onClick={clearSelectedAgent}
+          onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); clearSelectedAgent() } }}
+          style={{ cursor: 'pointer' }}>
+          <text x={W - 14} y={18} fontSize="12" fontFamily="monospace" fill="white">
+            ✕
+          </text>
+        </g>
 
         {/* Status badge */}
         <circle cx={12} cy={42} r={5} fill={STATUS_COLORS[status] || color || '#888'} />

--- a/src/components/ControlPanel.jsx
+++ b/src/components/ControlPanel.jsx
@@ -32,7 +32,7 @@ const HEALTH_TONE = {
   emerald: { bg: 'bg-emerald-500',              text: 'text-emerald-600 dark:text-emerald-400' },
   gray:    { bg: 'bg-gray-400 dark:bg-gray-500', text: 'text-gray-500 dark:text-gray-400' },
 }
-function HealthDot({ dot }) {
+function HealthDot({ dot, reducedMotion }) {
   const tone = HEALTH_TONE[dot.tone] || HEALTH_TONE.gray
   const detail = t(dot.labelKey, dot.level).replace('{0}', dot.labelVal == null ? '' : String(dot.labelVal))
   const summary = `${t('aria.health', 'Connection status')}: ${detail}`
@@ -44,7 +44,7 @@ function HealthDot({ dot }) {
         aria-label={summary}
         title={detail}
       >
-        <span className={`inline-block w-1.5 h-1.5 rounded-full ${tone.bg} ${dot.pulse ? 'animate-pulse' : ''}`} aria-hidden="true" />
+        <span className={`inline-block w-1.5 h-1.5 rounded-full ${tone.bg} ${dot.pulse && !reducedMotion ? 'animate-pulse' : ''}`} aria-hidden="true" />
         {dot.trouble && <span className={`text-[10px] font-medium ${tone.text}`}>{detail}</span>}
       </button>
       {!dot.trouble && (
@@ -93,6 +93,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
   const statusSource = useOfficeStore((s) => s.statusSource)
   const tokens = useOfficeStore(useShallow((s) => s.tokens))  // AVO-108
   const integrationHealth = useOfficeStore(useShallow((s) => s.integrationHealth))
+  const reducedMotion = useOfficeStore((s) => s.reducedMotion)
   // Subscribe to ledger objects (clone-on-write — identity only changes on actual
   // increment or day rollover). Sum in useMemo so the reduction doesn't re-run on
   // unrelated re-renders (clock tick, agent move).
@@ -220,7 +221,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
             })}
           </div>
           {/* AVO-130: one health dot (was separate live + offline pills). */}
-          <HealthDot dot={dotState} />
+          <HealthDot dot={dotState} reducedMotion={reducedMotion} />
           {/* AVO-129: ✓/✗ KPI removed from the persistent bar (the day's rhythm is felt
               through events, not read off a tally). Data path (ledgers) is unchanged. */}
           <button onClick={togglePause} className="px-1 py-0.5 rounded border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800" aria-label={isPaused ? t('aria.resume', 'Resume') : t('aria.pause', 'Pause')}>
@@ -421,7 +422,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         </div>
 
         {activeEvent && (
-          <div className="text-yellow-600 dark:text-yellow-400 animate-pulse shrink-0">
+          <div className={`text-yellow-600 dark:text-yellow-400 shrink-0${reducedMotion ? '' : ' animate-pulse'}`}>
             {activeEvent.id ? eventName(activeEvent.id) : activeEvent.name}
           </div>
         )}
@@ -429,7 +430,7 @@ export default function ControlPanel({ platform = 'browser', mode = 'full' }) {
         {/* AVO-130: one health dot replaces the 2–4 connection/integration pills that used to
             render side-by-side. Trouble auto-shows its inline label; calm states reveal detail
             on hover/focus. */}
-        <HealthDot dot={dotState} />
+        <HealthDot dot={dotState} reducedMotion={reducedMotion} />
 
         {/* AVO-129 + AVO-127: the ✓/✗ KPI and 🪙 token meter live on-demand in the info popover
             (opened from the ⚙ menu). AVO-130: language, list-view, run-workflow, help, and the

--- a/src/components/NarrowRoster.jsx
+++ b/src/components/NarrowRoster.jsx
@@ -25,9 +25,9 @@ function lastChangedAt(ext) {
 }
 
 function TypingDots({ reducedMotion }) {
-  if (reducedMotion) return <span className="text-gray-400" aria-label="working">…</span>
+  if (reducedMotion) return <span className="text-gray-400" aria-label={t('statusLabels.working', 'working')}>…</span>
   return (
-    <span className="inline-flex items-center gap-[3px] pr-0.5" aria-label="working">
+    <span className="inline-flex items-center gap-[3px] pr-0.5" aria-label={t('statusLabels.working', 'working')}>
       {[0, 1, 2].map((i) => (
         <span
           key={i}

--- a/src/components/OfficePet.jsx
+++ b/src/components/OfficePet.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useOfficeStore } from '../systems/store.js'
 import { clampToFloor, isOnFloor, isOnObstacle } from '../systems/movementSystem.js'
-import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, modeEmote, pickWanderTarget, PET_MODES } from '../systems/petState.js'
+import { derivePetState, petIsMobile, resolvePetMode, petReadabilityScale, petMotionGrammar, runTarget, modeEmote, pickWanderTarget, countAttentionBlockers, firstAttentionBlockerId, PET_MODES } from '../systems/petState.js'
 import PetSprite from './petSprites.jsx'
 import { useTransientFlag } from './useTransientFlag.js'
 
@@ -49,13 +49,15 @@ export default function OfficePet() {
   const reducedMotion = useOfficeStore((s) => s.reducedMotion)
   const mood = useOfficeStore((s) => s.mood)
   // live blocked count — primitive, so the pet re-renders only when it actually changes.
-  const blockedCount = useOfficeStore((s) =>
-    Object.values(s.externalStatus).filter((e) => e && e.status === 'blocked').length)
+  // AVO-171: counts `blocked` AND `awaiting-approval` (a permission-prompt wait is still a real
+  // "needs-you" blocker) so the hide-on-blocker honesty guarantee can't be bypassed by the 90s
+  // blocked→awaiting-approval idle-gap reclassification.
+  const blockedCount = useOfficeStore((s) => countAttentionBlockers(s.externalStatus))
   // #39: the position of a currently-blocked agent (so the pet can trot over and "point at" it). A
   // PRIMITIVE "x,y" string → stable re-render; reads the store's already-published agent.position
   // (read-only — never HOME_POSITIONS / movement internals).
   const blockedAgentPos = useOfficeStore((s) => {
-    const id = Object.keys(s.externalStatus).find((k) => s.externalStatus[k]?.status === 'blocked')
+    const id = firstAttentionBlockerId(s.externalStatus)
     const p = id && s.agents[id]?.position
     return p && Number.isFinite(p.x) ? `${Math.round(p.x)},${Math.round(p.y)}` : null
   })

--- a/src/components/PixelOffice.jsx
+++ b/src/components/PixelOffice.jsx
@@ -1252,7 +1252,7 @@ export default function PixelOffice({ animationQuality = 'full', mode = 'full' }
 
       {/* ═══ CONNECTION HINT (shown until first external status is received) ═══ */}
       {!hasEverReceivedStatus && (
-        <g className="animate-pulse" opacity="0.85" pointerEvents="none">
+        <g className={reducedMotion ? '' : 'animate-pulse'} opacity="0.85" pointerEvents="none">
           <text x="400" y="28" textAnchor="middle" fontSize="11" fill="#d4c8a0" fontFamily="monospace">
             {t('hint.noConnection')}
           </text>

--- a/src/inference/desktopNotifier.js
+++ b/src/inference/desktopNotifier.js
@@ -207,6 +207,12 @@ export function startDesktopNotifier(store, options = {}) {
         notifiedFor.delete(agentId)
       }
     }
+    // AVO-172: recurringNotifiedFor can hold keys that blockedSince does NOT (an episode entering via
+    // the awaiting-approval branch never sets blockedSince), so prune it by its OWN keys — otherwise a
+    // re-spawned same-id agent's recurring-failure notice stays suppressed across spawned instances.
+    for (const agentId of recurringNotifiedFor.keys()) {
+      if (!(agentId in currentAgents)) recurringNotifiedFor.delete(agentId)
+    }
   }
 }
 
@@ -217,4 +223,10 @@ export function startDesktopNotifier(store, options = {}) {
 export function _resetDesktopNotifierState() {
   blockedSince.clear()
   notifiedFor.clear()
+  recurringNotifiedFor.clear()  // AVO-172: was leaking recurring dedupe state across tests
+}
+
+// Test/inspection helper: current keys of the recurring-notification dedupe map (AVO-172 prune test).
+export function _recurringNotifiedKeys() {
+  return [...recurringNotifiedFor.keys()]
 }

--- a/src/inference/idleGapInfer.js
+++ b/src/inference/idleGapInfer.js
@@ -86,12 +86,19 @@ function tick(store, opts, now = Date.now) {
  * (movementSystem mutates position 60 times per second). We track only the
  * (status, task) signature.
  */
-function computeSig(agents) {
+function computeSig(state) {
+  const agents = state?.agents
   if (!agents) return ''
+  // AVO-173: `task` lives on externalStatus in production — the agents slice never carries it
+  // (store.js applyExternalStatus writes only status/behavior/expression). Read task from there so a
+  // tool change (Read→Grep with status staying 'working') resets the clock and we don't falsely infer
+  // 'thinking' on an actively tool-using agent. Fall back to agents[id].task for robustness/older tests.
+  const externalStatus = state?.externalStatus || {}
   let sig = ''
   for (const id of Object.keys(agents)) {
     const a = agents[id]
-    sig += `${id}:${a?.status ?? ''}:${a?.task ?? ''};`
+    const task = externalStatus[id]?.task ?? a?.task ?? ''
+    sig += `${id}:${a?.status ?? ''}:${task};`
   }
   return sig
 }
@@ -101,9 +108,9 @@ function subscribeAgentUpdates(store, now = Date.now) {
   // only sees real diffs — without this, every agent in the initial roster
   // would be treated as "newly added" and get stamped on the first store
   // mutation, defeating the gap-detection logic.
-  let prevSig = computeSig(store.getState().agents)
+  let prevSig = computeSig(store.getState())
   return store.subscribe((state) => {
-    const nextSig = computeSig(state.agents)
+    const nextSig = computeSig(state)
     if (nextSig === prevSig) return
     // At least one agent's status/task changed. Diff which one and stamp.
     // For simplicity we re-stamp all agents whose signature differs from

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -312,7 +312,10 @@
     "petOn": "Show office pet",
     "petType": "Change pet",
     "settings": "Settings",
-    "info": "Info"
+    "info": "Info",
+    "showOffice": "Show office",
+    "showList": "Show list view",
+    "close": "Close inspector"
   },
   "settings": {
     "weather": "Weather animations",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -312,7 +312,10 @@
     "petOn": "顯示辦公室寵物",
     "petType": "更換寵物",
     "settings": "設定",
-    "info": "資訊"
+    "info": "資訊",
+    "showOffice": "顯示辦公室",
+    "showList": "顯示清單",
+    "close": "關閉資訊卡"
   },
   "settings": {
     "weather": "天氣動畫",

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -50,6 +50,35 @@ export function derivePetState({ mood, blockedCount = 0 } = {}) {
   return MOOD_TO_PET[mood] || PET_MODES.WANDER
 }
 
+// AVO-171: statuses that count as a real "needs-you" blocker for the hide-on-blocker honesty
+// guarantee. `awaiting-approval` is idle-gap-inferred from blocked+90s — an agent stuck at a
+// permission prompt is STILL blocked, so it must hide the pet (and never let it celebrate). Mirrors
+// desktopNotifier `BLOCKED_DERIVED` + recurringFailure `BLOCKED_FAMILY`; centralised here so the
+// pet's definition can't drift from the notifier's blocked-episode definition (the AVO-171 bug).
+export const BLOCKED_LIKE_STATUSES = Object.freeze(['blocked', 'awaiting-approval'])
+const BLOCKED_LIKE_SET = new Set(BLOCKED_LIKE_STATUSES)
+
+// countAttentionBlockers(externalStatus) → how many agents are in a real "needs-you" blocked state
+// (blocked OR awaiting-approval). Pure → unit-testable. The pet's blockedCount selector uses this.
+export function countAttentionBlockers(externalStatus) {
+  if (!externalStatus) return 0
+  let n = 0
+  for (const e of Object.values(externalStatus)) {
+    if (e && BLOCKED_LIKE_SET.has(e.status)) n++
+  }
+  return n
+}
+
+// firstAttentionBlockerId(externalStatus) → id of the first blocked/awaiting-approval agent (for the
+// pet's run-to-desk "point at the blocker" beat), or null. Pure.
+export function firstAttentionBlockerId(externalStatus) {
+  if (!externalStatus) return null
+  for (const id of Object.keys(externalStatus)) {
+    if (BLOCKED_LIKE_SET.has(externalStatus[id]?.status)) return id
+  }
+  return null
+}
+
 // The pet only roams in the active base modes; nap/hide and the transient reaction poses
 // (alert/celebrate) hold position so the pose itself conveys the signal.
 export function petIsMobile(mode) {

--- a/src/systems/petState.test.js
+++ b/src/systems/petState.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import {
+  countAttentionBlockers,
+  firstAttentionBlockerId,
+  derivePetState,
+  resolvePetMode,
+  PET_MODES,
+  BLOCKED_LIKE_STATUSES,
+} from './petState.js'
+
+// AVO-171 — the pet's hide-on-blocker honesty guarantee must include `awaiting-approval`
+// (idle-gap-inferred from blocked+90s = an agent stuck at a permission prompt). Before the fix, the
+// pet only counted `status === 'blocked'`, so after the 90s reclassification the pet un-hid and a
+// concurrent deploy/eureka could fire CELEBRATE while an agent was genuinely stuck.
+describe('AVO-171 pet hide-on-blocker includes awaiting-approval', () => {
+  it('BLOCKED_LIKE_STATUSES covers blocked + awaiting-approval', () => {
+    expect([...BLOCKED_LIKE_STATUSES].sort()).toEqual(['awaiting-approval', 'blocked'])
+  })
+
+  it('countAttentionBlockers counts blocked', () => {
+    expect(countAttentionBlockers({ a: { status: 'blocked' } })).toBe(1)
+  })
+
+  it('countAttentionBlockers counts awaiting-approval (the gap this fix closes)', () => {
+    expect(countAttentionBlockers({ a: { status: 'awaiting-approval' } })).toBe(1)
+  })
+
+  it('counts both blocked and awaiting-approval, ignores other/empty statuses', () => {
+    const ext = {
+      a: { status: 'blocked' },
+      b: { status: 'awaiting-approval' },
+      c: { status: 'working' },
+      d: { status: 'idle' },
+      e: null,
+    }
+    expect(countAttentionBlockers(ext)).toBe(2)
+  })
+
+  it('handles empty / nullish input', () => {
+    expect(countAttentionBlockers({})).toBe(0)
+    expect(countAttentionBlockers(null)).toBe(0)
+    expect(countAttentionBlockers(undefined)).toBe(0)
+  })
+
+  it('firstAttentionBlockerId returns the first blocked/awaiting-approval id, else null', () => {
+    expect(firstAttentionBlockerId({ a: { status: 'working' }, b: { status: 'awaiting-approval' } })).toBe('b')
+    expect(firstAttentionBlockerId({ a: { status: 'blocked' } })).toBe('a')
+    expect(firstAttentionBlockerId({ a: { status: 'idle' } })).toBeNull()
+    expect(firstAttentionBlockerId(null)).toBeNull()
+  })
+
+  it('an awaiting-approval agent forces the pet to HIDE (derivePetState)', () => {
+    const blockedCount = countAttentionBlockers({ a: { status: 'awaiting-approval' } })
+    expect(derivePetState({ mood: 'smooth', blockedCount })).toBe(PET_MODES.HIDE)
+  })
+
+  it('REGRESSION: the pet does NOT celebrate while an agent is awaiting-approval', () => {
+    const blockedCount = countAttentionBlockers({ stuck: { status: 'awaiting-approval' } })
+    const base = derivePetState({ mood: 'smooth', blockedCount })
+    const mode = resolvePetMode({ base, celebrate: true })
+    expect(mode).toBe(PET_MODES.HIDE)
+    expect(mode).not.toBe(PET_MODES.CELEBRATE)
+  })
+})

--- a/tests/desktopNotifier.test.js
+++ b/tests/desktopNotifier.test.js
@@ -18,6 +18,7 @@ import {
   getNotificationState,
   isNotificationGranted,
   _resetDesktopNotifierState,
+  _recurringNotifiedKeys,
 } from '../src/inference/desktopNotifier.js'
 
 // Minimal store shim
@@ -382,5 +383,23 @@ describe('desktopNotifier — recurring-failure notice (AVO-117)', () => {
     const stop = startDesktopNotifier(store, { now: () => now })
     expect(recurringFires().length).toBe(0)
     stop()
+  })
+
+  it('AVO-172: prunes recurringNotifiedFor for an evicted agent on stop (re-spawn re-notifies)', () => {
+    const now = 3_000_000
+    let state = {
+      agents: { dev: { status: 'blocked' } },
+      externalStatus: { dev: { reasonCode: 'build-failed' } },
+      recurringFailureLog: { dev: { 'build-failed': [now - 2000, now - 1000, now] } },
+    }
+    const store = { getState: () => state }
+    const stop = startDesktopNotifier(store, { now: () => now }) // immediate tick fires recurring
+    expect(recurringFires().length).toBe(1)
+    expect(_recurringNotifiedKeys()).toContain('dev')
+    // Agent evicted (worktree/session ended) before stop → cleanup must prune the recurring entry,
+    // else a re-spawned same-id agent's recurring-failure notice stays suppressed.
+    state = { ...state, agents: {} }
+    stop()
+    expect(_recurringNotifiedKeys()).not.toContain('dev')
   })
 })

--- a/tests/idleGapInfer.test.js
+++ b/tests/idleGapInfer.test.js
@@ -82,6 +82,32 @@ describe('idleGapInfer — working → thinking inference', () => {
     stop()
   })
 
+  it('AVO-173: a tool change on externalStatus (production shape) resets the clock — no false thinking', () => {
+    // Production: `task` lives on externalStatus[id], NOT on agents[id] (store.js applyExternalStatus
+    // writes only status/behavior/expression to the agents slice). A tool change (Bash→Read) with
+    // status staying 'working' must reset the clock so a busy agent is not mislabelled 'thinking'.
+    // Fails before the fix (computeSig read agents[id].task, always undefined → no reset → infers).
+    const apply = vi.fn()
+    let state = {
+      agents: { dev: { status: 'working' } },
+      externalStatus: { dev: { task: 'Bash' } },
+      applyExternalStatus: apply,
+    }
+    const listeners = new Set()
+    const store = {
+      getState: () => state,
+      subscribe: (l) => { listeners.add(l); return () => listeners.delete(l) },
+    }
+    const stop = startIdleGapInference(store, { intervalMs: 1000 })
+    vi.advanceTimersByTime(30000)
+    // Real hook tick: status unchanged on the agents slice, the TOOL changes on externalStatus only.
+    state = { ...state, externalStatus: { dev: { task: 'Read' } } }
+    for (const l of listeners) l(state)
+    vi.advanceTimersByTime(30000) // 60s total, but only 30s since the tool change
+    expect(apply).not.toHaveBeenCalled()
+    stop()
+  })
+
   it('configurable threshold respected', () => {
     const store = makeStore({ dev: { status: 'working', task: 'Bash' } })
     const stop = startIdleGapInference(store, { intervalMs: 500, workingGapMs: 5000 })


### PR DESCRIPTION
## Summary

A research → catalogue → fix pass (2026-06-19). Closes 6 of 9 audit-found defects (3 honesty/correctness + 3 a11y) and records the rest as a vetted backlog catalogue. All items framed in AVO's own terms.

## Bug fixes (with tests)

- **AVO-171 (P1 honesty)** — the office pet's hide-on-blocker guarantee missed `awaiting-approval` (idle-gap-inferred from blocked+90s = stuck at a permission prompt), so the pet could un-hide and CELEBRATE while an agent was genuinely stuck. Centralised the blocker definition in `petState.js` (`countAttentionBlockers`/`firstAttentionBlockerId`/`BLOCKED_LIKE_STATUSES`) so it can't drift from `desktopNotifier` `BLOCKED_DERIVED`. +8 regression tests.
- **AVO-172** — `stopDesktopNotifier` pruned `blockedSince`/`notifiedFor` for evicted agents but not `recurringNotifiedFor` (which can hold keys `blockedSince` never had), so a re-spawned same-id agent's recurring-failure notice stayed suppressed. Prune by its own keys + fix `_resetDesktopNotifierState` (was leaking across tests). +1 test.
- **AVO-173** — `idleGapInfer.computeSig` read `agents[id].task`, but the agents slice never carries `task` (it lives on `externalStatus[id]`), so a tool-busy agent (Read→Grep→Edit, status stays `working`) was falsely inferred `thinking` after 45s. The old test passed only because its mock store used a non-production shape. Read task from `externalStatus`; production-shape regression added + **test-the-test verified** (fails before the fix). +1 test.
- **AVO-175 (a11y)** — gate `animate-pulse` on `reducedMotion` at the health-dot, activeEvent pill, and connection-hint.
- **AVO-176 (a11y)** — agent-inspector ✕ close is now a keyboard-operable `role="button"` with `aria-label` + Enter/Space.
- **AVO-177 (a11y)** — route NarrowRoster/ActivityFeed/control-bar aria through `t()`; add `aria.showOffice`/`showList`/`close` (en + zh-TW).

## Docs

- Catalogue **AVO-163..179** (optimization + bug/a11y/test-debt tiers) + a considered-and-declined ledger in `_product-backlog.md`.
- Retract **AVO-162** to `## Closed` — it was a duplicate of shipped AVO-111 (time-of-day lighting), caught same-session by a codebase grep.

## Verification

- Full suite **2169 passing** (+11), `npm run build` clean.
- Uniform CRLF, valid locale JSON with en/zh-TW aria-key parity, `validate.sh` text-integrity + backlog↔SSoT consistency PASS.

## Still open (catalogued, not in this PR)

AVO-174 (title-inference can inject `blocked` from a browser tab title — needs a scope decision), AVO-178/179 (test debt for movementSystem + honesty-path inference), AVO-163..170 (optimizations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
