### PR TITLE
fix: title-inference channel can no longer fabricate blocked/done (AVO-174)

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-19T05:14:49Z
-- **Update Sequence**: 94
+- **Last Updated**: 2026-06-19T05:23:18Z
+- **Update Sequence**: 95
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -163,6 +163,12 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-fix-avo-174-title-inference-honesty-2026-06-19 (PR #174 — title channel can't fake blocked/done)
+
+- Shipped AVO-174 (quick-win, honesty). The document-title inference channel (`inferStatus.js` `listenTitleChanges`, wired at the channel list) injected `status:'blocked'` from any tab title matching `error|failed|blocked|stuck` and `status:'done'` from `done|complete|success|finished` — fabricating the most-alarming / a conclusive state from the weakest signal (e.g. an unrelated browser tab titled "build failed"). Removed both conclusive patterns; the channel is now capped to the working role-hints only. Extracted a pure `classifyTitle(title)` (exported) that can only ever return `status:'working'` or null; `listenTitleChanges` uses it.
+- Verify: new `tests/titleInference.test.js` (working-hint regression + "never blocked/done" + null cases); **test-the-test verified** (re-adding the blocked pattern fails the honesty assertion). Full suite **2172 pass** (+3); build clean.
+- Tests: Pass
 
 ### Ship-fix-honesty-a11y-bugs-2026-06-19 (PR #173 — AVO-171/172/173 + AVO-175/176/177 + audit catalogue)
 

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -104,7 +104,9 @@ last_updated: 2026-06-15
 > +8 tests), AVO-172 (notifier recurring-prune + reset-helper, +1 test), **AVO-173** (idle-gap now reads
 > `task` from externalStatus so a busy tool-using agent isn't mislabelled `thinking`; the old test used a
 > non-production store shape — production-shape regression added + test-the-test verified, +1 test),
