### PR TITLE
refactor(AVO-181): consolidate the blocked-family set into one constants SSoT (4→1)

### DIFF
--- a/docs/specs/_product-backlog.md
+++ b/docs/specs/_product-backlog.md
@@ -159,7 +159,7 @@ last_updated: 2026-06-15
 | # | Item | Sev | Evidence (file:line) | Fix |
 |---|---|---|---|---|
 | AVO-180 | **Eviction memory-leak** — `_recentPicks` (`behaviorEngine.js:210`), `_storeRecentPicks` (`store.js:24`), and per-agent `recurringFailureLog` keys are NOT pruned when a dynamic `slug~role` worktree agent is evicted (`store.js:~1141`). Slow unbounded growth in long multi-worktree sessions. **Owner-relevant** (runs many parallel worktree agents). | MED | grep: only `__clearRecentPicks()` (test-only); `idleGapInfer` DOES prune on eviction (precedent) | export `pruneRecentPicks(id)` + delete the 3 keys at the eviction site, mirroring `idleGapInfer` |
-| AVO-181 | **Duplicated set/constant drift** — the blocked-family set lives in 4 copies (`petState.js:58` · `desktopNotifier.js:44` · `recurringFailure.js` · `agentInspectorModel.js:21` — AVO-169 added the 4th); `VALID_ROLES` ×3; the "working\|blocked" active-count rule ×3 (and `planning` is silently excluded from all 3). | MED | grep-confirmed | hoist canonical sets into `statusContract.mjs`, import everywhere |
+| ◑ AVO-181 | **Duplicated set/constant drift.** ✅ **blocked-family DONE** (PR #180 — single `BLOCKED_FAMILY` in `constants.js`, imported by petState/desktopNotifier/recurringFailure/agentInspectorModel; 4 copies → 1). **Remaining:** `VALID_ROLES` ×3 (mechanical hoist) · the "working\|blocked" active-count rule ×3 where **`planning` is silently excluded from all 3** — that's a SEMANTIC question (should planning count as active?) to resolve BEFORE consolidating, not a blind hoist. | MED | grep-confirmed | blocked-family done; VALID_ROLES + active-count are follow-ups |
 | AVO-182 | **Defensive-guard gaps (latent)** — `charName(null)` has no guard (`i18n.js:96`); `darken()` returns `#NaNNaNNaN` and caches it for a non-`#RRGGBB` config color (`AgentCharacter.jsx:248`); `u[f] \|\| null` coerces a valid empty-string carry field to null (`store.js:980`, `agentRouter.js:128`); ambientSound gesture listeners use `{once:false}` (`ambientSound.js:292`); `validatePersistedDailyDoneLedger` has no upper cap. | LOW | all read-verified | add the cheap guards (nullish not falsy; hex validation; `{once:true}`) |
 | AVO-183 | **INVESTIGATE (MED edge)** — `pushOutOfObstacle` single-pass: a point escaped from rect A can land in rect B (`movementSystem.js:94-108`); shorthand-POST copies body-level `activeFile` to ALL roles → could falsely trigger the pair-huddle overlay (`statusContract.mjs:148-157`). Both are rare geometry/payload edges; verify with a repro before fixing. | MED | reported, needs a repro | confirm-then-fix |
 | AVO-184 | **Complexity / dead code** — `applyExternalStatus` is a 372-line god-reducer on the hot path (`store.js:827`); `startStatusIntegration` 287-line closure (`inferStatus.js:709`); dead `MIN_AGENT_DIST` export (`constants.js:47`); `package-lock.json` version skew (1.4.0 vs 1.6.0). | MED maint. | grep-confirmed | extract named helpers; delete dead export; regen lockfile |
@@ -167,10 +167,10 @@ last_updated: 2026-06-15
 > **Fix status (PR #179):** ✅ **AVO-180** (eviction prune — `pruneRecentPicks` + `_storeRecentPicks` +
 > cloned-`rfLog` delete at the multi-session eviction site; +1 regression test) · ✅ **AVO-182** (the
 > crash/corruption guards: `charName` null-guard +2 tests, `darken` non-`#RRGGBB` passthrough,
-> ambientSound `{once:true}`). **Open:** AVO-181 (set-consolidation — deferred: it's a multi-file
-> refactor of honesty-critical code, do deliberately not in a fix-sweep) · AVO-183 (verify the two MED
-> edge cases with a repro first) · AVO-184 (the god-reducer extraction is an explicit refactor — ADR/
-> plan-gated, not a casual fix).
+> ambientSound `{once:true}`) · ◑ **AVO-181** (PR #180 — blocked-family consolidated 4→1 in
+> `constants.js`; VALID_ROLES + active-count remain as follow-ups, the latter has a `planning` semantic
+> question). **Open:** AVO-183 (verify the two MED edge cases with a repro first) · AVO-184 (the
+> god-reducer extraction is an explicit refactor — ADR/plan-gated, not a casual fix).
 
 ---
 

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -1,0 +1,117 @@
+// Visual verification for the panel-approved wave (AVO-165/167/169) — LOAD THE PAGE (green tests ≠
+// renders; preview_screenshot hangs in this repo, so we use headless Playwright against the dev server).
+// Stages dev=awaiting-approval (new cyan ring) next to qa=blocked (red ring), with changedAt 2min ago
+// so the inspector shows the elapsed-time line. Asserts 0 console errors + no ErrorBoundary, probes
+// that the new cyan actually renders, and shots the office + both inspector states + a ring close-up.
+import { chromium } from 'playwright-core'
+import { mkdirSync } from 'fs'
+
+const URL = 'http://localhost:5173/?lang=en'
+const OUT = 'C:/Users/wen/.gemini/antigravity/scratch/agent-virtual-office/.pet-shots'
+mkdirSync(OUT, { recursive: true })
+
+const browser = await chromium.launch({ headless: true }).catch(() =>
+  chromium.launch({ headless: true, executablePath: 'C:/Program Files/Google/Chrome/Application/chrome.exe' }))
+const page = await browser.newPage({ viewport: { width: 1400, height: 900 }, deviceScaleFactor: 2 })
+
+const errors = []
+page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
+page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message))
+
+await page.addInitScript(() => { try { localStorage.setItem('office-onboarded', '1') } catch {} })
+await page.goto(URL, { waitUntil: 'domcontentloaded' })
+await page.waitForSelector('svg', { timeout: 20000 })
+await page.waitForTimeout(900)
+
+const bodyText = await page.evaluate(() => document.body.innerText || '')
+const errorBoundary = /Something went wrong/i.test(bodyText)
+
+// Stage: dev = awaiting-approval (cyan), qa = blocked (red). changedAt 2min ago for the duration line.
+await page.evaluate(async () => {
+  const store = (await import('/src/systems/store.js')).useOfficeStore
+  const mv = await import('/src/systems/movementSystem.js')
+  const HOME = mv.HOME_POSITIONS
+  const s = store.getState()
+  const now = Date.now()
+  const agents = { ...s.agents }
+  for (const id of Object.keys(agents)) {
+    const h = HOME[id] || agents[id].position
+    agents[id] = { ...agents[id], position: { ...h }, targetPosition: { ...h }, isMoving: false,
+      inGroupEvent: false, journeyTarget: null,
+      status: id === 'dev' ? 'awaiting-approval' : id === 'qa' ? 'blocked' : agents[id].status }
+  }
+  store.setState({
+    agents,
+    externalStatus: {
+      dev: { status: 'awaiting-approval', changedAt: now - 120000 },
+      qa:  { status: 'blocked', reasonCode: 'test-run-failed', label: '❌ npm test failed', changedAt: now - 120000 },
+    },
+    isPaused: true, activeEvent: null, reducedMotion: true, handoffs: [], helpers: [],
+  })
+})
+await page.waitForTimeout(350)
+
+// Probe: did the new awaiting-approval cyan actually render (ring stroke + name-pill fill)?
+const cyanProbe = await page.evaluate(() => {
+  let stroke = 0, fill = 0
+  for (const el of document.querySelectorAll('svg *')) {
+    const st = (el.getAttribute('stroke') || '').toLowerCase()
+    const fl = (el.getAttribute('fill') || '').toLowerCase()
+    if (st === '#1e9fd4') stroke++
+    if (fl === '#1e9fd4') fill++
+  }
+  return { cyanStroke: stroke, cyanFill: fill }
+})
+
+await page.evaluate(() => { const svg = document.querySelector('svg'); if (svg) svg.setAttribute('viewBox', '0 0 800 560') })
+await page.waitForTimeout(150)
+await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-office-await-vs-blocked.png` })
+
+// AVO-169: inspector on the BLOCKED agent → "Blocked · 2m"
+await page.evaluate(async () => {
+  const store = (await import('/src/systems/store.js')).useOfficeStore
+  store.setState({ selectedAgent: 'qa' })
+})
+await page.waitForTimeout(300)
+const inspBlocked = await page.evaluate(() =>
+  Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && /·|\d+[smh]\b/.test(t)))
+await (await page.$('svg')).screenshot({ path: `${OUT}/avo169-inspector-blocked-duration.png` })
+
+// AVO-167+169: inspector on the AWAITING agent → "Awaiting approval · 2m" (cyan header)
+await page.evaluate(async () => {
+  const store = (await import('/src/systems/store.js')).useOfficeStore
+  store.setState({ selectedAgent: 'dev' })
+})
+await page.waitForTimeout(300)
+const inspAwait = await page.evaluate(() =>
+  Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && (/·|\d+[smh]\b/.test(t) || /await/i.test(t))))
+await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-169-inspector-await-duration.png` })
+
+// AVO-167: close-up of the awaiting-approval cyan ring (inspector closed for a clean shot)
+await page.evaluate(async () => {
+  const store = (await import('/src/systems/store.js')).useOfficeStore
+  store.setState({ selectedAgent: null })
+})
+await page.waitForTimeout(200)
+await page.evaluate(() => {
+  const svg = document.querySelector('svg')
+  const p = window.__avoDevPos
+  if (svg) svg.setAttribute('viewBox', p ? `${p.x - 70} ${p.y - 95} 140 145` : '180 300 180 180')
+})
+await page.evaluate(async () => {
+  const store = (await import('/src/systems/store.js')).useOfficeStore
+  window.__avoDevPos = store.getState().agents.dev?.position
+})
+await page.evaluate(() => {
+  const svg = document.querySelector('svg'); const p = window.__avoDevPos
+  if (svg && p) svg.setAttribute('viewBox', `${Math.round(p.x - 70)} ${Math.round(p.y - 95)} 140 145`)
+})
+await page.waitForTimeout(200)
+await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-await-ring-closeup.png` })
+
+await browser.close()
+const result = { errors, errorBoundary, cyanProbe, inspBlocked, inspAwait }
+console.log(JSON.stringify(result, null, 2))
+const pass = errors.length === 0 && !errorBoundary && cyanProbe.cyanStroke > 0 && cyanProbe.cyanFill > 0
+  && inspBlocked.some(t => /·/.test(t)) && inspAwait.some(t => /·/.test(t))
+console.log(pass ? '✅ PASS: 0 errors, cyan ring+pill rendered, inspector duration shows' : '⚠️ CHECK the JSON above')

--- a/src/components/agentInspectorModel.js
+++ b/src/components/agentInspectorModel.js
@@ -1,5 +1,6 @@
 import { classifyTask } from '../systems/classify.js'
 import { formatTimeAgo } from '../utils/formatTime'
+import { BLOCKED_FAMILY } from '../systems/constants.js'  // AVO-181: single source for the blocked family
 
 // The single line of "what is this agent doing" the inspector shows. The hook's
 // human `label` ("✏️ 改 App.jsx", "❌ npm test failed") is richest, so it wins.
@@ -18,11 +19,10 @@ export function inspectorTaskLabel(ext) {
 // Honest by construction — driven only by the real `changedAt` (stamped on a real status/task change),
 // returns null below 30s or when `changedAt` is missing (NEVER a fabricated "0m" freshly-entered
 // reading). Compact form (e.g. "3m"). Restricted to the two states where "how long" is actionable.
-const STATE_DURATION_STATUSES = new Set(['blocked', 'awaiting-approval'])
 const STATE_DURATION_MIN_MS = 30000
 
 export function stateDurationLabel(status, changedAt, now = Date.now()) {
-  if (!STATE_DURATION_STATUSES.has(status)) return null
+  if (!BLOCKED_FAMILY.has(status)) return null
   if (!Number.isFinite(changedAt)) return null
   if (now - changedAt < STATE_DURATION_MIN_MS) return null
   return formatTimeAgo(changedAt, { compact: true })

--- a/src/inference/desktopNotifier.js
+++ b/src/inference/desktopNotifier.js
@@ -26,6 +26,7 @@
  */
 import { t, charName } from '../i18n.js'
 import { recurringInfo } from '../systems/recurringFailure.js'
+import { BLOCKED_FAMILY } from '../systems/constants.js'  // AVO-181: single source for the blocked family
 
 const DEFAULT_BLOCKED_THRESHOLD_MS = 30_000
 const POLL_INTERVAL_MS = 5_000
@@ -37,11 +38,10 @@ const notifiedFor  = new Map()  // agentId → blocked-since timestamp we alread
 // Reset on leaving the blocked family so a fresh recurrence (after recovery) can re-fire once.
 const recurringNotifiedFor = new Map()
 
-// Statuses that the idle-gap inferrer reclassifies FROM 'blocked' (fix #2).
-// These are still considered part of the same blocked episode for dedupe
-// purposes — clearing blockedSince/notifiedFor here would cause a 2nd OS
-// notification when the same unanswered prompt re-asserts 'blocked'.
-const BLOCKED_DERIVED = new Set(['awaiting-approval'])
+// AVO-181: the blocked family (real `blocked` + its idle-gap-inferred `awaiting-approval`) is
+// `BLOCKED_FAMILY` (imported). Both are the SAME blocked episode for dedupe — clearing
+// blockedSince/notifiedFor on the awaiting-approval flap would cause a 2nd OS notification when
+// 'blocked' re-asserts for the same unanswered prompt.
 
 export function getNotificationState() {
   if (typeof Notification === 'undefined') return 'unsupported'
@@ -133,7 +133,7 @@ function tick(store, opts, now = Date.now) {
   const agents = store.getState().agents
   for (const id of Object.keys(agents)) {
     const a = agents[id]
-    if (a?.status === 'blocked' || BLOCKED_DERIVED.has(a?.status)) {
+    if (BLOCKED_FAMILY.has(a?.status)) {
       // 'blocked' and derived statuses (e.g. 'awaiting-approval' inferred by idle-gap)
       // are treated as the SAME episode. If the episode started while status was 'blocked'
       // and idle-gap reclassified to 'awaiting-approval', we must not clear blockedSince —

--- a/src/systems/constants.js
+++ b/src/systems/constants.js
@@ -32,6 +32,13 @@ export const ACTIVE_SESSION_STATUSES = new Set([
   'working', 'thinking', 'blocked', 'awaiting-approval', 'planning',
 ])
 
+// AVO-181: the "needs-you" blocked family — a real `blocked` + its idle-gap-inferred
+// `awaiting-approval` counterpart (an unanswered permission prompt). SINGLE source for the pet
+// hide-on-blocker guard (petState), the recurring-episode continuation check (recurringFailure), the
+// inspector duration line (agentInspectorModel), and the notifier episode gate (desktopNotifier) —
+// so extending the family is ONE edit, not 4 drifting copies.
+export const BLOCKED_FAMILY = new Set(['blocked', 'awaiting-approval'])
+
 // The behavior watchdog (AgentCharacter) restarts the scheduling chain when a
 // behavior value sits unchanged past WATCHDOG_TIMEOUT, treating it as a dead
 // chain. Skip that restart when behavior is being driven/held externally:

--- a/src/systems/petState.js
+++ b/src/systems/petState.js
@@ -6,6 +6,8 @@
 // Honesty guarantee: `hide` ALWAYS wins when an agent is actually blocked — the pet must never look
 // happy/asleep while someone needs a human. That single rule is what keeps the toy truthful.
 
+import { BLOCKED_FAMILY } from './constants.js'  // AVO-181: single source for the blocked family
+
 export const PET_MODES = Object.freeze({
   HIDE: 'hide',         // a real blocker, or a rough team mood — the pet crouches/hides
   NAP: 'nap',           // the team is idle/resting — the pet curls up
@@ -53,10 +55,10 @@ export function derivePetState({ mood, blockedCount = 0 } = {}) {
 // AVO-171: statuses that count as a real "needs-you" blocker for the hide-on-blocker honesty
 // guarantee. `awaiting-approval` is idle-gap-inferred from blocked+90s — an agent stuck at a
 // permission prompt is STILL blocked, so it must hide the pet (and never let it celebrate). Mirrors
-// desktopNotifier `BLOCKED_DERIVED` + recurringFailure `BLOCKED_FAMILY`; centralised here so the
-// pet's definition can't drift from the notifier's blocked-episode definition (the AVO-171 bug).
-export const BLOCKED_LIKE_STATUSES = Object.freeze(['blocked', 'awaiting-approval'])
-const BLOCKED_LIKE_SET = new Set(BLOCKED_LIKE_STATUSES)
+// Sourced from the shared `BLOCKED_FAMILY` (constants.js, AVO-181) so the pet's definition can't
+// drift from the notifier/inspector/recurring blocked-episode definition (the AVO-171 bug class).
+export const BLOCKED_LIKE_STATUSES = [...BLOCKED_FAMILY]  // AVO-181: public name kept; sourced from the SSoT
+const BLOCKED_LIKE_SET = BLOCKED_FAMILY                   // alias for internal .has()
 
 // countAttentionBlockers(externalStatus) → how many agents are in a real "needs-you" blocked state
 // (blocked OR awaiting-approval). Pure → unit-testable. The pet's blockedCount selector uses this.

--- a/src/systems/recurringFailure.js
+++ b/src/systems/recurringFailure.js
@@ -2,7 +2,8 @@
 // Honest by construction: we aggregate ONLY the real, hook-derived reasonCode stream (AVO-110),
 // count DISTINCT blocked episodes (the store decides what an episode-edge is — this module just
 // records the timestamps it's given), and claim only a recurring PATTERN of a KIND — never a
-// specific root cause (reasonCode is the coarse, observable unit). No React, no store import.
+// specific root cause (reasonCode is the coarse, observable unit). No React, no store.
+import { BLOCKED_FAMILY } from './constants.js'  // AVO-181: shared blocked family (a pure constant, not the store)
 
 // Only AVO-110's SPECIFIC reasons can recur. 'blocked-unknown' is deliberately EXCLUDED — a
 // recurring *unknown* cause is low-actionability noise and would over-claim. (Mirrors the
@@ -23,10 +24,9 @@ function isRecurringReason(reasonCode) {
 }
 
 // The idle-gap inferrer reclassifies a single stuck agent `blocked → awaiting-approval → blocked`
-// for the SAME unanswered state (see desktopNotifier's BLOCKED_DERIVED). Counting each re-entry as
+// for the SAME unanswered state (the shared BLOCKED_FAMILY in constants.js). Counting each re-entry as
 // a new episode would manufacture a FALSE recurrence from one real block — the exact alarm the spec
 // forbids. So a blocked-family status is a CONTINUATION, not a new episode.
-const BLOCKED_FAMILY = new Set(['blocked', 'awaiting-approval'])
 
 // Is `next` the START of a NEW blocked episode (vs a continuation / poll re-read)? New episode =
 // entering 'blocked' with a SPECIFIC reason from a NON-blocked-family prior state, OR a genuine


### PR DESCRIPTION
Consolidates the `{blocked, awaiting-approval}` 'needs-you' family — duplicated in 4 modules (petState/desktopNotifier/recurringFailure/agentInspectorModel) — into a single `BLOCKED_FAMILY` in `constants.js` (pure leaf), imported everywhere. A new status now needs ONE edit, not 4. petState keeps its public `BLOCKED_LIKE_STATUSES` export (derived from the SSoT) → API + tests unchanged.

VALID_ROLES + active-count consolidation left as follow-ups (the latter has a `planning`-excluded semantic question to settle first — flagged, not blindly hoisted).

Verify: full suite **2184 pass**, build clean, 87 affected tests green, exactly 1 `BLOCKED_FAMILY` def remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)