### PR TITLE
docs(AVO-184): fix stale MIN_AGENT_DIST comment caught by the wave's expert review

### DIFF
--- a/src/systems/movementSystem.js
+++ b/src/systems/movementSystem.js
@@ -701,8 +701,8 @@ export function needsLocationChange(behaviorId) {
 }
 
 // ─── Anti-overlap system ──────────────────────────────────────────────
-// (MIN_AGENT_DIST no longer consumed here — the separation contract is the visual ellipse
-// below; the constant stays in constants.js for external readers.)
+// (the separation contract is the visual ellipse below, not a circular MIN_AGENT_DIST — that
+// constant was removed in AVO-184 as it had no remaining consumers.)
 import { OBSTACLE_PUSH_PX, CORRIDOR_JITTER, DOOR_JITTER } from './constants.js'
 
 // Get all other agents' claimed standing spots. Resolution order matters (forensic


### PR DESCRIPTION
The 3-expert review of the round-2 fix wave (AVO-180/181/182/183/184) found NO bugs/regressions — except one LOW finding: a stale comment in `movementSystem.js` still claimed `MIN_AGENT_DIST` 'stays in constants.js for external readers', but AVO-184 removed it. Corrected. Comment-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)