-> AVO-175/176/177 (a11y). **Open:** AVO-174 (P3 — read `inferStatus.js` first), AVO-178/179 (test debt).
+> AVO-175/176/177 (a11y). **AVO-174** (title-inference channel can no longer inject `blocked`/`done` —
+> removed both conclusive patterns; channel capped to working role-hints; pure `classifyTitle` extracted
+> + tested, test-the-test verified; PR #174). **Open:** AVO-178/179 (test debt), AVO-163..170 (optimizations).
 
 | # | Defect | Severity | Evidence (file:line) | Fix (small + reversible) | Verified |
 |---|---|---|---|---|---|

--- a/src/inference/inferStatus.js
+++ b/src/inference/inferStatus.js
@@ -648,35 +648,45 @@ function listenHashChanges(callback) {
 // Some platforms put task info in the title. We look for patterns like:
 // "Implementing auth..." or "Testing: unit tests" or "[building] feature X"
 
+// AVO-174: heuristic role-hint patterns ONLY. The conclusive/alarming `blocked` and `done` mappings
+// were REMOVED — a weak page-title match (a browser tab titled "build failed" or "all done") must
+// never fabricate the most-alarming (blocked) or a completion (done) state; those require a real hook
+// signal, not a title heuristic. The title channel can only HINT that a role is working.
+const TITLE_PATTERNS = [
+  { pattern: /implement|coding|writing code|building/i, role: 'dev', status: 'working' },
+  { pattern: /testing|reviewing|linting/i, role: 'qa', status: 'working' },
+  { pattern: /planning|spec|bootstrap/i, role: 'pm', status: 'working' },
+  { pattern: /deploy|shipping|release/i, role: 'ops', status: 'working' },
+  { pattern: /research|analyzing|exploring/i, role: 'res', status: 'working' },
+  { pattern: /design|architect|brainstorm/i, role: 'arch', status: 'working' },
+]
+
+// Exported for testing. Returns a heuristic { role, status } hint for a document title, or null.
+// By construction it can only ever return status: 'working' (AVO-174 honesty floor).
+export function classifyTitle(title) {
+  if (typeof title !== 'string') return null
+  for (const { pattern, role, status } of TITLE_PATTERNS) {
+    if (pattern.test(title)) return { role: role || 'dev', status }
+  }
+  return null
+}
+
 function listenTitleChanges(callback) {
   let lastTitle = document.title
-  const TITLE_PATTERNS = [
-    { pattern: /implement|coding|writing code|building/i, role: 'dev', status: 'working' },
-    { pattern: /testing|reviewing|linting/i, role: 'qa', status: 'working' },
-    { pattern: /planning|spec|bootstrap/i, role: 'pm', status: 'working' },
-    { pattern: /deploy|shipping|release/i, role: 'ops', status: 'working' },
-    { pattern: /research|analyzing|exploring/i, role: 'res', status: 'working' },
-    { pattern: /design|architect|brainstorm/i, role: 'arch', status: 'working' },
-    { pattern: /error|failed|blocked|stuck/i, role: null, status: 'blocked' },
-    { pattern: /done|complete|success|finished/i, role: null, status: 'done' },
-  ]
 
   const observer = new MutationObserver(() => {
     const title = document.title
     if (title === lastTitle) return
     lastTitle = title
 
-    for (const { pattern, role, status } of TITLE_PATTERNS) {
-      if (pattern.test(title)) {
-        const msg = normalizeStatusMessage({
-          type: 'office-status',
-          agents: [{ role: role || 'dev', task: title, status, label: null }],
-          source: 'title',
-        })
-        if (msg) callback(msg)
-        return
-      }
-    }
+    const hint = classifyTitle(title)
+    if (!hint) return
+    const msg = normalizeStatusMessage({
+      type: 'office-status',
+      agents: [{ role: hint.role, task: title, status: hint.status, label: null }],
+      source: 'title',
+    })
+    if (msg) callback(msg)
   })
 
   const titleEl = document.querySelector('title')

--- a/tests/titleInference.test.js
+++ b/tests/titleInference.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { classifyTitle } from '../src/inference/inferStatus.js'
+
+// AVO-174 — the document-title channel is a WEAK heuristic. It must only ever HINT that a role is
+// working; it must NEVER fabricate the most-alarming state (blocked) or a completion (done) from a
+// page title (a browser tab titled "build failed" or "all done" is not a real agent signal).
+describe('AVO-174 title inference never fabricates blocked/done', () => {
+  it('still classifies the working role-hints (regression)', () => {
+    expect(classifyTitle('Implementing the auth flow')).toEqual({ role: 'dev', status: 'working' })
+    expect(classifyTitle('Linting the project')).toEqual({ role: 'qa', status: 'working' })
+    expect(classifyTitle('Planning the spec')).toEqual({ role: 'pm', status: 'working' })
+    expect(classifyTitle('Deploying to prod')).toEqual({ role: 'ops', status: 'working' })
+    expect(classifyTitle('Analyzing the data')).toEqual({ role: 'res', status: 'working' })
+    expect(classifyTitle('Architecting the system')).toEqual({ role: 'arch', status: 'working' })
+  })
+
+  it('never returns blocked or done — even for alarming/conclusive title words', () => {
+    const titles = [
+      'error', 'Tests failed', 'blocked on review', 'stuck',
+      'all done', 'success', 'finished', 'task complete', 'Build complete',
+    ]
+    for (const t of titles) {
+      const r = classifyTitle(t)
+      // either no hint at all, or (if a working keyword also appears) a 'working' hint — never blocked/done
+      expect(r === null || r.status === 'working').toBe(true)
+      if (r) {
+        expect(r.status).not.toBe('blocked')
+        expect(r.status).not.toBe('done')
+      }
+    }
+  })
+
+  it('returns null for unmatched titles and non-strings', () => {
+    expect(classifyTitle('some random page title')).toBeNull()
+    expect(classifyTitle('')).toBeNull()
+    expect(classifyTitle(null)).toBeNull()
+    expect(classifyTitle(undefined)).toBeNull()
+    expect(classifyTitle(123)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

**AVO-174 (honesty).** The document-title inference channel (`inferStatus.js` `listenTitleChanges`, wired into the active channel list) injected `status:'blocked'` from any tab title matching `error|failed|blocked|stuck`, and `status:'done'` from `done|complete|success|finished` — fabricating the most-alarming (blocked) or a conclusive (done) state from the weakest possible signal. An unrelated browser tab titled "build failed" would mark `dev` as **blocked** for up to 120s.

## Fix

- Removed both conclusive patterns. The title channel is now capped to **working role-hints only**.
- Extracted a pure, exported `classifyTitle(title)` that can only ever return `{ role, status: 'working' }` or `null` — `listenTitleChanges` uses it.

## Verification

- New `tests/titleInference.test.js`: working-hint regression + a "never returns blocked/done" sweep over alarming/conclusive words + null/non-string cases.
- **test-the-test verified**: re-adding the blocked pattern fails the honesty assertion.
- Full suite **2172 passing** (+3), build clean, `validate.sh` text-integrity PASS, uniform CRLF.
- Same-PR ship-closure: SSoT Ship History entry + sequence bump; backlog AVO-174 marked fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
