### PR TITLE
feat: status + calm optimizations (AVO-165 walk-cap / AVO-167 await-you ring / AVO-169 inspector duration)

### DIFF
--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -61,7 +61,7 @@ last_updated: 2026-06-15
 |---|---|---|---|---|
 | AVO-163 | Static idle agents get a phase-desynced **breathing/blink micro-loop** (+ ease-out motion) so they read "alive" with zero new assets. | Fires ONLY in genuine idle; breathe is IDENTICAL regardless of status (never implies progress/emotion); distinct from the existing supervising-breathe / working-pulse rings. | ~ (polish on existing motion) | `AgentCharacter.jsx` `CharacterPixelSprite` (idle body is static today, ~L368-397) |
 | AVO-164 | An all-idle office renders a deliberate **"all quiet / all caught up"** calm state (vs reading dead) → honest permission-to-stop. | No streak, no "agents miss you", no fake activity to fill the screen. | ✅ (reframes empty, adds nothing) | new calm-state branch; not present today |
-| AVO-165 | **Walk-rhythm / out-trip reduction**: trim ambient out-trips so the office reads calmer (owner's recurring "too walk-heavy"). | `statusOverrides.working` (R1) and `social` weight untouched; before/after via `getNextBehavior` category split. | ✅✅ (fewer out-trips) | `behaviorEngine.js:21` `baseWeights{work:74,away:5}` → work↑ / away↓ |
+| ✅ AVO-165 | **Walk-rhythm — concurrent out-trip soft-cap** (panel chose this over weight reduction: the felt "always walking" is a CONCURRENCY effect, 8×~32%≈94%, not a per-agent rate the two prior tunes could fix). `MAX_CONCURRENT_OUT_TRIPS=2`; at cap an ambient agent stays at its desk this cycle. | R1-safe (keeps agent AT desk, never relocates a working agent); `social` weight untouched; +4 tests. | ✅✅ (fewer simultaneous walkers) | `behaviorEngine.js` getNextBehavior + `AgentCharacter.jsx` journeyTarget count |
 | AVO-166 | Codify a **"no-fabricated-need" rule** (ban streak / decay-if-you-leave / fake urgency / relationship-memory / unbound decorative channels) into the guardrails — makes the honesty boundary enforceable for every future ambient/pet proposal. | Doc/guardrail only — gates future proposals, fabricates nothing. | ✅ (a guard, not a feature) | `.agent/rules/` guardrails |
 | AVO-167 | Give the **`awaiting-approval` ("waiting on you") state its own ring + name-tag colour** — today it falls back to identity colour and reads like a normal idle agent. | State already inferred from real signals (`idleGapInfer`); new colour must pass the existing contrast guard. | ~ (one colour entry + one ring branch) | `constants.js:82-88` STATUS_COLORS · `AgentCharacter.jsx:1411` ring branch |
 | AVO-168 | **Ambient events rarer + more rewarding**: widen the daily/rare event intervals and give a rare event a slightly bigger juice payload. | Juice stays gated on real signals (`eventEligible`); no new event types added. | ✅ (less churn) | `constants.js:53-54` intervals · `eventJuice.js:15-16` counts |
@@ -71,7 +71,14 @@ last_updated: 2026-06-15
 > **AC-SEQ:** each resolves to `do | refine | kill` with evidence when picked up. Likely first
 > pickups (owner pacing lean + core status-visibility value): **AVO-165** (walk-rhythm — measure
 > `getNextBehavior` split first) + **AVO-167** (await-you visibility). AVO-168/169/170 are cheap
-> measurable tunes; AVO-163/164 need the chill panel first; AVO-166 is a doc landable anytime.
+> measurable tunes; AVO-163/164 need the chill panel first; AVO-166 is a doc landable anytime (→ ADR-008, PR #176).
+>
+> **Expert panel + build (2026-06-19, PR #177):** a 4-lens adversarial panel (cozy / honesty / REDUCE-skeptic
+> / status-legibility) verdicted **AVO-165 + AVO-167 + AVO-169 → DO**; **AVO-168 → descope (rarity-only,
+> drop the bigger-juice)**; **AVO-163 / AVO-164 → defer** (163 fights the owner's "calmer" goal; 164
+> contested). The three DOs are **built + tested, awaiting owner vibe confirm**: AVO-167 cyan
+> `awaiting-approval` ring + name-pill (contrast-guarded), AVO-169 inline "blocked · 3m" in the inspector
+> (honest `changedAt`, ≥30s, hide-when-null), AVO-165 concurrent out-trip soft-cap (`MAX_CONCURRENT_OUT_TRIPS=2`).
 >
 > **Considered & declined 2026-06-19** (recorded so they are NOT re-proposed as actionable): auto-apply
 > a calendar season tint (conflicts with AVO-123's deliberate manual opt-in; only ½ the year has

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -1115,7 +1115,11 @@ function AgentCharacter({ agent }) {
       // never modulated (R1) → pass teamPulse 0. `tracked` is reused for the focusAnchor bias below.
       const tracked = !!store.externalStatus[id]
       const teamPulse = tracked ? 0 : (store.teamPulse || 0)
-      const next = getNextBehavior(id, agent.status || 'idle', new Date().getHours(), store.mood || 'normal', teamPulse)
+      // AVO-165: count agents currently OUT (walking — non-null journeyTarget) so getNextBehavior can
+      // soft-cap concurrent out-trips and stop the "always someone walking" pile-up (a concurrency
+      // effect, not a per-agent rate). Read-only; keeping an agent at its desk is honest + R1-safe.
+      const outTripCount = Object.values(store.agents).filter((a) => a && a.journeyTarget).length
+      const next = getNextBehavior(id, agent.status || 'idle', new Date().getHours(), store.mood || 'normal', teamPulse, outTripCount)
       // Guard the re-schedule delay: a non-finite or non-positive duration would make
       // setTimeout(doSchedule, nextDelay) fire on the next tick, spinning the behavior
       // chain in a tight CPU loop. Fall back to the 8s default if the value is unusable.
@@ -1411,6 +1415,14 @@ function AgentCharacter({ agent }) {
       {state.status === 'blocked' && (
         <circle cx={0} cy={-18} r={22} fill="none" stroke={glowColor} strokeWidth="2" opacity="0.4">
           {!reducedMotion && <animate attributeName="opacity" values="0.2;0.5;0.2" dur="1s" repeatCount="indefinite" />}
+        </circle>
+      )}
+      {/* AVO-167: 'awaiting-approval' (waiting on the human) — a CALM slow breathe (2.4s), deliberately
+          NOT the alarm-fast 1s blocked pulse: present but unhurried "I'm waiting for you". Honest (tied
+          to the real awaiting-approval signal); distinct cool-cyan ring + name-pill via STATUS_COLORS. */}
+      {state.status === 'awaiting-approval' && (
+        <circle cx={0} cy={-18} r={22} fill="none" stroke={glowColor} strokeWidth="2" opacity="0.45">
+          {!reducedMotion && <animate attributeName="opacity" values="0.3;0.55;0.3" dur="2.4s" repeatCount="indefinite" />}
         </circle>
       )}
       {/* AVO-135: 'done' is a ONE-SHOT celebratory flash, not a standing ring — removes the

--- a/src/components/AgentInspector.jsx
+++ b/src/components/AgentInspector.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo } from 'react'
 import { useOfficeStore, STATUS_COLORS } from '../systems/store'
 import { charName, behaviorLabel, t, useLocale } from '../i18n'
 import { formatTimeAgo } from '../utils/formatTime'
-import { buildAgentInspectorMeta, inspectorTaskLabel } from './agentInspectorModel'
+import { buildAgentInspectorMeta, inspectorTaskLabel, stateDurationLabel } from './agentInspectorModel'
 
 // POINT 2 follow-up: the inspector counter-scales so its small detail fonts (8–9px) stay readable
 // at ANY office scale. Only ONE inspector is ever open and it is clamped inside the viewBox, so it
@@ -18,6 +18,7 @@ const statusEmoji = {
   done: '✅',
   blocked: '🚫',
   planning: '🧠',
+  'awaiting-approval': '⏳',  // AVO-167: "waiting on you"
 }
 
 export default function AgentInspector() {
@@ -66,6 +67,8 @@ export default function AgentInspector() {
   const name = charName(selectedAgent)
   const status = agent.status || 'idle'
   const statusLabel = t(`statusLabels.${status}`, status)
+  // AVO-169: inline "how long" for the actionable waiting states (honest, real changedAt, ≥30s only).
+  const stateSince = stateDurationLabel(status, ext?.changedAt)
   const currentBehavior = behaviorLabel(agent.behavior)
   const task = inspectorTaskLabel(ext)
   const color = agent.color || '#888'
@@ -159,7 +162,7 @@ export default function AgentInspector() {
         {/* Status badge */}
         <circle cx={12} cy={42} r={5} fill={STATUS_COLORS[status] || color || '#888'} />
         <text x={22} y={45} fontSize="10" fontFamily="monospace" fill={STATUS_COLORS[status] || color || '#888'} fontWeight="bold">
-          {statusEmoji[status]} {statusLabel}
+          {statusEmoji[status]} {statusLabel}{stateSince ? ` · ${stateSince}` : ''}
         </text>
 
         {/* Current behavior */}

--- a/src/components/agentInspectorModel.js
+++ b/src/components/agentInspectorModel.js
@@ -1,4 +1,5 @@
 import { classifyTask } from '../systems/classify.js'
+import { formatTimeAgo } from '../utils/formatTime'
 
 // The single line of "what is this agent doing" the inspector shows. The hook's
 // human `label` ("✏️ 改 App.jsx", "❌ npm test failed") is richest, so it wins.
@@ -11,6 +12,20 @@ export function inspectorTaskLabel(ext) {
   if (ext.label) return ext.label
   if (ext.task) return classifyTask(ext.task).visualLabel
   return null
+}
+
+// AVO-169: how long the agent has been in an ACTIONABLE waiting state, shown inline in the inspector.
+// Honest by construction — driven only by the real `changedAt` (stamped on a real status/task change),
+// returns null below 30s or when `changedAt` is missing (NEVER a fabricated "0m" freshly-entered
+// reading). Compact form (e.g. "3m"). Restricted to the two states where "how long" is actionable.
+const STATE_DURATION_STATUSES = new Set(['blocked', 'awaiting-approval'])
+const STATE_DURATION_MIN_MS = 30000
+
+export function stateDurationLabel(status, changedAt, now = Date.now()) {
+  if (!STATE_DURATION_STATUSES.has(status)) return null
+  if (!Number.isFinite(changedAt)) return null
+  if (now - changedAt < STATE_DURATION_MIN_MS) return null
+  return formatTimeAgo(changedAt, { compact: true })
 }
 
 export function countAgentDoneToday(activityLog, agentId, now = Date.now()) {

--- a/src/systems/behaviorEngine.js
+++ b/src/systems/behaviorEngine.js
@@ -20,6 +20,14 @@ import { rng } from './rng.js'
 // weights move — `working` (real-work, R1 honesty) / `done` / `blocked` are untouched.
 const baseWeights = { work: 74, daily: 8, social: 13, away: 5 }
 
+// AVO-165: concurrent out-trip soft-cap. The owner's recurring "一直有人在走動" is a CONCURRENCY effect
+// — 8 agents each ~32% out-trip → P(≥1 walking) ≈ 94% — not a per-agent rate the two prior tunes
+// (−28%, round-2) could fix. When this many agents are ALREADY out (non-null journeyTarget), an agent
+// that rolls an out-trip stays at its desk this cycle instead. Honest + R1-safe: keeping an agent AT
+// its desk never hides a real signal nor relocates a working agent (R1 forbids moving a working agent
+// AWAY — this does the opposite). Per-agent cadence + the `social` weight are untouched.
+export const MAX_CONCURRENT_OUT_TRIPS = 2
+
 const statusOverrides = {
   working: { work: 82, daily: 8, social: 5, away: 5 },
   idle: { work: 68, daily: 12, social: 14, away: 6 },
@@ -216,7 +224,7 @@ function pushRecentPick(agentId, msg) {
 // Exported for tests only — allows clearing the ring in beforeEach.
 export function __clearRecentPicks() { _recentPicks.clear() }
 
-export function getNextBehavior(agentId, status = 'idle', hour = new Date().getHours(), mood = 'normal', teamPulse = 0) {
+export function getNextBehavior(agentId, status = 'idle', hour = new Date().getHours(), mood = 'normal', teamPulse = 0, outTripCount = 0) {
   // Start with status-based weights, then apply hour modifiers
   let weights = { ...(statusOverrides[status] || baseWeights) }
   const hourMod = getHourModifiers(hour)
@@ -249,7 +257,14 @@ export function getNextBehavior(agentId, status = 'idle', hour = new Date().getH
     }
   }
 
-  const category = weightedRandom(weights)
+  let category = weightedRandom(weights)
+  // AVO-165: soft-cap concurrent out-trips (daily/social/away = leaving the desk). When the office
+  // already has MAX_CONCURRENT_OUT_TRIPS agents out, an agent that rolled an out-trip stays at its desk
+  // this cycle (reported category becomes 'work' so downstream is consistent). Trims the simultaneous
+  // pile-up the owner sees, without touching per-agent cadence or the social weight.
+  if ((category === 'daily' || category === 'social' || category === 'away') && outTripCount >= MAX_CONCURRENT_OUT_TRIPS) {
+    category = 'work'
+  }
   const behavior = pickBehavior(agentId, category)
 
   // AC-S1a: use per-agent ring buffer for anti-repeat

--- a/src/systems/constants.js
+++ b/src/systems/constants.js
@@ -85,4 +85,8 @@ export const STATUS_COLORS = {
   done: '#5CB88A',
   blocked: '#E24B4A',
   planning: '#8B7FD6',
+  // AVO-167: 'awaiting-approval' ("waiting on YOU", idle-gap-inferred from blocked+90s) gets its own
+  // cool cyan so it is visually distinct from a normal idle agent in the scene — and distinct from
+  // working amber + blocked red. Contrast-guarded (theme.test.js iterates STATUS_COLORS).
+  'awaiting-approval': '#1E9FD4',
 }

--- a/tests/agentInspector.test.js
+++ b/tests/agentInspector.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { countAgentDoneToday, inspectorTaskLabel } = await import('../src/components/agentInspectorModel.js')
+const { countAgentDoneToday, inspectorTaskLabel, stateDurationLabel } = await import('../src/components/agentInspectorModel.js')
 const { useOfficeStore } = await import('../src/systems/store.js')
 
 describe('inspectorTaskLabel — task line for the inspector', () => {
@@ -466,6 +466,43 @@ describe('STATUS_COLORS — planning entry (AVO-132)', () => {
     expect(planning).not.toBe(blocked)
     expect(planning).not.toBe(done)
     expect(planning).not.toBe(idle)
+  })
+})
+
+describe('STATUS_COLORS — awaiting-approval entry (AVO-167)', () => {
+  it('has an awaiting-approval entry distinct from every other status colour', async () => {
+    const { STATUS_COLORS } = await import('../src/systems/constants.js')
+    const c = STATUS_COLORS['awaiting-approval']
+    expect(c).toBeDefined()
+    expect(c).toMatch(/^#/)
+    for (const other of ['working', 'blocked', 'done', 'idle', 'planning']) {
+      expect(c).not.toBe(STATUS_COLORS[other])
+    }
+  })
+})
+
+describe('stateDurationLabel — inline waiting-state duration (AVO-169)', () => {
+  it('returns a compact duration for blocked/awaiting-approval once past 30s', () => {
+    const now = Date.now()
+    expect(stateDurationLabel('blocked', now - 120_000, now)).toBe('2m')
+    expect(stateDurationLabel('awaiting-approval', now - 45_000, now)).toBe('45s')
+  })
+  it('returns null below the 30s floor (no noise)', () => {
+    const now = Date.now()
+    expect(stateDurationLabel('blocked', now - 10_000, now)).toBeNull()
+    expect(stateDurationLabel('awaiting-approval', now - 29_000, now)).toBeNull()
+  })
+  it('returns null for non-waiting statuses', () => {
+    const now = Date.now()
+    expect(stateDurationLabel('working', now - 120_000, now)).toBeNull()
+    expect(stateDurationLabel('idle', now - 120_000, now)).toBeNull()
+    expect(stateDurationLabel('done', now - 120_000, now)).toBeNull()
+  })
+  it('never fabricates a duration when changedAt is missing/invalid', () => {
+    const now = Date.now()
+    expect(stateDurationLabel('blocked', null, now)).toBeNull()
+    expect(stateDurationLabel('blocked', undefined, now)).toBeNull()
+    expect(stateDurationLabel('blocked', NaN, now)).toBeNull()
   })
 })
 

--- a/tests/behaviorEngine.test.js
+++ b/tests/behaviorEngine.test.js
@@ -14,7 +14,7 @@ function __mulberry32(seed) {
 const __realRandom = Math.random
 beforeAll(() => { Math.random = __mulberry32(0x0ff1ce) })
 afterAll(() => { Math.random = __realRandom })
-import { getNextBehavior, getHourModifiers } from '../src/systems/behaviorEngine.js'
+import { getNextBehavior, getHourModifiers, MAX_CONCURRENT_OUT_TRIPS } from '../src/systems/behaviorEngine.js'
 import { needsLocationChange } from '../src/systems/movementSystem.js'
 
 // Every VALID_ROLE plus a couple of composite worktree ids — getNextBehavior must
@@ -222,5 +222,43 @@ describe('getNextBehavior — calm rhythm (no solo meeting, bounded walk share)'
     for (const id of ['drink-coffee', 'drink-water', 'goto-coffee-machine']) {
       expect(seen.has(id), `${id} should still occur for an idle agent`).toBe(true)
     }
+  })
+})
+
+describe('AVO-165 — concurrent out-trip soft-cap', () => {
+  const OUT = new Set(['daily', 'social', 'away'])
+
+  it('at/above the cap, an idle agent never starts an out-trip (stays at desk)', () => {
+    let outTrips = 0
+    for (let i = 0; i < 400; i++) {
+      const c = getNextBehavior('dev', 'idle', 10, 'normal', 0, MAX_CONCURRENT_OUT_TRIPS).category
+      if (OUT.has(c)) outTrips++
+    }
+    expect(outTrips).toBe(0)
+  })
+
+  it('below the cap, out-trips still happen (the cap does not deaden the office)', () => {
+    let outTrips = 0
+    for (let i = 0; i < 400; i++) {
+      const c = getNextBehavior('dev', 'idle', 10, 'normal', 0, 0).category
+      if (OUT.has(c)) outTrips++
+    }
+    expect(outTrips).toBeGreaterThan(0)
+  })
+
+  it('a capped out-trip resolves to a real work behavior (consistent category + behaviorId)', () => {
+    const b = getNextBehavior('dev', 'idle', 10, 'normal', 0, MAX_CONCURRENT_OUT_TRIPS + 5)
+    expect(b.category).toBe('work')
+    expect(typeof b.behaviorId).toBe('string')
+    expect(b.behaviorId.length).toBeGreaterThan(0)
+  })
+
+  it('default outTripCount (0) preserves prior behavior — out-trips unaffected', () => {
+    let outTrips = 0
+    for (let i = 0; i < 400; i++) {
+      const c = getNextBehavior('dev', 'idle', 10, 'normal').category  // no outTripCount arg
+      if (OUT.has(c)) outTrips++
+    }
+    expect(outTrips).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

The 3 optimizations a 4-lens adversarial expert panel (cozy game-designer / honesty auditor / REDUCE-skeptic / status-legibility) verdicted **DO**. Each honors the product style + ADR-008 honesty rule.

- **AVO-167 — `awaiting-approval` visibility (status core, panel P0).** "Waiting on YOU" was visually identical to a normal idle agent in the SVG scene (only surfaced in side panels/notification). Now it has its own **cool-cyan** ring + name-pill (`STATUS_COLORS['awaiting-approval'] = #1E9FD4`, distinct from working amber / blocked red, **contrast-guarded** by `theme.test.js`) and inspector emoji. The ring is a **calm 2.4s breathe**, deliberately not the alarm-fast 1s blocked pulse — "I'm waiting for you", unhurried.
- **AVO-169 — elapsed-time in the inspector.** Pure `stateDurationLabel(status, changedAt, now)` → inline `blocked · 3m` / `awaiting-approval · 3m`. Honest: real `changedAt` only, blocked/await states only, hidden below 30s and when `changedAt` is missing (never a fabricated "0m"). Inspector-only, zero scene clutter.
- **AVO-165 — concurrent out-trip soft-cap.** The owner's recurring "一直有人在走動" is a **concurrency** effect — 8 agents × ~32% out-trip → P(≥1 walking) ≈ 94% — not a per-agent rate (already tuned twice). `MAX_CONCURRENT_OUT_TRIPS = 2`: when 2 agents are already out (non-null `journeyTarget`), an agent that rolled an out-trip stays at its desk this cycle. **R1-safe** (keeps it AT its desk — never relocates a working agent); `social` weight untouched; per-agent cadence below the cap unchanged.

## Verification

- Full suite **2181 passing** (+12: behaviorEngine cap tests, inspector duration + colour tests). Build clean. Contrast guard passes the new cyan. EOL/whitespace clean.
- AVO-165 "before/after category split" is captured in tests: at cap → out-trip rate 0; below cap → unaffected.

## Notes

- **Visual vibe = owner confirm pending** — the panel + contrast guard + tests gate correctness, but the final "does it feel calmer / does the cyan read right" is yours (preview is unreliable in this repo). Pull the branch to eyeball.
- Independent of #176 (ADR-008) — this branch is main-based; AVO-166/ADR-008 lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
