### PR TITLE
fix(round2): AVO-180 eviction memory-leak prune + AVO-182 crash/corruption guards

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-06-19T05:39:23Z
-- **Update Sequence**: 96
+- **Last Updated**: 2026-06-19T07:01:38Z
+- **Update Sequence**: 97
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -164,6 +164,13 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-fix-round2-leaks-and-guards-2026-06-19 (PR #179 — AVO-180 eviction leak + AVO-182 guards)
+
+- Shipped the verified, well-scoped items from the round-2 bug/tech-debt sweep (quick-win). **AVO-180**: the multi-session eviction site (`store.js`) now prunes the per-agent transient module state of an evicted dynamic worktree agent — `pruneRecentPicks(id)` (new export from `behaviorEngine.js`), `_storeRecentPicks.delete(id)`, and a cloned-then-deleted `recurringFailureLog[id]` (never mutates a published log). Mirrors `idleGapInfer`'s existing eviction prune; closes an unbounded-Map leak relevant to the owner's many-worktree workflow. +1 regression test (rfLog pruned on eviction). **AVO-182** (crash/corruption guards): `charName` null/non-string guard (was `charId.includes('~')` → throw; +2 tests) · `darken` non-`#RRGGBB` passthrough (was caching `#NaNNaNNaN`) · ambientSound gesture listeners `{once:true}`.
+- Deferred (catalogued, NOT in this PR): AVO-181 (blocked-family/VALID_ROLES set-consolidation — a multi-file refactor of honesty-critical code, do deliberately) · AVO-183 (two MED movement/POST edge cases — verify with a repro first) · AVO-184 (god-reducer extraction — explicit refactor, ADR/plan-gated).
+- Verify: full suite **2184 pass** (+3); build clean; EOL/whitespace clean. The round-2 sweep also dismissed the "dailyCard/lighting/ambientSound untested" FALSE POSITIVES (co-located `src/systems/*.test.js` exist).
+- Tests: Pass
 
 ### Ship-fix-avo-174-title-inference-honesty-2026-06-19 (PR #174 — title channel can't fake blocked/done)
 

--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -164,6 +164,14 @@ last_updated: 2026-06-15
 | AVO-183 | **INVESTIGATE (MED edge)** — `pushOutOfObstacle` single-pass: a point escaped from rect A can land in rect B (`movementSystem.js:94-108`); shorthand-POST copies body-level `activeFile` to ALL roles → could falsely trigger the pair-huddle overlay (`statusContract.mjs:148-157`). Both are rare geometry/payload edges; verify with a repro before fixing. | MED | reported, needs a repro | confirm-then-fix |
 | AVO-184 | **Complexity / dead code** — `applyExternalStatus` is a 372-line god-reducer on the hot path (`store.js:827`); `startStatusIntegration` 287-line closure (`inferStatus.js:709`); dead `MIN_AGENT_DIST` export (`constants.js:47`); `package-lock.json` version skew (1.4.0 vs 1.6.0). | MED maint. | grep-confirmed | extract named helpers; delete dead export; regen lockfile |
 
+> **Fix status (PR #179):** ✅ **AVO-180** (eviction prune — `pruneRecentPicks` + `_storeRecentPicks` +
+> cloned-`rfLog` delete at the multi-session eviction site; +1 regression test) · ✅ **AVO-182** (the
+> crash/corruption guards: `charName` null-guard +2 tests, `darken` non-`#RRGGBB` passthrough,
+> ambientSound `{once:true}`). **Open:** AVO-181 (set-consolidation — deferred: it's a multi-file
+> refactor of honesty-critical code, do deliberately not in a fix-sweep) · AVO-183 (verify the two MED
+> edge cases with a repro first) · AVO-184 (the god-reducer extraction is an explicit refactor — ADR/
+> plan-gated, not a casual fix).
+
 ---
 
 ## Closed

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -243,6 +243,9 @@ function clearRow(grid, row) {
 
 const _darkenCache = new Map()
 function darken(hex, amount) {
+  // AVO-182: a non-#RRGGBB input (e.g. a CSS named colour or #RGB from a bad config) would parseInt→NaN
+  // and cache "#NaNNaNNaN" forever. Pass the input through unchanged instead of corrupting the cache.
+  if (typeof hex !== 'string' || !/^#[0-9a-fA-F]{6}$/.test(hex)) return hex
   const key = `${hex}:${amount}`
   if (_darkenCache.has(key)) return _darkenCache.get(key)
   const r = Math.max(0, parseInt(hex.slice(1, 3), 16) - amount)

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -88,6 +88,7 @@ export function setNameResolver(fn) { _nameResolver = fn }
 
 // Convenience: get character name (custom profile overrides i18n)
 export function charName(charId) {
+  if (typeof charId !== 'string' || !charId) return String(charId ?? '?')  // AVO-182: guard null/non-string (charId.includes below would throw)
   if (_nameResolver) {
     const custom = _nameResolver(charId)
     if (custom) return custom

--- a/src/systems/ambientSound.js
+++ b/src/systems/ambientSound.js
@@ -289,8 +289,8 @@ export function startAmbientSound(store) {
       window.removeEventListener('keydown', onGesture)
       gestureCleanup = null
     }
-    window.addEventListener('pointerdown', onGesture, { once: false })
-    window.addEventListener('keydown', onGesture, { once: false })
+    window.addEventListener('pointerdown', onGesture, { once: true })  // AVO-182: the fired listener auto-removes even if removeGesture no-ops
+    window.addEventListener('keydown', onGesture, { once: true })
     gestureCleanup = removeGesture
   }
 

--- a/src/systems/behaviorEngine.js
+++ b/src/systems/behaviorEngine.js
@@ -224,6 +224,11 @@ function pushRecentPick(agentId, msg) {
 // Exported for tests only — allows clearing the ring in beforeEach.
 export function __clearRecentPicks() { _recentPicks.clear() }
 
+// AVO-180: prune one agent's anti-repeat slot when a dynamic worktree agent is evicted, so the Map
+// doesn't grow unbounded across many short-lived `slug~role` sessions (mirrors idleGapInfer's
+// eviction prune). The store calls this from its multi-session reconciliation eviction site.
+export function pruneRecentPicks(agentId) { _recentPicks.delete(agentId) }
+
 export function getNextBehavior(agentId, status = 'idle', hour = new Date().getHours(), mood = 'normal', teamPulse = 0, outTripCount = 0) {
   // Start with status-based weights, then apply hour modifiers
   let weights = { ...(statusOverrides[status] || baseWeights) }

--- a/src/systems/store.js
+++ b/src/systems/store.js
@@ -9,6 +9,7 @@ import { STATUS_COLORS } from './constants.js'
 import { classifyTask, familyToBehavior, decideBehavior } from './classify.js'
 import { FEED_ORIGINS } from './rosterModel.js'
 import { PET_TYPES, nextPetType } from './petState.js'
+import { pruneRecentPicks } from './behaviorEngine.js'  // AVO-180: prune on eviction
 import { isValidTheme, DEFAULT_THEME } from './theme.js'
 import { recordEpisode, isNewBlockedEpisode } from './recurringFailure.js'
 import { AGENT_CARRY_FIELDS } from '../utils/statusFields.js'
@@ -1130,6 +1131,7 @@ export const useOfficeStore = create((set) => ({
       let evictedSelected = false
       if (meta.source === 'multi-session') {
         const present = new Set(updates.map(u => u.agentId))
+        const evicted = []
         for (const id of Object.keys(agents)) {
           const a = agents[id]
           // A dynamic agent is identified solely by a non-null `session` slug — only
@@ -1141,11 +1143,27 @@ export const useOfficeStore = create((set) => ({
             delete agents[id]
             delete ext[id]
             agentsMutated = true
+            evicted.push(id)
             // If the inspector had this now-deleted dynamic agent selected, the id would
             // dangle forever: AgentInspector renders nothing (its `agent` lookup is null)
             // but selectedAgent stays set, so a future click on the SAME id toggles the
             // panel off instead of open. Drop the selection when its target is evicted.
             if (s.selectedAgent === id) evictedSelected = true
+          }
+        }
+        // AVO-180: prune transient per-agent MODULE state for evicted dynamic agents so these Maps
+        // don't grow unbounded across many short-lived worktree sessions (mirrors idleGapInfer's
+        // eviction prune). rfLog is cloned before deleting so we never mutate an already-published
+        // recurringFailureLog object held by a prior subscriber.
+        if (evicted.length > 0) {
+          let rfCloned = false
+          for (const id of evicted) {
+            pruneRecentPicks(id)
+            _storeRecentPicks.delete(id)
+            if (rfLog[id]) {
+              if (!rfCloned) { rfLog = { ...rfLog }; rfCloned = true }
+              delete rfLog[id]
+            }
           }
         }
       }

--- a/tests/charNameGuard.test.js
+++ b/tests/charNameGuard.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { charName } from '../src/i18n'
+
+// AVO-182 — charName(charId) does `charId.includes('~')`, which throws on a null/non-string id.
+// The guard makes it crash-safe (a stray null agentId in a feed/roster row must not take down the
+// component). Valid role ids still resolve normally.
+describe('AVO-182 charName null/non-string guard', () => {
+  it('never throws on null / undefined / non-string', () => {
+    expect(() => charName(null)).not.toThrow()
+    expect(() => charName(undefined)).not.toThrow()
+    expect(() => charName(123)).not.toThrow()
+    expect(() => charName('')).not.toThrow()
+    expect(typeof charName(null)).toBe('string')
+  })
+
+  it('still resolves a real role id and a session-prefixed id', () => {
+    expect(charName('dev').length).toBeGreaterThan(0)
+    expect(charName('feat-x~dev').length).toBeGreaterThan(0)
+  })
+})

--- a/tests/storeReconcile.test.js
+++ b/tests/storeReconcile.test.js
@@ -64,6 +64,30 @@ describe('applyExternalStatus — multi-session ghost reconciliation (R63)', () 
     expect(s.externalStatus['feat-a~dev']).toBeTruthy()
   })
 
+  it('AVO-180: prunes recurringFailureLog for an evicted dynamic agent (no unbounded leak)', () => {
+    const { applyExternalStatus } = useOfficeStore.getState()
+
+    // Tick 1: feat-b enters a recurring-reason blocked episode → it gets a recurringFailureLog entry.
+    applyExternalStatus(
+      [
+        { agentId: 'feat-a~dev', status: 'working', task: null, label: null, session: 'feat-a' },
+        { agentId: 'feat-b~dev', status: 'blocked', reasonCode: 'build-failed', task: null, label: null, session: 'feat-b' },
+      ],
+      { source: 'multi-session' },
+    )
+    expect(useOfficeStore.getState().recurringFailureLog['feat-b~dev']).toBeTruthy()
+
+    // Tick 2: feat-b's session ended → it is evicted. Its rfLog history must be pruned, not retained.
+    applyExternalStatus(
+      [{ agentId: 'feat-a~dev', status: 'working', task: null, label: null, session: 'feat-a' }],
+      { source: 'multi-session' },
+    )
+    const s = useOfficeStore.getState()
+    expect(s.agents['feat-b~dev']).toBeUndefined()                 // evicted
+    expect(s.recurringFailureLog['feat-b~dev']).toBeUndefined()    // AVO-180: pruned, not leaked
+    expect(s.agents['feat-a~dev']).toBeTruthy()                    // survivor unaffected
+  })
+
   it('does NOT evict dynamic agents on a non-multi-session update (single agent deliveries)', () => {
     const { applyExternalStatus } = useOfficeStore.getState()
 


### PR DESCRIPTION
Fixes the verified, well-scoped items from the round-2 sweep (owner: 修吧).

- **AVO-180** — eviction memory-leak: the multi-session reconciliation eviction site now prunes an evicted dynamic worktree agent's transient module state (`pruneRecentPicks` + `_storeRecentPicks` + cloned `recurringFailureLog` delete), mirroring `idleGapInfer`'s existing eviction prune. Closes an unbounded-Map growth relevant to the many-worktree workflow. +1 regression test.
- **AVO-182** — crash/corruption guards: `charName` null/non-string guard (was `charId.includes` → throw; +2 tests) · `darken` non-`#RRGGBB` passthrough (was caching `#NaNNaNNaN`) · ambientSound `{once:true}`.

Deferred (catalogued): AVO-181 (set-consolidation refactor), AVO-183 (MED edge cases — repro first), AVO-184 (god-reducer extraction — ADR/plan-gated).

Verify: full suite **2184 pass** (+3), build clean, EOL/whitespace clean. Same-PR ship-closure (Ship History + seq bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)