### PR TITLE
chore(release): v1.6.3 — office layout enrichment (#192)

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -165,6 +165,11 @@
 
 ## Ship History
 
+### Ship-chore-release-v1.6.3-2026-06-27 (office layout enrichment) · release v1.6.3
+
+- Release cutting the merged office-layout-enrichment work (PR #192, squash `fcf5ee1`) as **v1.6.3**: `package.json` 1.6.2→1.6.3 + CHANGELOG narrative (Unreleased → v1.6.3 "Fuller corners, honest windows"). No further app change. Lockfile root version left stale per convention. Tag + `npm publish` performed manually by owner.
+- Tests: Pass (full suite 2222, from #192)
+
 ### Ship-feat-office-layout-enrichment-2026-06-27 (meeting-room nook + hallway decor + interior-window fix)
 
 - Shipped office layout enrichment (quick-win, cosmetic, **decor-only — no movementSystem geometry touched**). Filled the two real dead zones found in a rendered-office audit: the meeting-room right column got a breakout nook (rug + couch + coffee table + plants); the entrance hallway got a gate-gap window + 2 framed pictures (new `<FramedArt>` component) + a reception water-cooler/plant corner; plus a 3rd meeting window, a meeting wall clock, and a night ceiling-light over the nook. **Owner-found correctness fix**: removed 4 "night-sky" windows wrongly mounted on the INTERIOR north wall (hallway is on the other side, not outdoors) + their `NightSky` moon/star clips → framed art + clock instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ live in `docs/specs/_shipped-log.md`; this file is the high-level story.
 
 Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
-## Unreleased
+## v1.6.3 — 2026-06-27 — Fuller corners, honest windows
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Pixel-art virtual office that visualizes your AI coding agents in real time — Claude Code, Codex, Gemini CLI, or any tool that can POST status. Pure SVG, zero backend, runs locally.",
   "main": "bin/cli.js",
   "bin": {


### PR DESCRIPTION
## Release v1.6.3 — Fuller corners, honest windows

Lean patch release cutting the merged **office layout enrichment** ([#192](https://github.com/KbWen/agent-virtual-office/pull/192), squash `fcf5ee1`).

### This PR
- `package.json` 1.6.2 → 1.6.3 (lockfile root version left stale, per convention)
- CHANGELOG: `Unreleased` → `v1.6.3` narrative
- SSoT Ship History: release entry added

### What shipped in #192
- Meeting-room breakout nook (couch / coffee table / plants) + 3rd window + wall clock + night light
- Hallway framed art + reception water-cooler corner + a window over the gate
- **Fix**: removed 4 night-sky windows wrongly mounted on the interior partition wall
- Pure decor (zero status signal); 4-lens expert review + UI/UX polish + 2 QA rounds; full suite **2222 pass**

### After merge (owner, manual)
- `git tag v1.6.3` + `npm publish` — per project convention these stay manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
