### PR TITLE
[codex] Strengthen panel feature verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run smoke
       - run: npm run smoke:panel
+      - run: SOAK_SPAWN=1 node scripts/sim-soak.mjs --minutes 0.05
 
   pack-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - run: npm run build
       - run: npx playwright install --with-deps chromium
       - run: npm run smoke
+      - run: npm run smoke:panel
 
   pack-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run smoke
       - run: npm run smoke:panel
-      - run: SOAK_SPAWN=1 node scripts/sim-soak.mjs --minutes 0.05
+      - name: Spawn soak smoke
+        run: npm run soak:spawn -- --minutes 0.05
 
   pack-smoke:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "smoke:panel": "node scripts/panel-features-verify.mjs",
     "smoke:pack": "node scripts/pack-smoke.mjs",
     "soak": "node scripts/sim-soak.mjs",
+    "soak:spawn": "node scripts/sim-soak.mjs --spawn",
     "test": "vitest run",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build:single": "vite build --outDir dist-single",
     "serve": "node server.mjs",
     "smoke": "node scripts/render-smoke.mjs",
+    "smoke:panel": "node scripts/panel-features-verify.mjs",
     "smoke:pack": "node scripts/pack-smoke.mjs",
     "soak": "node scripts/sim-soak.mjs",
     "test": "vitest run",

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -230,18 +230,23 @@ try {
   await stageOffice()
 
   const cyanProbe = await page.evaluate(() => {
-    const group = document.querySelector('svg g[data-agent-id="dev"][data-agent-status="awaiting-approval"]')
-    let cyanStroke = 0
-    let cyanFill = 0
-    if (group) {
+    const countCyan = (selector) => {
+      const group = document.querySelector(selector)
+      let cyanStroke = 0
+      let cyanFill = 0
+      if (!group) return { scoped: false, cyanStroke, cyanFill }
       for (const el of group.querySelectorAll('*')) {
         const st = (el.getAttribute('stroke') || '').toLowerCase()
         const fl = (el.getAttribute('fill') || '').toLowerCase()
         if (st === '#1e9fd4') cyanStroke++
         if (fl === '#1e9fd4') cyanFill++
       }
+      return { scoped: true, cyanStroke, cyanFill }
     }
-    return { scopedToDev: !!group, cyanStroke, cyanFill }
+    return {
+      awaiting: countCyan('svg g[data-agent-id="dev"][data-agent-status="awaiting-approval"]'),
+      blocked: countCyan('svg g[data-agent-id="qa"][data-agent-status="blocked"]'),
+    }
   })
 
   await page.evaluate(() => { const svg = document.querySelector('svg'); if (svg) svg.setAttribute('viewBox', '0 0 800 560') })
@@ -277,8 +282,9 @@ try {
   await (await page.$('svg')).screenshot({ path: path.join(OUT, 'avo167-await-ring-closeup.png') })
 
   result = { baseUrl: BASE_URL, shotDir: OUT, errors, errorBoundary, cyanProbe, inspBlocked, inspAwait }
-  pass = errors.length === 0 && !errorBoundary && cyanProbe.scopedToDev
-    && cyanProbe.cyanStroke > 0 && cyanProbe.cyanFill > 0
+  pass = errors.length === 0 && !errorBoundary
+    && cyanProbe.awaiting.scoped && cyanProbe.awaiting.cyanStroke > 0 && cyanProbe.awaiting.cyanFill > 0
+    && cyanProbe.blocked.scoped && cyanProbe.blocked.cyanStroke === 0 && cyanProbe.blocked.cyanFill === 0
     && inspBlocked.some(t => /Blocked · \d/.test(t)) && inspAwait.some(t => /Awaiting approval · \d/.test(t))
 } catch (err) {
   result = { ...(result || {}), error: err.message, stack: err.stack?.split('\n').slice(0, 8) }

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -19,6 +19,7 @@ const OUT = process.env.PANEL_SHOT_DIR
   : path.join(ROOT, '.pet-shots')
 const READY_TIMEOUT_MS = 20_000
 const POLL_INTERVAL_MS = 250
+const FETCH_ATTEMPT_TIMEOUT_MS = 1000
 
 mkdirSync(OUT, { recursive: true })
 
@@ -60,7 +61,9 @@ async function waitForServer(url, deadlineMs, getServerExit) {
       )
     }
     try {
-      const res = await fetch(url)
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), FETCH_ATTEMPT_TIMEOUT_MS)
+      const res = await fetch(url, { signal: controller.signal }).finally(() => clearTimeout(timer))
       if (res.ok) return true
     } catch {}
     await new Promise(r => setTimeout(r, POLL_INTERVAL_MS))
@@ -99,6 +102,8 @@ let serverStderr = ''
 let serverExit = null
 serverProc.stdout.on('data', d => { serverStdout += d.toString() })
 serverProc.stderr.on('data', d => { serverStderr += d.toString() })
+serverProc.stdout.on('error', () => {})
+serverProc.stderr.on('error', () => {})
 serverProc.once('close', (code, signal) => { serverExit = { code, signal } })
 
 let browser = null
@@ -136,6 +141,8 @@ async function cleanup() {
   try { await page?.close() } catch {}
   try { await browser?.close() } catch {}
   await stopServerProcessTree()
+  try { serverProc.stdout?.destroy() } catch {}
+  try { serverProc.stderr?.destroy() } catch {}
   })()
   return cleanupPromise
 }
@@ -281,4 +288,4 @@ try {
 
 console.log(JSON.stringify(result, null, 2))
 console.log(pass ? 'PASS: 0 errors, scoped cyan ring+pill rendered, inspector durations show' : 'FAIL: panel visual assertions did not pass')
-process.exit(pass ? 0 : 1)
+process.exitCode = pass ? 0 : 1

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -22,22 +22,43 @@ const POLL_INTERVAL_MS = 250
 
 mkdirSync(OUT, { recursive: true })
 
+function failEarly(message) {
+  console.log(JSON.stringify({ error: message }, null, 2))
+  console.log('FAIL: panel visual assertions did not pass')
+  process.exit(1)
+}
+
+function parsePortEnv(name, value) {
+  if (!/^\d+$/.test(value || '')) throw new Error(`${name} must be an integer port in 1..65535`)
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} must be an integer port in 1..65535`)
+  }
+  return port
+}
+
 async function pickPort() {
-  if (process.env.PANEL_PORT) return parseInt(process.env.PANEL_PORT, 10)
+  if (process.env.PANEL_PORT) return parsePortEnv('PANEL_PORT', process.env.PANEL_PORT)
   return await new Promise((resolve, reject) => {
     const server = createServer()
     server.on('error', reject)
     server.listen(0, '127.0.0.1', () => {
       const address = server.address()
       const port = typeof address === 'object' && address ? address.port : 0
-      server.close(() => resolve(port))
+      server.close(() => port ? resolve(port) : reject(new Error('failed to reserve a local port')))
     })
   })
 }
 
-async function waitForServer(url, deadlineMs) {
+async function waitForServer(url, deadlineMs, getServerExit) {
   const deadline = Date.now() + deadlineMs
   while (Date.now() < deadline) {
+    const serverExit = getServerExit()
+    if (serverExit) {
+      throw new Error(
+        `vite exited before readiness (code=${serverExit.code}, signal=${serverExit.signal}); stderr=${serverStderr.slice(-500)}`
+      )
+    }
     try {
       const res = await fetch(url)
       if (res.ok) return true
@@ -59,9 +80,9 @@ async function launchBrowser() {
   }
 }
 
-const PORT = await pickPort()
+const PORT = await pickPort().catch(err => failEarly(err.message))
 const BASE_URL = `http://127.0.0.1:${PORT}`
-const URL = `${BASE_URL}/?lang=en&smoke=panel`
+const PAGE_URL = `${BASE_URL}/?lang=en&smoke=panel`
 const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js')
 if (!existsSync(viteBin)) {
   console.error('ERROR: Vite binary not found. Run `npm ci` first.')
@@ -75,16 +96,19 @@ const serverProc = spawn(
 
 let serverStdout = ''
 let serverStderr = ''
+let serverExit = null
 serverProc.stdout.on('data', d => { serverStdout += d.toString() })
 serverProc.stderr.on('data', d => { serverStderr += d.toString() })
+serverProc.once('close', (code, signal) => { serverExit = { code, signal } })
 
 let browser = null
 let page = null
 let result = null
 let pass = false
+let cleanupPromise = null
 
 async function stopServerProcessTree() {
-  if (!serverProc.pid) return
+  if (!serverProc.pid || serverExit) return
   if (process.platform === 'win32') {
     await new Promise(resolve => {
       const killer = spawn('taskkill.exe', ['/pid', String(serverProc.pid), '/t', '/f'], { stdio: 'ignore' })
@@ -107,13 +131,28 @@ async function stopServerProcessTree() {
 }
 
 async function cleanup() {
+  if (cleanupPromise) return cleanupPromise
+  cleanupPromise = (async () => {
   try { await page?.close() } catch {}
   try { await browser?.close() } catch {}
   await stopServerProcessTree()
+  })()
+  return cleanupPromise
 }
 
+async function shutdownFromSignal(code) {
+  await cleanup()
+  process.exit(code)
+}
+process.once('SIGINT', () => { shutdownFromSignal(130) })
+process.once('SIGTERM', () => { shutdownFromSignal(143) })
+process.once('exit', () => {
+  if (!serverProc.pid || serverExit || process.platform === 'win32') return
+  try { process.kill(-serverProc.pid, 'SIGKILL') } catch {}
+})
+
 try {
-  const ready = await waitForServer(BASE_URL, READY_TIMEOUT_MS)
+  const ready = await waitForServer(BASE_URL, READY_TIMEOUT_MS, () => serverExit)
   if (!ready) {
     throw new Error(
       `server did not become ready on ${BASE_URL}; stdout=${serverStdout.slice(-500)} stderr=${serverStderr.slice(-500)}`
@@ -127,15 +166,22 @@ try {
   page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
   page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message))
 
-  await page.route('**/api/status**', route => route.fulfill({
-    status: route.request().url().includes('/api/status/stream') ? 204 : 200,
-    contentType: route.request().url().includes('/api/status/stream') ? 'text/plain' : 'application/json',
-    body: route.request().url().includes('/api/status/stream')
-      ? ''
-      : JSON.stringify({ ok: true, agents: [], sessions: [], workflow: null }),
-  }))
+  await page.route('**/*', route => {
+    const pathname = new globalThis.URL(route.request().url()).pathname
+    if (pathname === '/api/status/stream') {
+      return route.fulfill({ status: 204, contentType: 'text/plain', body: '' })
+    }
+    if (pathname === '/api/status') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ ok: true, agents: [], sessions: [], workflow: null }),
+      })
+    }
+    return route.continue()
+  })
   await page.addInitScript(() => { try { localStorage.setItem('office-onboarded', '1') } catch {} })
-  await page.goto(URL, { waitUntil: 'domcontentloaded' })
+  await page.goto(PAGE_URL, { waitUntil: 'domcontentloaded' })
   await page.waitForSelector('svg', { timeout: 20_000 })
   await page.waitForTimeout(500)
 

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -26,30 +26,41 @@ await page.waitForTimeout(900)
 const bodyText = await page.evaluate(() => document.body.innerText || '')
 const errorBoundary = /Something went wrong/i.test(bodyText)
 
-// Stage: dev = awaiting-approval (cyan), qa = blocked (red). changedAt 2min ago for the duration line.
-await page.evaluate(async () => {
-  const store = (await import('/src/systems/store.js')).useOfficeStore
-  const mv = await import('/src/systems/movementSystem.js')
-  const HOME = mv.HOME_POSITIONS
-  const s = store.getState()
-  const now = Date.now()
-  const agents = { ...s.agents }
-  for (const id of Object.keys(agents)) {
-    const h = HOME[id] || agents[id].position
-    agents[id] = { ...agents[id], position: { ...h }, targetPosition: { ...h }, isMoving: false,
-      inGroupEvent: false, journeyTarget: null,
-      status: id === 'dev' ? 'awaiting-approval' : id === 'qa' ? 'blocked' : agents[id].status }
-  }
-  store.setState({
-    agents,
-    externalStatus: {
-      dev: { status: 'awaiting-approval', changedAt: now - 120000 },
-      qa:  { status: 'blocked', reasonCode: 'test-run-failed', label: '❌ npm test failed', changedAt: now - 120000 },
-    },
-    isPaused: true, activeEvent: null, reducedMotion: true, handoffs: [], helpers: [],
-  })
-})
-await page.waitForTimeout(350)
+async function stageOffice(selectedAgent = null) {
+  // Restage immediately before every probe. The real app's status integration can poll after page
+  // load and legitimately overwrite store state; a visual verifier must control its own fixture.
+  await page.evaluate(async (selected) => {
+    const store = (await import('/src/systems/store.js')).useOfficeStore
+    const mv = await import('/src/systems/movementSystem.js')
+    const HOME = mv.HOME_POSITIONS
+    const s = store.getState()
+    const now = Date.now()
+    const agents = { ...s.agents }
+    for (const id of Object.keys(agents)) {
+      const h = HOME[id] || agents[id].position
+      agents[id] = { ...agents[id], position: { ...h }, targetPosition: { ...h }, isMoving: false,
+        inGroupEvent: false, journeyTarget: null, bubble: null,
+        status: id === 'dev' ? 'awaiting-approval' : id === 'qa' ? 'blocked' : agents[id].status }
+    }
+    store.setState({
+      agents,
+      externalStatus: {
+        dev: { status: 'awaiting-approval', task: 'Review', label: 'Waiting for approval', changedAt: now - 120000 },
+        qa:  { status: 'blocked', task: 'Test run', reasonCode: 'test-run-failed', label: 'npm test failed', changedAt: now - 120000 },
+      },
+      selectedAgent: selected,
+      isPaused: true,
+      activeEvent: null,
+      activeWorkflow: null,
+      reducedMotion: true,
+      handoffs: [],
+      helpers: [],
+    })
+  }, selectedAgent)
+  await page.waitForTimeout(150)
+}
+
+await stageOffice()
 
 // Probe: did the new awaiting-approval cyan actually render (ring stroke + name-pill fill)?
 const cyanProbe = await page.evaluate(() => {
@@ -68,31 +79,25 @@ await page.waitForTimeout(150)
 await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-office-await-vs-blocked.png` })
 
 // AVO-169: inspector on the BLOCKED agent → "Blocked · 2m"
-await page.evaluate(async () => {
-  const store = (await import('/src/systems/store.js')).useOfficeStore
-  store.setState({ selectedAgent: 'qa' })
-})
-await page.waitForTimeout(300)
+await stageOffice('qa')
+await page.waitForFunction(() =>
+  Array.from(document.querySelectorAll('svg text')).some((t) => /Blocked · \d/.test(t.textContent || '')),
+  { timeout: 5000 })
 const inspBlocked = await page.evaluate(() =>
   Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && /·|\d+[smh]\b/.test(t)))
 await (await page.$('svg')).screenshot({ path: `${OUT}/avo169-inspector-blocked-duration.png` })
 
 // AVO-167+169: inspector on the AWAITING agent → "Awaiting approval · 2m" (cyan header)
-await page.evaluate(async () => {
-  const store = (await import('/src/systems/store.js')).useOfficeStore
-  store.setState({ selectedAgent: 'dev' })
-})
-await page.waitForTimeout(300)
+await stageOffice('dev')
+await page.waitForFunction(() =>
+  Array.from(document.querySelectorAll('svg text')).some((t) => /Awaiting approval · \d/.test(t.textContent || '')),
+  { timeout: 5000 })
 const inspAwait = await page.evaluate(() =>
   Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && (/·|\d+[smh]\b/.test(t) || /await/i.test(t))))
 await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-169-inspector-await-duration.png` })
 
 // AVO-167: close-up of the awaiting-approval cyan ring (inspector closed for a clean shot)
-await page.evaluate(async () => {
-  const store = (await import('/src/systems/store.js')).useOfficeStore
-  store.setState({ selectedAgent: null })
-})
-await page.waitForTimeout(200)
+await stageOffice(null)
 await page.evaluate(() => {
   const svg = document.querySelector('svg')
   const p = window.__avoDevPos
@@ -113,5 +118,6 @@ await browser.close()
 const result = { errors, errorBoundary, cyanProbe, inspBlocked, inspAwait }
 console.log(JSON.stringify(result, null, 2))
 const pass = errors.length === 0 && !errorBoundary && cyanProbe.cyanStroke > 0 && cyanProbe.cyanFill > 0
-  && inspBlocked.some(t => /·/.test(t)) && inspAwait.some(t => /·/.test(t))
+  && inspBlocked.some(t => /Blocked · \d/.test(t)) && inspAwait.some(t => /Awaiting approval · \d/.test(t))
 console.log(pass ? '✅ PASS: 0 errors, cyan ring+pill rendered, inspector duration shows' : '⚠️ CHECK the JSON above')
+if (!pass) process.exit(1)

--- a/scripts/panel-features-verify.mjs
+++ b/scripts/panel-features-verify.mjs
@@ -1,123 +1,238 @@
-// Visual verification for the panel-approved wave (AVO-165/167/169) — LOAD THE PAGE (green tests ≠
-// renders; preview_screenshot hangs in this repo, so we use headless Playwright against the dev server).
-// Stages dev=awaiting-approval (new cyan ring) next to qa=blocked (red ring), with changedAt 2min ago
-// so the inspector shows the elapsed-time line. Asserts 0 console errors + no ErrorBoundary, probes
-// that the new cyan actually renders, and shots the office + both inspector states + a ring close-up.
-import { chromium } from 'playwright-core'
-import { mkdirSync } from 'fs'
+#!/usr/bin/env node
+// Visual verification for the panel-approved wave (AVO-165/167/169).
+//
+// Runs against a throwaway Vite dev server because the fixture stages app internals through
+// browser-side module imports. The browser route stubs below intentionally freeze /api/status
+// and SSE: this verifier owns its fixture state, and live local status files must not race or
+// mask the visual assertions.
+import { chromium } from 'playwright'
+import { spawn } from 'node:child_process'
+import { mkdirSync, existsSync } from 'node:fs'
+import { createServer } from 'node:net'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const URL = 'http://localhost:5173/?lang=en'
-const OUT = 'C:/Users/wen/.gemini/antigravity/scratch/agent-virtual-office/.pet-shots'
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const OUT = process.env.PANEL_SHOT_DIR
+  ? path.resolve(process.env.PANEL_SHOT_DIR)
+  : path.join(ROOT, '.pet-shots')
+const READY_TIMEOUT_MS = 20_000
+const POLL_INTERVAL_MS = 250
+
 mkdirSync(OUT, { recursive: true })
 
-const browser = await chromium.launch({ headless: true }).catch(() =>
-  chromium.launch({ headless: true, executablePath: 'C:/Program Files/Google/Chrome/Application/chrome.exe' }))
-const page = await browser.newPage({ viewport: { width: 1400, height: 900 }, deviceScaleFactor: 2 })
-
-const errors = []
-page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
-page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message))
-
-await page.addInitScript(() => { try { localStorage.setItem('office-onboarded', '1') } catch {} })
-await page.goto(URL, { waitUntil: 'domcontentloaded' })
-await page.waitForSelector('svg', { timeout: 20000 })
-await page.waitForTimeout(900)
-
-const bodyText = await page.evaluate(() => document.body.innerText || '')
-const errorBoundary = /Something went wrong/i.test(bodyText)
-
-async function stageOffice(selectedAgent = null) {
-  // Restage immediately before every probe. The real app's status integration can poll after page
-  // load and legitimately overwrite store state; a visual verifier must control its own fixture.
-  await page.evaluate(async (selected) => {
-    const store = (await import('/src/systems/store.js')).useOfficeStore
-    const mv = await import('/src/systems/movementSystem.js')
-    const HOME = mv.HOME_POSITIONS
-    const s = store.getState()
-    const now = Date.now()
-    const agents = { ...s.agents }
-    for (const id of Object.keys(agents)) {
-      const h = HOME[id] || agents[id].position
-      agents[id] = { ...agents[id], position: { ...h }, targetPosition: { ...h }, isMoving: false,
-        inGroupEvent: false, journeyTarget: null, bubble: null,
-        status: id === 'dev' ? 'awaiting-approval' : id === 'qa' ? 'blocked' : agents[id].status }
-    }
-    store.setState({
-      agents,
-      externalStatus: {
-        dev: { status: 'awaiting-approval', task: 'Review', label: 'Waiting for approval', changedAt: now - 120000 },
-        qa:  { status: 'blocked', task: 'Test run', reasonCode: 'test-run-failed', label: 'npm test failed', changedAt: now - 120000 },
-      },
-      selectedAgent: selected,
-      isPaused: true,
-      activeEvent: null,
-      activeWorkflow: null,
-      reducedMotion: true,
-      handoffs: [],
-      helpers: [],
+async function pickPort() {
+  if (process.env.PANEL_PORT) return parseInt(process.env.PANEL_PORT, 10)
+  return await new Promise((resolve, reject) => {
+    const server = createServer()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      const port = typeof address === 'object' && address ? address.port : 0
+      server.close(() => resolve(port))
     })
-  }, selectedAgent)
-  await page.waitForTimeout(150)
+  })
 }
 
-await stageOffice()
-
-// Probe: did the new awaiting-approval cyan actually render (ring stroke + name-pill fill)?
-const cyanProbe = await page.evaluate(() => {
-  let stroke = 0, fill = 0
-  for (const el of document.querySelectorAll('svg *')) {
-    const st = (el.getAttribute('stroke') || '').toLowerCase()
-    const fl = (el.getAttribute('fill') || '').toLowerCase()
-    if (st === '#1e9fd4') stroke++
-    if (fl === '#1e9fd4') fill++
+async function waitForServer(url, deadlineMs) {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url)
+      if (res.ok) return true
+    } catch {}
+    await new Promise(r => setTimeout(r, POLL_INTERVAL_MS))
   }
-  return { cyanStroke: stroke, cyanFill: fill }
-})
+  return false
+}
 
-await page.evaluate(() => { const svg = document.querySelector('svg'); if (svg) svg.setAttribute('viewBox', '0 0 800 560') })
-await page.waitForTimeout(150)
-await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-office-await-vs-blocked.png` })
+async function launchBrowser() {
+  try {
+    return await chromium.launch({ headless: true })
+  } catch {
+    const systemChrome = 'C:/Program Files/Google/Chrome/Application/chrome.exe'
+    if (existsSync(systemChrome)) {
+      return await chromium.launch({ headless: true, executablePath: systemChrome })
+    }
+    throw new Error('No Chromium available. Run: npx playwright install --with-deps chromium')
+  }
+}
 
-// AVO-169: inspector on the BLOCKED agent → "Blocked · 2m"
-await stageOffice('qa')
-await page.waitForFunction(() =>
-  Array.from(document.querySelectorAll('svg text')).some((t) => /Blocked · \d/.test(t.textContent || '')),
-  { timeout: 5000 })
-const inspBlocked = await page.evaluate(() =>
-  Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && /·|\d+[smh]\b/.test(t)))
-await (await page.$('svg')).screenshot({ path: `${OUT}/avo169-inspector-blocked-duration.png` })
+const PORT = await pickPort()
+const BASE_URL = `http://127.0.0.1:${PORT}`
+const URL = `${BASE_URL}/?lang=en&smoke=panel`
+const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js')
+if (!existsSync(viteBin)) {
+  console.error('ERROR: Vite binary not found. Run `npm ci` first.')
+  process.exit(1)
+}
+const serverProc = spawn(
+  process.execPath,
+  [viteBin, '--host', '127.0.0.1', '--port', String(PORT), '--strictPort'],
+  { cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'], detached: process.platform !== 'win32' }
+)
 
-// AVO-167+169: inspector on the AWAITING agent → "Awaiting approval · 2m" (cyan header)
-await stageOffice('dev')
-await page.waitForFunction(() =>
-  Array.from(document.querySelectorAll('svg text')).some((t) => /Awaiting approval · \d/.test(t.textContent || '')),
-  { timeout: 5000 })
-const inspAwait = await page.evaluate(() =>
-  Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && (/·|\d+[smh]\b/.test(t) || /await/i.test(t))))
-await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-169-inspector-await-duration.png` })
+let serverStdout = ''
+let serverStderr = ''
+serverProc.stdout.on('data', d => { serverStdout += d.toString() })
+serverProc.stderr.on('data', d => { serverStderr += d.toString() })
 
-// AVO-167: close-up of the awaiting-approval cyan ring (inspector closed for a clean shot)
-await stageOffice(null)
-await page.evaluate(() => {
-  const svg = document.querySelector('svg')
-  const p = window.__avoDevPos
-  if (svg) svg.setAttribute('viewBox', p ? `${p.x - 70} ${p.y - 95} 140 145` : '180 300 180 180')
-})
-await page.evaluate(async () => {
-  const store = (await import('/src/systems/store.js')).useOfficeStore
-  window.__avoDevPos = store.getState().agents.dev?.position
-})
-await page.evaluate(() => {
-  const svg = document.querySelector('svg'); const p = window.__avoDevPos
-  if (svg && p) svg.setAttribute('viewBox', `${Math.round(p.x - 70)} ${Math.round(p.y - 95)} 140 145`)
-})
-await page.waitForTimeout(200)
-await (await page.$('svg')).screenshot({ path: `${OUT}/avo167-await-ring-closeup.png` })
+let browser = null
+let page = null
+let result = null
+let pass = false
 
-await browser.close()
-const result = { errors, errorBoundary, cyanProbe, inspBlocked, inspAwait }
+async function stopServerProcessTree() {
+  if (!serverProc.pid) return
+  if (process.platform === 'win32') {
+    await new Promise(resolve => {
+      const killer = spawn('taskkill.exe', ['/pid', String(serverProc.pid), '/t', '/f'], { stdio: 'ignore' })
+      killer.on('error', resolve)
+      killer.on('exit', resolve)
+    })
+    return
+  }
+  try {
+    process.kill(-serverProc.pid, 'SIGTERM')
+    const exited = await new Promise(resolve => {
+      const timer = setTimeout(() => resolve(false), 1500)
+      serverProc.once('close', () => {
+        clearTimeout(timer)
+        resolve(true)
+      })
+    })
+    if (!exited) process.kill(-serverProc.pid, 'SIGKILL')
+  } catch {}
+}
+
+async function cleanup() {
+  try { await page?.close() } catch {}
+  try { await browser?.close() } catch {}
+  await stopServerProcessTree()
+}
+
+try {
+  const ready = await waitForServer(BASE_URL, READY_TIMEOUT_MS)
+  if (!ready) {
+    throw new Error(
+      `server did not become ready on ${BASE_URL}; stdout=${serverStdout.slice(-500)} stderr=${serverStderr.slice(-500)}`
+    )
+  }
+
+  browser = await launchBrowser()
+  page = await browser.newPage({ viewport: { width: 1400, height: 900 }, deviceScaleFactor: 2 })
+
+  const errors = []
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()) })
+  page.on('pageerror', (e) => errors.push('PAGEERROR: ' + e.message))
+
+  await page.route('**/api/status**', route => route.fulfill({
+    status: route.request().url().includes('/api/status/stream') ? 204 : 200,
+    contentType: route.request().url().includes('/api/status/stream') ? 'text/plain' : 'application/json',
+    body: route.request().url().includes('/api/status/stream')
+      ? ''
+      : JSON.stringify({ ok: true, agents: [], sessions: [], workflow: null }),
+  }))
+  await page.addInitScript(() => { try { localStorage.setItem('office-onboarded', '1') } catch {} })
+  await page.goto(URL, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('svg', { timeout: 20_000 })
+  await page.waitForTimeout(500)
+
+  const bodyText = await page.evaluate(() => document.body.innerText || '')
+  const errorBoundary = /Something went wrong/i.test(bodyText)
+
+  async function stageOffice(selectedAgent = null) {
+    await page.evaluate(async (selected) => {
+      const store = (await import('/src/systems/store.js')).useOfficeStore
+      const mv = await import('/src/systems/movementSystem.js')
+      const HOME = mv.HOME_POSITIONS
+      const s = store.getState()
+      const now = Date.now()
+      const agents = { ...s.agents }
+      for (const id of Object.keys(agents)) {
+        const h = HOME[id] || agents[id].position
+        agents[id] = { ...agents[id], position: { ...h }, targetPosition: { ...h }, isMoving: false,
+          inGroupEvent: false, journeyTarget: null, bubble: null,
+          status: id === 'dev' ? 'awaiting-approval' : id === 'qa' ? 'blocked' : agents[id].status }
+      }
+      store.setState({
+        agents,
+        externalStatus: {
+          dev: { status: 'awaiting-approval', task: 'Review', label: 'Waiting for approval', changedAt: now - 120000 },
+          qa:  { status: 'blocked', task: 'Test run', reasonCode: 'test-run-failed', label: 'npm test failed', changedAt: now - 120000 },
+        },
+        selectedAgent: selected,
+        isPaused: true,
+        activeEvent: null,
+        activeWorkflow: null,
+        reducedMotion: true,
+        handoffs: [],
+        helpers: [],
+      })
+    }, selectedAgent)
+    await page.waitForTimeout(150)
+  }
+
+  await stageOffice()
+
+  const cyanProbe = await page.evaluate(() => {
+    const group = document.querySelector('svg g[data-agent-id="dev"][data-agent-status="awaiting-approval"]')
+    let cyanStroke = 0
+    let cyanFill = 0
+    if (group) {
+      for (const el of group.querySelectorAll('*')) {
+        const st = (el.getAttribute('stroke') || '').toLowerCase()
+        const fl = (el.getAttribute('fill') || '').toLowerCase()
+        if (st === '#1e9fd4') cyanStroke++
+        if (fl === '#1e9fd4') cyanFill++
+      }
+    }
+    return { scopedToDev: !!group, cyanStroke, cyanFill }
+  })
+
+  await page.evaluate(() => { const svg = document.querySelector('svg'); if (svg) svg.setAttribute('viewBox', '0 0 800 560') })
+  await page.waitForTimeout(150)
+  await (await page.$('svg')).screenshot({ path: path.join(OUT, 'avo167-office-await-vs-blocked.png') })
+
+  await stageOffice('qa')
+  await page.waitForFunction(() =>
+    Array.from(document.querySelectorAll('svg text')).some((t) => /Blocked · \d/.test(t.textContent || '')),
+    { timeout: 5000 })
+  const inspBlocked = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && /·|\d+[smh]\b/.test(t)))
+  await (await page.$('svg')).screenshot({ path: path.join(OUT, 'avo169-inspector-blocked-duration.png') })
+
+  await stageOffice('dev')
+  await page.waitForFunction(() =>
+    Array.from(document.querySelectorAll('svg text')).some((t) => /Awaiting approval · \d/.test(t.textContent || '')),
+    { timeout: 5000 })
+  const inspAwait = await page.evaluate(() =>
+    Array.from(document.querySelectorAll('svg text')).map(t => t.textContent).filter(t => t && (/·|\d+[smh]\b/.test(t) || /await/i.test(t))))
+  await (await page.$('svg')).screenshot({ path: path.join(OUT, 'avo167-169-inspector-await-duration.png') })
+
+  await stageOffice(null)
+  await page.evaluate(async () => {
+    const store = (await import('/src/systems/store.js')).useOfficeStore
+    window.__avoDevPos = store.getState().agents.dev?.position
+  })
+  await page.evaluate(() => {
+    const svg = document.querySelector('svg'); const p = window.__avoDevPos
+    if (svg && p) svg.setAttribute('viewBox', `${Math.round(p.x - 70)} ${Math.round(p.y - 95)} 140 145`)
+  })
+  await page.waitForTimeout(200)
+  await (await page.$('svg')).screenshot({ path: path.join(OUT, 'avo167-await-ring-closeup.png') })
+
+  result = { baseUrl: BASE_URL, shotDir: OUT, errors, errorBoundary, cyanProbe, inspBlocked, inspAwait }
+  pass = errors.length === 0 && !errorBoundary && cyanProbe.scopedToDev
+    && cyanProbe.cyanStroke > 0 && cyanProbe.cyanFill > 0
+    && inspBlocked.some(t => /Blocked · \d/.test(t)) && inspAwait.some(t => /Awaiting approval · \d/.test(t))
+} catch (err) {
+  result = { ...(result || {}), error: err.message, stack: err.stack?.split('\n').slice(0, 8) }
+} finally {
+  await cleanup()
+}
+
 console.log(JSON.stringify(result, null, 2))
-const pass = errors.length === 0 && !errorBoundary && cyanProbe.cyanStroke > 0 && cyanProbe.cyanFill > 0
-  && inspBlocked.some(t => /Blocked · \d/.test(t)) && inspAwait.some(t => /Awaiting approval · \d/.test(t))
-console.log(pass ? '✅ PASS: 0 errors, cyan ring+pill rendered, inspector duration shows' : '⚠️ CHECK the JSON above')
-if (!pass) process.exit(1)
+console.log(pass ? 'PASS: 0 errors, scoped cyan ring+pill rendered, inspector durations show' : 'FAIL: panel visual assertions did not pass')
+process.exit(pass ? 0 : 1)

--- a/scripts/sim-soak.mjs
+++ b/scripts/sim-soak.mjs
@@ -14,7 +14,9 @@
  *
  * USAGE:
  *   npm run soak                       # 5-minute local soak (reuses :5173 if up)
+ *   npm run soak:spawn                 # 5-minute local soak with a fresh Vite server
  *   node scripts/sim-soak.mjs --minutes 12
+ *   node scripts/sim-soak.mjs --spawn --minutes 12
  *   SOAK_URL=http://localhost:5173 node scripts/sim-soak.mjs   # reuse a running server
  *   SOAK_REPORT=soak-report.json ...                            # also write a JSON report
  *
@@ -33,6 +35,7 @@ const FETCH_ATTEMPT_TIMEOUT_MS = 1000
 const argIdx = process.argv.indexOf('--minutes')
 const MINUTES = argIdx > -1 ? Number(process.argv[argIdx + 1]) : 5
 const SAMPLE_INTERVAL_MS = 250
+const FORCE_SPAWN = process.env.SOAK_SPAWN === '1' || process.argv.includes('--spawn')
 
 function failEarly(message) {
   console.error(`sim-soak ERROR: ${message}`)
@@ -72,11 +75,11 @@ async function urlUp(url) {
 }
 
 // ── Server: reuse SOAK_URL / a running :5173 dev server, else spawn vite ──────────────
-// SOAK_SPAWN=1 skips the reuse shortcuts — lets the CI spawn path be exercised locally.
-let baseUrl = process.env.SOAK_SPAWN === '1' ? null : (process.env.SOAK_URL || null)
+// SOAK_SPAWN=1 / --spawn skips reuse shortcuts — lets the CI spawn path be exercised locally.
+let baseUrl = FORCE_SPAWN ? null : (process.env.SOAK_URL || null)
 let serverProc = null
 let serverExit = null
-if (!baseUrl && process.env.SOAK_SPAWN !== '1' && await urlUp('http://localhost:5173/')) baseUrl = 'http://localhost:5173'
+if (!baseUrl && !FORCE_SPAWN && await urlUp('http://localhost:5173/')) baseUrl = 'http://localhost:5173'
 if (!baseUrl) {
   const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js')
   if (!existsSync(viteBin)) {

--- a/scripts/sim-soak.mjs
+++ b/scripts/sim-soak.mjs
@@ -23,11 +23,36 @@
 import { chromium } from 'playwright'
 import { spawn } from 'node:child_process'
 import { existsSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { evaluateSoak } from './soakInvariants.mjs'
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
 const argIdx = process.argv.indexOf('--minutes')
 const MINUTES = argIdx > -1 ? Number(process.argv[argIdx + 1]) : 5
-const PORT = parseInt(process.env.SOAK_PORT || '5198', 10)
+
+function failEarly(message) {
+  console.error(`sim-soak ERROR: ${message}`)
+  process.exit(1)
+}
+
+function parsePortEnv(name, value) {
+  if (!/^\d+$/.test(value || '')) throw new Error(`${name} must be an integer port in 1..65535`)
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`${name} must be an integer port in 1..65535`)
+  }
+  return port
+}
+
+const PORT = (() => {
+  try {
+    return parsePortEnv('SOAK_PORT', process.env.SOAK_PORT || '5198')
+  } catch (err) {
+    failEarly(err.message)
+  }
+})()
 
 async function urlUp(url) {
   try { return (await fetch(url)).ok } catch { return false }
@@ -37,28 +62,74 @@ async function urlUp(url) {
 // SOAK_SPAWN=1 skips the reuse shortcuts — lets the CI spawn path be exercised locally.
 let baseUrl = process.env.SOAK_SPAWN === '1' ? null : (process.env.SOAK_URL || null)
 let serverProc = null
+let serverExit = null
 if (!baseUrl && process.env.SOAK_SPAWN !== '1' && await urlUp('http://localhost:5173/')) baseUrl = 'http://localhost:5173'
 if (!baseUrl) {
-  // shell:true is required for npx on Windows (.cmd shim); PORT is a parseInt-validated
-  // module-level int (worst case NaN → harmless flag), no external string reaches the line.
-  // nosemgrep: javascript.lang.security.audit.spawn-shell-true.spawn-shell-true
-  serverProc = spawn(`npx vite --port ${PORT} --strictPort`, { shell: true, stdio: ['ignore', 'pipe', 'pipe'] })
+  const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js')
+  if (!existsSync(viteBin)) {
+    console.error('sim-soak ERROR: Vite binary not found. Run `npm ci` first.')
+    process.exit(1)
+  }
+  serverProc = spawn(
+    process.execPath,
+    [viteBin, '--host', '127.0.0.1', '--port', String(PORT), '--strictPort'],
+    { cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'], detached: process.platform !== 'win32' }
+  )
+  serverProc.once('close', (code, signal) => { serverExit = { code, signal } })
   baseUrl = `http://localhost:${PORT}`
   const deadline = Date.now() + 30000
-  while (Date.now() < deadline && !(await urlUp(baseUrl + '/'))) await new Promise(r => setTimeout(r, 300))
+  while (Date.now() < deadline && !(await urlUp(baseUrl + '/'))) {
+    if (serverExit) {
+      console.error(`sim-soak ERROR: vite exited before readiness (code=${serverExit.code}, signal=${serverExit.signal})`)
+      process.exit(1)
+    }
+    await new Promise(r => setTimeout(r, 300))
+  }
   if (!(await urlUp(baseUrl + '/'))) {
     console.error('sim-soak ERROR: vite dev server did not become ready')
-    serverProc?.kill('SIGKILL')
+    await cleanup()
     process.exit(1)
   }
 }
 
 let browser = null
-async function cleanup() {
-  try { await browser?.close() } catch {}
-  try { serverProc?.kill('SIGTERM') } catch {}
+let cleanupPromise = null
+async function stopServerProcessTree() {
+  if (!serverProc?.pid || serverExit) return
+  if (process.platform === 'win32') {
+    await new Promise(resolve => {
+      const killer = spawn('taskkill.exe', ['/pid', String(serverProc.pid), '/t', '/f'], { stdio: 'ignore' })
+      killer.on('error', resolve)
+      killer.on('exit', resolve)
+    })
+    return
+  }
+  try {
+    process.kill(-serverProc.pid, 'SIGTERM')
+    const exited = await new Promise(resolve => {
+      const timer = setTimeout(() => resolve(false), 1500)
+      serverProc.once('close', () => {
+        clearTimeout(timer)
+        resolve(true)
+      })
+    })
+    if (!exited) process.kill(-serverProc.pid, 'SIGKILL')
+  } catch {}
 }
-process.on('SIGINT', () => cleanup().then(() => process.exit(130)))
+async function cleanup() {
+  if (cleanupPromise) return cleanupPromise
+  cleanupPromise = (async () => {
+  try { await browser?.close() } catch {}
+  await stopServerProcessTree()
+  })()
+  return cleanupPromise
+}
+process.once('SIGINT', () => cleanup().then(() => process.exit(130)))
+process.once('SIGTERM', () => cleanup().then(() => process.exit(143)))
+process.once('exit', () => {
+  if (!serverProc?.pid || serverExit || process.platform === 'win32') return
+  try { process.kill(-serverProc.pid, 'SIGKILL') } catch {}
+})
 
 let exitCode = 0
 try {

--- a/scripts/sim-soak.mjs
+++ b/scripts/sim-soak.mjs
@@ -32,6 +32,7 @@ const ROOT = path.resolve(__dirname, '..')
 const FETCH_ATTEMPT_TIMEOUT_MS = 1000
 const argIdx = process.argv.indexOf('--minutes')
 const MINUTES = argIdx > -1 ? Number(process.argv[argIdx + 1]) : 5
+const SAMPLE_INTERVAL_MS = 250
 
 function failEarly(message) {
   console.error(`sim-soak ERROR: ${message}`)
@@ -54,6 +55,10 @@ const PORT = (() => {
     failEarly(err.message)
   }
 })()
+
+if (!Number.isFinite(MINUTES) || MINUTES <= 0) {
+  failEarly('--minutes must be a finite number greater than 0')
+}
 
 async function urlUp(url) {
   try {
@@ -190,6 +195,11 @@ try {
     }
     return out
   }, { minutes: MINUTES })
+
+  const minSamples = Math.max(1, Math.floor((MINUTES * 60000) / SAMPLE_INTERVAL_MS) - 2)
+  if (samples.length < minSamples) {
+    throw new Error(`insufficient samples: got ${samples.length}, expected at least ${minSamples}`)
+  }
 
   const result = evaluateSoak(samples)
   if (process.env.SOAK_REPORT) {

--- a/scripts/sim-soak.mjs
+++ b/scripts/sim-soak.mjs
@@ -29,6 +29,7 @@ import { evaluateSoak } from './soakInvariants.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.resolve(__dirname, '..')
+const FETCH_ATTEMPT_TIMEOUT_MS = 1000
 const argIdx = process.argv.indexOf('--minutes')
 const MINUTES = argIdx > -1 ? Number(process.argv[argIdx + 1]) : 5
 
@@ -55,7 +56,14 @@ const PORT = (() => {
 })()
 
 async function urlUp(url) {
-  try { return (await fetch(url)).ok } catch { return false }
+  try {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), FETCH_ATTEMPT_TIMEOUT_MS)
+    const ok = (await fetch(url, { signal: controller.signal }).finally(() => clearTimeout(timer))).ok
+    return ok
+  } catch {
+    return false
+  }
 }
 
 // ── Server: reuse SOAK_URL / a running :5173 dev server, else spawn vite ──────────────
@@ -75,6 +83,8 @@ if (!baseUrl) {
     [viteBin, '--host', '127.0.0.1', '--port', String(PORT), '--strictPort'],
     { cwd: ROOT, stdio: ['ignore', 'pipe', 'pipe'], detached: process.platform !== 'win32' }
   )
+  serverProc.stdout.on('error', () => {})
+  serverProc.stderr.on('error', () => {})
   serverProc.once('close', (code, signal) => { serverExit = { code, signal } })
   baseUrl = `http://localhost:${PORT}`
   const deadline = Date.now() + 30000
@@ -121,6 +131,8 @@ async function cleanup() {
   cleanupPromise = (async () => {
   try { await browser?.close() } catch {}
   await stopServerProcessTree()
+  try { serverProc?.stdout?.destroy() } catch {}
+  try { serverProc?.stderr?.destroy() } catch {}
   })()
   return cleanupPromise
 }

--- a/server.mjs
+++ b/server.mjs
@@ -30,7 +30,7 @@ import { normalizePost, nextSeq, VALID_ROLES, VALID_STATUSES } from './src/utils
 // Count working/blocked agents — used by the /api/event webhook handler.
 function countActive(agents) {
   let n = 0
-  for (const a of agents) if (a.status === 'working' || a.status === 'blocked') n++
+  for (const a of agents) if (a.status === 'working' || a.status === 'blocked' || a.status === 'planning' || a.status === 'awaiting-approval') n++
   return n
 }
 
@@ -247,8 +247,7 @@ function handleStatus(req, res) {
       let normalized
       try {
         normalized = normalizePost(JSON.parse(body))
-        // _cwd omitted intentionally: POST-pushed status is not project-scoped;
-        // scanSessions always includes the bare office-status.json regardless of CWD.
+        normalized._cwd = process.cwd()
         if (!atomicWrite(STATUS_PATH, JSON.stringify(normalized, null, 2))) {
           res.statusCode = 500; return res.end(JSON.stringify({ ok: false, error: 'Write failed' }))
         }
@@ -369,8 +368,9 @@ function handleEvent(req, res) {
         _seq: nextSeq(),
         type: 'office-status', agents,
         activeCount: countActive(agents),
-        workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : eventName,
+        workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : null,
         source: 'webhook',
+        _cwd: process.cwd(),
       }
       if (!atomicWrite(STATUS_PATH, JSON.stringify(output, null, 2))) {
         res.statusCode = 500; return res.end(JSON.stringify({ ok: false, error: 'Write failed' }))

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -6,7 +6,7 @@ import { eventBubble, charName, useLocale, t } from '../i18n'
 import { BlockedReasonBadge } from './blockedReasonBadge'
 import { recurringInfo } from '../systems/recurringFailure'
 import { selectVisibleBubbles, BUBBLE_VISIBLE_CAP } from '../systems/bubbleVisibility.js'
-import { stepWalkFrame, GAP_SNAP_MS } from '../systems/walkFrame.js'
+import { stepWalkFrame } from '../systems/walkFrame.js'
 import { WALK_SPEED, WALK_FRAME_INTERVAL, BEHAVIOR_STUCK_RETRIES, BEHAVIOR_STUCK_RETRY_MS, WATCHDOG_INTERVAL, WATCHDOG_TIMEOUT, shouldSkipBehaviorWatchdog } from '../systems/constants.js'
 import BehaviorBubble from './BehaviorBubble'
 import { shouldShakeDesk } from '../systems/eventJuice.js'
@@ -15,6 +15,7 @@ import { pickPokeReaction, pickQuipIndex } from '../systems/pokeReaction.js'
 // Character sprite scale. The root <g> scales by this; the name-tag/bubble group undoes it with
 // 1/CHAR_SCALE. Keep both in sync via this one constant.
 const CHAR_SCALE = 1.35
+export const RAF_STALL_RESTART_MS = 2500
 
 // Pure guard: returns true if a social arriver's TARGET should face back.
 // R1: tracked agents (live externalStatus entry) are NEVER modulated.
@@ -27,9 +28,10 @@ export function shouldFaceBack(targetExtStatus, targetAgent) {
   return true
 }
 
-// RAF watchdog is only for a genuinely stale visible walk loop. Visible jank in the 1.5-5s range
-// should resume smoothly; stepWalkFrame uses the same >GAP_SNAP_MS boundary to snap real freezes.
-export function shouldRestartRafWatchdog(lastFrameWallTime, now, visibilityState, stallMs = GAP_SNAP_MS) {
+// RAF watchdog is only for a genuinely stale visible walk loop. Restarting the lost chain is
+// non-snapping, so it can happen before GAP_SNAP_MS; true long-freeze fast-forward still lives in
+// stepWalkFrame's >GAP_SNAP_MS branch.
+export function shouldRestartRafWatchdog(lastFrameWallTime, now, visibilityState, stallMs = RAF_STALL_RESTART_MS) {
   if (visibilityState !== 'visible') return false
   if (!Number.isFinite(lastFrameWallTime) || lastFrameWallTime <= 0) return false
   return now - lastFrameWallTime > stallMs
@@ -49,6 +51,23 @@ export function shouldRecordRafWatchdogRestart(hadPendingFrame, isFocused, conse
 
 export function hasRafHandle(value) {
   return value !== null && value !== undefined
+}
+
+export function collectArrivalNudgeClaims(agents, id) {
+  const blockers = []
+  const claims = []
+  for (const oid of Object.keys(agents || {})) {
+    if (oid === id) continue
+    const other = agents[oid]
+    if (!other) continue
+    if (other.groupTarget) { blockers.push(other.groupTarget); claims.push(other.groupTarget) }
+    if (other.position && !other.isMoving) { blockers.push(other.position); claims.push(other.position) }
+    if (other.isMoving) {
+      if (other.targetPosition) { blockers.push(other.targetPosition); claims.push(other.targetPosition) }
+      if (other.journeyTarget) { blockers.push(other.journeyTarget); claims.push(other.journeyTarget) }
+    }
+  }
+  return { blockers, claims }
 }
 
 // ═══ PIXEL ART SPRITE SYSTEM ═══
@@ -1017,20 +1036,8 @@ function AgentCharacter({ agent }) {
       const me = s2.agents[id]
       if (me && !me.inGroupEvent && nudgeCountRef.current === 0 && visualPosRef.current) {
         const myPos = visualPosRef.current
-        // I'm overlapped iff a STANDING agent's body intersects mine. The nudge DESTINATION,
-        // however, must clear every CLAIM — standers' positions AND in-flight walkers'
-        // journey ends — or two recovering agents can re-stack at the same resolved spot
-        // (fresh review 2026-06-10, MED: C nudges onto B's invisible nudge landing).
-        const standing = []
-        const claims = []
-        for (const oid of Object.keys(s2.agents)) {
-          if (oid === id) continue
-          const o = s2.agents[oid]
-          if (!o) continue
-          if (o.position && !o.isMoving) { standing.push(o.position); claims.push(o.position) }
-          else if (o.journeyTarget) claims.push(o.journeyTarget)
-        }
-        if (standing.some(p => visuallyOverlapping(myPos, p))) {
+        const { blockers, claims } = collectArrivalNudgeClaims(s2.agents, id)
+        if (blockers.some(p => visuallyOverlapping(myPos, p))) {
           const nudged = avoidOverlap({ x: myPos.x, y: myPos.y }, claims)
           const clear = claims.every(p => !visuallyOverlapping(nudged, p))
           // Only SPEND the single per-journey nudge on a spot verified clear of all claims;

--- a/src/components/AgentCharacter.jsx
+++ b/src/components/AgentCharacter.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useOfficeStore, STATUS_COLORS } from '../systems/store.js'
 import { getNextBehavior } from '../systems/behaviorEngine'
-import { getTargetForBehavior, pickSocialTarget, calcFacing, calculatePath, needsLocationChange, HOME_POSITIONS, resolveFocusFacing, SOCIAL_BEHAVIORS, visuallyOverlapping, avoidOverlap } from '../systems/movementSystem'
+import { getTargetForBehavior, pickSocialTarget, calcFacing, calculatePath, needsLocationChange, HOME_POSITIONS, resolveClaimAwareHomePosition, resolveFocusFacing, SOCIAL_BEHAVIORS, visuallyOverlapping, avoidOverlap } from '../systems/movementSystem'
 import { eventBubble, charName, useLocale, t } from '../i18n'
 import { BlockedReasonBadge } from './blockedReasonBadge'
 import { recurringInfo } from '../systems/recurringFailure'
@@ -1063,10 +1063,11 @@ function AgentCharacter({ agent }) {
 
   useEffect(() => {
     if (!agentState?.returnHomeOnIdle || agentState.status !== 'idle' || agentState.inGroupEvent || isWalking) return
-    const home = HOME_POSITIONS[id]
     const current = visualPosRef.current
-    if (!home || !current) return
+    if (!HOME_POSITIONS[id] || !current) return
     const store = useOfficeStore.getState()
+    const home = resolveClaimAwareHomePosition(id, store.agents)
+    if (!home) return
     store.clearReturnHomeIntent(id)
     if (Math.hypot(current.x - home.x, current.y - home.y) < 5) return
     const path = calculatePath(current, home)

--- a/src/inference/inferStatus.js
+++ b/src/inference/inferStatus.js
@@ -40,6 +40,7 @@ function withStatusEnvelope(raw, fallbackSource = 'external') {
 
 const CAP = 200  // max string length for untrusted fields from in-browser channels
 const SLUG_CAP = 64  // max length for a session slug prefix in a composite role id
+const AGENT_CAP = 50  // max office-status agents accepted from untrusted channels
 
 function capStr(v) { return typeof v === 'string' ? v.slice(0, CAP) : null }
 
@@ -115,9 +116,16 @@ export function normalizeStatusMessage(raw) {
   // New protocol — validate envelope so untrusted in-browser channels (postMessage,
   // BroadcastChannel, window.__office_status__) cannot inject unbounded strings into the store.
   if (raw.type === 'office-status') {
-    const agents = Array.isArray(raw.agents)
-      ? raw.agents.map(sanitizeAgent).filter(Boolean)
-      : []
+    const agents = []
+    const seenRoles = new Set()
+    if (Array.isArray(raw.agents)) {
+      for (const rawAgent of raw.agents.slice(0, AGENT_CAP)) {
+        const agent = sanitizeAgent(rawAgent)
+        if (!agent || seenRoles.has(agent.role)) continue
+        seenRoles.add(agent.role)
+        agents.push(agent)
+      }
+    }
     // Count active agents with a plain loop — `.filter(...).length` allocates a
     // throwaway intermediate array on every SSE message just to read its length.
     let activeCount = 0

--- a/src/inference/inferStatus.js
+++ b/src/inference/inferStatus.js
@@ -122,7 +122,7 @@ export function normalizeStatusMessage(raw) {
     // throwaway intermediate array on every SSE message just to read its length.
     let activeCount = 0
     for (const a of agents) {
-      if (a.status === 'working' || a.status === 'blocked') activeCount++
+      if (a.status === 'working' || a.status === 'blocked' || a.status === 'planning' || a.status === 'awaiting-approval') activeCount++
     }
     const validated = {
       ...raw,

--- a/src/server/scanSessions.mjs
+++ b/src/server/scanSessions.mjs
@@ -21,6 +21,7 @@ import path from 'node:path'
 
 const STATUS_FILE_RE = /^office-status(-[^.]+)?\.json$/
 const isWin = process.platform === 'win32'
+const VALID_ROLES = new Set(['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate', 'designer'])
 
 // Shared TTL constants — keep in sync between scanAndMerge and getSessionStats
 const STALE_MS = 300_000   // sessions older than 5 min are stale
@@ -28,6 +29,13 @@ const FUTURE_MS = 300_000  // sessions more than 5 min in the future are implaus
 
 function pathsEqual(a, b) {
   return isWin ? a.toLowerCase() === b.toLowerCase() : a === b
+}
+
+function hasValidBaseRole(role) {
+  if (typeof role !== 'string' || role.length === 0) return false
+  const sep = role.lastIndexOf('~')
+  const base = sep === -1 ? role : role.slice(sep + 1)
+  return VALID_ROLES.has(base)
 }
 
 // ─── mtime-based parse cache ──────────────────────────────────────────────
@@ -181,7 +189,7 @@ export function scanAndMerge(dir, projectRoot) {
       // a TypeError that crashed the server at the unguarded SSE-connect + watch-debounce
       // callers. Array.isArray is the precise guard — a non-array session contributes no agent.
       const pick = (Array.isArray(data.agents) ? data.agents : [])
-        .filter(a => a && typeof a === 'object' && typeof a.status === 'string' && Object.prototype.hasOwnProperty.call(PRI, a.status))
+        .filter(a => a && typeof a === 'object' && hasValidBaseRole(a.role) && typeof a.status === 'string' && Object.prototype.hasOwnProperty.call(PRI, a.status))
         .sort((a, b) => {
           const pd = (PRI[a.status] ?? 9) - (PRI[b.status] ?? 9)
           return pd !== 0 ? pd : (a.role < b.role ? -1 : a.role > b.role ? 1 : 0)

--- a/src/server/scanSessions.mjs
+++ b/src/server/scanSessions.mjs
@@ -26,6 +26,11 @@ const VALID_ROLES = new Set(['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate', 'd
 // Shared TTL constants — keep in sync between scanAndMerge and getSessionStats
 const STALE_MS = 300_000   // sessions older than 5 min are stale
 const FUTURE_MS = 300_000  // sessions more than 5 min in the future are implausible (NTP jump)
+// A fully-finished session's only representative is 'done'. Render that terminal "wrapping up"
+// beat for this long, then drop it — instead of letting the sprite loiter until STALE_MS (5 min)
+// as a motionless green corpse. Multi-worktree finish-waves otherwise stack several dead sprites
+// on the floor, exactly the clutter the REDUCE bias exists to avoid (panel review 2026-07-01).
+const DONE_RENDER_MS = 45_000
 
 function pathsEqual(a, b) {
   return isWin ? a.toLowerCase() === b.toLowerCase() : a === b
@@ -195,8 +200,12 @@ export function scanAndMerge(dir, projectRoot) {
           return pd !== 0 ? pd : (a.role < b.role ? -1 : a.role > b.role ? 1 : 0)
         })[0]
       if (pick && typeof pick.role === 'string') {
-        // Only adopt workflow from a LIVE session. Done/idle terminal event sessions
-        // should still render briefly, but must not become a phantom active banner.
+        // Terminal 'done' representatives render only for DONE_RENDER_MS (a brief "just
+        // finished" beat), then drop — so a finished session's sprite doesn't loiter for
+        // the full STALE_MS. Live statuses are unaffected; idle is already filtered above.
+        if (pick.status === 'done' && (now - (parseInt(data._seq, 10) || 0)) > DONE_RENDER_MS) continue
+        // Only adopt workflow from a LIVE session. Done terminal sessions still render (for
+        // the window above) but must not become a phantom active banner.
         if (!workflow && LIVE_STATUSES.has(pick.status) && data.workflow) workflow = data.workflow
         allAgents.push({ ...pick, role: `${slug}~${pick.role}`, session: slug })
       }

--- a/src/server/scanSessions.mjs
+++ b/src/server/scanSessions.mjs
@@ -168,7 +168,8 @@ export function scanAndMerge(dir, projectRoot) {
     merged = { ...sessions[0].data }
     delete merged._cwd
   } else {
-    const PRI = { blocked: 0, working: 1, done: 2, idle: 3 }
+    const LIVE_STATUSES = new Set(['blocked', 'awaiting-approval', 'working', 'planning'])
+    const PRI = { blocked: 0, 'awaiting-approval': 1, working: 2, planning: 3, done: 4, idle: 5 }
     const allAgents = []
     let workflow = null
     for (const { slug, data } of sessions) {
@@ -180,16 +181,15 @@ export function scanAndMerge(dir, projectRoot) {
       // a TypeError that crashed the server at the unguarded SSE-connect + watch-debounce
       // callers. Array.isArray is the precise guard — a non-array session contributes no agent.
       const pick = (Array.isArray(data.agents) ? data.agents : [])
-        .filter(a => a && typeof a === 'object' && (a.status === 'working' || a.status === 'blocked'))
+        .filter(a => a && typeof a === 'object' && typeof a.status === 'string' && Object.prototype.hasOwnProperty.call(PRI, a.status))
         .sort((a, b) => {
           const pd = (PRI[a.status] ?? 9) - (PRI[b.status] ?? 9)
           return pd !== 0 ? pd : (a.role < b.role ? -1 : a.role > b.role ? 1 : 0)
         })[0]
       if (pick && typeof pick.role === 'string') {
-        // Only adopt workflow from a session that is actively contributing an agent.
-        // A finished session (all agents done) can leave a stale workflow string that
-        // would otherwise appear as a phantom banner over an unrelated active session.
-        if (!workflow && data.workflow) workflow = data.workflow
+        // Only adopt workflow from a LIVE session. Done/idle terminal event sessions
+        // should still render briefly, but must not become a phantom active banner.
+        if (!workflow && LIVE_STATUSES.has(pick.status) && data.workflow) workflow = data.workflow
         allAgents.push({ ...pick, role: `${slug}~${pick.role}`, session: slug })
       }
     }
@@ -205,15 +205,13 @@ export function scanAndMerge(dir, projectRoot) {
       if (s > maxSeqNum) maxSeqNum = s
     }
     const maxSeq = String(maxSeqNum)
+    let activeCount = 0
+    for (const a of allAgents) if (LIVE_STATUSES.has(a.status)) activeCount++
     merged = {
       _seq: maxSeq,
       type: 'office-status',
       agents: allAgents,
-      // Every entry in allAgents is a `pick` already filtered to working/blocked
-      // (see the .filter above) before being pushed — so activeCount is exactly
-      // allAgents.length. The previous .filter(...).length re-scanned the array
-      // and allocated a throwaway filtered copy on every GET/SSE multi-session tick.
-      activeCount: allAgents.length,
+      activeCount,
       workflow,
       source: 'multi-session',
       sessionCount: sessions.length,
@@ -222,7 +220,8 @@ export function scanAndMerge(dir, projectRoot) {
     // Restrict to sessions that contributed an active agent — same rationale as workflow:
     // a finished session (all agents done) must not inject its mood over an unrelated active
     // session whose own agents carry no mood of their own.
-    const activeSlugs = new Set(allAgents.map(a => a.session))
+    const activeSlugs = new Set()
+    for (const a of allAgents) if (LIVE_STATUSES.has(a.status)) activeSlugs.add(a.session)
     const moodSession = [...sessions]
       .filter(s => activeSlugs.has(s.slug))
       .sort((a, b) => (parseInt(b.data._seq, 10) || 0) - (parseInt(a.data._seq, 10) || 0))

--- a/src/server/scanSessions.mjs
+++ b/src/server/scanSessions.mjs
@@ -169,7 +169,7 @@ export function scanAndMerge(dir, projectRoot) {
     delete merged._cwd
   } else {
     const LIVE_STATUSES = new Set(['blocked', 'awaiting-approval', 'working', 'planning'])
-    const PRI = { blocked: 0, 'awaiting-approval': 1, working: 2, planning: 3, done: 4, idle: 5 }
+    const PRI = { blocked: 0, 'awaiting-approval': 1, working: 2, planning: 3, done: 4 }
     const allAgents = []
     let workflow = null
     for (const { slug, data } of sessions) {

--- a/src/systems/movementSystem.js
+++ b/src/systems/movementSystem.js
@@ -783,6 +783,14 @@ export function avoidOverlap(pos, occupied, maxAttempts = 8) {
   return clampToFloor({ x, y })  // degraded fallback (matches the old code's last-resort behavior)
 }
 
+export function resolveClaimAwareHomePosition(agentId, allAgents) {
+  const home = HOME_POSITIONS[agentId] || null
+  if (!home) return null
+  const occupied = getOccupiedPositions(agentId, allAgents)
+  if (!occupied.some(o => visuallyOverlapping(home, o))) return home
+  return avoidOverlap(home, occupied)
+}
+
 // Add jitter then clamp to walkable floor
 function jitter(pos, amount = 16) {
   return clampToFloor({
@@ -860,9 +868,11 @@ export function getTargetForBehavior(agentId, behaviorId, allAgents, socialTarge
     }
   }
 
-  // Home position — always valid, skip overlap check (it's their seat)
+  // Home position — keep the exact seat when clear, but side-step if another
+  // agent currently claims it. Soak caught owners walking back into occupied
+  // desks and visibly stacking beside the stander for several seconds.
   const waypointKey = BEHAVIOR_LOCATIONS[behaviorId]
-  if (waypointKey === undefined) return HOME_POSITIONS[agentId] || null
+  if (waypointKey === undefined) return resolveClaimAwareHomePosition(agentId, allAgents)
 
   const base = WAYPOINTS[waypointKey] || HOME_POSITIONS[agentId]
   if (!base) return null

--- a/src/utils/statusContract.mjs
+++ b/src/utils/statusContract.mjs
@@ -23,7 +23,7 @@
 // stay byte-identical to the pre-#122 definitions (constants.js exported plain arrays);
 // this refactor changes the definition SITE only, never runtime behavior.
 export const VALID_ROLES    = ['pm', 'arch', 'dev', 'qa', 'ops', 'res', 'gate', 'designer']
-export const VALID_STATUSES = ['idle', 'working', 'blocked', 'done', 'planning']
+export const VALID_STATUSES = ['idle', 'working', 'blocked', 'done', 'planning', 'awaiting-approval']
 export const VALID_MOODS    = ['normal', 'rushing', 'frustrated', 'stuck', 'smooth', 'intense', 'idle']
 export const MAX_MOOD_DURATION = 3_600_000  // 1 hour in ms
 
@@ -78,7 +78,7 @@ function clampMoodDuration(raw) {
 
 function countActive(agents) {
   let n = 0
-  for (const a of agents) if (a.status === 'working' || a.status === 'blocked') n++
+  for (const a of agents) if (a.status === 'working' || a.status === 'blocked' || a.status === 'planning' || a.status === 'awaiting-approval') n++
   return n
 }
 

--- a/tests/movementSystem.test.js
+++ b/tests/movementSystem.test.js
@@ -9,6 +9,7 @@ import {
   OVERFLOW_POSITIONS,
   OVERFLOW_SLOT_BY_XY,
   HOME_POSITIONS,
+  visuallyOverlapping,
 } from '../src/systems/movementSystem.js'
 
 // ─── calcFacing ──────────────────────────────────────────────────────
@@ -177,10 +178,21 @@ describe('getTargetForBehavior', () => {
     }
   })
 
-  it('unknown behavior (not in BEHAVIOR_LOCATIONS) → HOME_POSITIONS for the agent', () => {
+  it('unknown behavior (not in BEHAVIOR_LOCATIONS) → HOME_POSITIONS for the agent when clear', () => {
     expect(getTargetForBehavior('dev',  'work', {})).toEqual(HOME_POSITIONS['dev'])
     expect(getTargetForBehavior('arch', 'code', {})).toEqual(HOME_POSITIONS['arch'])
     expect(getTargetForBehavior('pm',   'read', {})).toEqual(HOME_POSITIONS['pm'])
+  })
+
+  it('unknown behavior side-steps when another agent occupies this agent home', () => {
+    const occupiedHome = HOME_POSITIONS.ops
+    const pos = getTargetForBehavior('ops', 'work', {
+      pm: { position: occupiedHome, targetPosition: occupiedHome, isMoving: false },
+      ops: { position: { x: 500, y: 300 } },
+    })
+    expect(pos).toBeTruthy()
+    expect(pos).not.toEqual(occupiedHome)
+    expect(visuallyOverlapping(pos, occupiedHome)).toBe(false)
   })
 
   it('unknown agentId with unknown behavior → null', () => {

--- a/tests/normalizePost.test.js
+++ b/tests/normalizePost.test.js
@@ -25,6 +25,13 @@ describe('normalizePost', () => {
       expect(result.activeCount).toBe(2) // dev + qa, not ops (done)
     })
 
+    it('treats awaiting-approval as a real transport status', () => {
+      const result = normalizePost({ qa: 'awaiting-approval' })
+      expect(result.agents[0].status).toBe('awaiting-approval')
+      expect(result.agents[0].task).toBeNull()
+      expect(result.activeCount).toBe(1)
+    })
+
     it('does not count idle agents as active', () => {
       const result = normalizePost({ dev: 'idle', qa: 'working' })
       expect(result.activeCount).toBe(1) // only qa (working), not dev (idle)
@@ -309,9 +316,9 @@ describe('constants', () => {
     expect(VALID_ROLES).toHaveLength(8)
   })
 
-  it('VALID_STATUSES has 5 entries incl. planning (AVO-101)', () => {
-    expect(VALID_STATUSES).toHaveLength(5)
+  it('VALID_STATUSES includes plan mode and human-approval waits', () => {
     expect(VALID_STATUSES).toContain('planning')
+    expect(VALID_STATUSES).toContain('awaiting-approval')
   })
 
   it('VALID_MOODS has 7 entries', () => {

--- a/tests/normalizeStatusMessage.test.js
+++ b/tests/normalizeStatusMessage.test.js
@@ -91,17 +91,19 @@ describe('normalizeStatusMessage', () => {
       expect(invalid.mood).toBeUndefined()
     })
 
-    it('M-1: activeCount counts only working+blocked agents (not idle)', () => {
+    it('M-1: activeCount counts live transport statuses, not idle/done', () => {
       const msg = {
         type: 'office-status',
         agents: [
           { role: 'dev', status: 'working' },
+          { role: 'arch', status: 'planning' },
+          { role: 'gate', status: 'awaiting-approval' },
           { role: 'qa', status: 'idle' },
           { role: 'ops', status: 'done' },
         ],
       }
       const result = normalizeStatusMessage(msg)
-      expect(result.activeCount).toBe(1)
+      expect(result.activeCount).toBe(3)
     })
 
     it('M-1: tolerates non-array agents without throwing', () => {

--- a/tests/normalizeStatusMessage.test.js
+++ b/tests/normalizeStatusMessage.test.js
@@ -106,6 +106,37 @@ describe('normalizeStatusMessage', () => {
       expect(result.activeCount).toBe(3)
     })
 
+    it('bounds untrusted office-status agent scanning before counting active agents', () => {
+      const agents = []
+      for (let i = 0; i < 100; i++) {
+        agents.push({ role: `session-${i}~qa`, status: 'working', session: `session-${i}` })
+      }
+
+      const result = normalizeStatusMessage({ type: 'office-status', agents })
+
+      expect(result.agents).toHaveLength(50)
+      expect(result.activeCount).toBe(50)
+    })
+
+    it('de-duplicates untrusted office-status agents by sanitized role with first occurrence winning', () => {
+      const result = normalizeStatusMessage({
+        type: 'office-status',
+        agents: [
+          { role: 'dev', status: 'working' },
+          { role: 'dev', status: 'blocked' },
+          { role: 'feat-x~qa', status: 'planning', session: 'feat-x' },
+          { role: 'feat-x~qa', status: 'blocked', session: 'feat-x' },
+        ],
+      })
+
+      expect(result.agents).toHaveLength(2)
+      expect(result.agents.map(a => [a.role, a.status])).toEqual([
+        ['dev', 'working'],
+        ['feat-x~qa', 'planning'],
+      ])
+      expect(result.activeCount).toBe(2)
+    })
+
     it('M-1: tolerates non-array agents without throwing', () => {
       const msg = { type: 'office-status', agents: 'not-an-array' }
       const result = normalizeStatusMessage(msg)

--- a/tests/rafWatchdog.test.js
+++ b/tests/rafWatchdog.test.js
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest'
 import {
+  collectArrivalNudgeClaims,
   hasRafHandle,
   isDocumentFocused,
+  RAF_STALL_RESTART_MS,
   shouldRecordRafWatchdogRestart,
   shouldRestartRafWatchdog,
   shouldStopStaleLocalWalk,
@@ -14,12 +16,13 @@ describe('shouldRestartRafWatchdog', () => {
   })
 
   it('does not restart for visible jank inside the smooth-resume window', () => {
-    expect(shouldRestartRafWatchdog(1000, 1000 + 4200, 'visible')).toBe(false)
+    expect(shouldRestartRafWatchdog(1000, 1000 + RAF_STALL_RESTART_MS, 'visible')).toBe(false)
   })
 
-  it('uses the same strict >GAP_SNAP_MS boundary as walk-frame snapping', () => {
-    expect(shouldRestartRafWatchdog(1000, 1000 + GAP_SNAP_MS, 'visible')).toBe(false)
-    expect(shouldRestartRafWatchdog(1000, 1000 + GAP_SNAP_MS + 1, 'visible')).toBe(true)
+  it('restarts the lost RAF chain before the long-freeze snap boundary', () => {
+    expect(RAF_STALL_RESTART_MS).toBeLessThan(GAP_SNAP_MS)
+    expect(shouldRestartRafWatchdog(1000, 1000 + RAF_STALL_RESTART_MS + 1, 'visible')).toBe(true)
+    expect(shouldRestartRafWatchdog(1000, 1000 + GAP_SNAP_MS, 'visible')).toBe(true)
   })
 
   it('does not restart before the first RAF timestamp is recorded', () => {
@@ -64,6 +67,25 @@ describe('hasRafHandle', () => {
     expect(hasRafHandle(null)).toBe(false)
     expect(hasRafHandle(undefined)).toBe(false)
     expect(hasRafHandle(42)).toBe(true)
+  })
+})
+
+describe('collectArrivalNudgeClaims', () => {
+  it('treats moving agents current-leg and journey-end targets as arrival blockers', () => {
+    const claims = collectArrivalNudgeClaims({
+      arch: { position: { x: 460, y: 364 }, isMoving: false },
+      ops: {
+        position: { x: 430, y: 360 },
+        targetPosition: { x: 470, y: 369 },
+        journeyTarget: { x: 460, y: 364 },
+        isMoving: true,
+      },
+    }, 'arch')
+
+    expect(claims.blockers).toContainEqual({ x: 470, y: 369 })
+    expect(claims.blockers).toContainEqual({ x: 460, y: 364 })
+    expect(claims.claims).toContainEqual({ x: 470, y: 369 })
+    expect(claims.claims).toContainEqual({ x: 460, y: 364 })
   })
 })
 

--- a/tests/scanSessions.test.js
+++ b/tests/scanSessions.test.js
@@ -285,9 +285,10 @@ describe('multi-session merge', () => {
     const result = scanAndMerge(dir, dir)
     // beta's agent is active → alpha's done-only session must not leak its mood
     expect(result.mood).toBeUndefined()
-    // beta's agent is still present
+    // beta's agent is still live; alpha may render as a terminal event but must not
+    // contribute mood.
     expect(result.agents.some(a => a.session === 'beta')).toBe(true)
-    expect(result.agents.some(a => a.session === 'alpha')).toBe(false)
+    expect(result.agents.some(a => a.session === 'alpha' && a.status === 'done')).toBe(true)
   })
 
   // Agent priority and role tiebreaker (multi-session path only — single session returns all agents)
@@ -323,14 +324,25 @@ describe('multi-session merge', () => {
     expect(alphaAgent1.role).toMatch(/dev/)
   })
 
-  it('only includes working/blocked agents in activeCount', () => {
+  it('includes terminal done representatives but not in activeCount', () => {
     const base = Date.now()
     writeSlugged('alpha', base + 100, [{ role: 'dev', status: 'done', task: null, label: null }])
     writeSlugged('beta', base + 200, [{ role: 'qa', status: 'working', task: null, label: null }])
     const result = scanAndMerge(dir, dir)
-    // alpha's agent is 'done' → not picked; beta's agent is 'working' → picked
+    expect(result.agents.some(a => a.session === 'alpha' && a.status === 'done')).toBe(true)
     expect(result.activeCount).toBe(1)
   })
+
+  it('keeps planning and awaiting-approval representatives in multi-session output', () => {
+    const base = Date.now()
+    writeSlugged('alpha', base + 100, [{ role: 'dev', status: 'planning', task: null, label: null }])
+    writeSlugged('beta', base + 200, [{ role: 'qa', status: 'awaiting-approval', task: null, label: null }])
+    const result = scanAndMerge(dir, dir)
+    expect(result.agents.some(a => a.session === 'alpha' && a.status === 'planning')).toBe(true)
+    expect(result.agents.some(a => a.session === 'beta' && a.status === 'awaiting-approval')).toBe(true)
+    expect(result.activeCount).toBe(2)
+  })
+
 })
 
 // ─── helpers concat / de-dupe / bound (multi-session) ────────────────────────

--- a/tests/scanSessions.test.js
+++ b/tests/scanSessions.test.js
@@ -343,6 +343,16 @@ describe('multi-session merge', () => {
     expect(result.activeCount).toBe(2)
   })
 
+  it('drops idle representatives from multi-session output so cleanup can run', () => {
+    const base = Date.now()
+    writeSlugged('alpha', base + 100, [{ role: 'dev', status: 'idle', task: null, label: null }])
+    writeSlugged('beta', base + 200, [{ role: 'qa', status: 'working', task: null, label: null }])
+    const result = scanAndMerge(dir, dir)
+    expect(result.agents.some(a => a.session === 'alpha')).toBe(false)
+    expect(result.agents.some(a => a.session === 'beta' && a.status === 'working')).toBe(true)
+    expect(result.activeCount).toBe(1)
+  })
+
 })
 
 // ─── helpers concat / de-dupe / bound (multi-session) ────────────────────────

--- a/tests/scanSessions.test.js
+++ b/tests/scanSessions.test.js
@@ -337,12 +337,23 @@ describe('multi-session merge', () => {
     expect(alphaAgent1.role).toMatch(/dev/)
   })
 
-  it('includes terminal done representatives but not in activeCount', () => {
+  it('includes FRESH terminal done representatives but not in activeCount', () => {
     const base = Date.now()
     writeSlugged('alpha', base + 100, [{ role: 'dev', status: 'done', task: null, label: null }])
     writeSlugged('beta', base + 200, [{ role: 'qa', status: 'working', task: null, label: null }])
     const result = scanAndMerge(dir, dir)
     expect(result.agents.some(a => a.session === 'alpha' && a.status === 'done')).toBe(true)
+    expect(result.activeCount).toBe(1)
+  })
+
+  it('drops done representatives older than DONE_RENDER_MS so finished sessions do not loiter', () => {
+    const base = Date.now()
+    // alpha finished ~60s ago: past the ~45s done-render window but still inside the 5-min stale TTL.
+    writeSlugged('alpha', base - 60_000, [{ role: 'dev', status: 'done', task: null, label: null }])
+    writeSlugged('beta', base + 200, [{ role: 'qa', status: 'working', task: null, label: null }])
+    const result = scanAndMerge(dir, dir)
+    expect(result.agents.some(a => a.session === 'alpha')).toBe(false)
+    expect(result.agents.some(a => a.session === 'beta' && a.status === 'working')).toBe(true)
     expect(result.activeCount).toBe(1)
   })
 

--- a/tests/scanSessions.test.js
+++ b/tests/scanSessions.test.js
@@ -206,6 +206,19 @@ describe('multi-session merge', () => {
     }
   })
 
+  it('drops live representatives with invalid roles so they cannot create phantom workflows', () => {
+    const base = Date.now()
+    writeSlugged('bad', base + 100, [{ role: 'hacker', status: 'blocked', task: 'pwn', label: null }], { workflow: 'evil-flow' })
+    writeSlugged('good', base + 200, [{ role: 'dev', status: 'done', task: 'done', label: null }])
+
+    const result = scanAndMerge(dir, dir)
+
+    expect(result.source).toBe('multi-session')
+    expect(result.agents.map(a => a.role)).toEqual(['good~dev'])
+    expect(result.activeCount).toBe(0)
+    expect(result.workflow).toBeNull()
+  })
+
   it('carries token usage + effort from the most-recent active session (AVO-108/AVO-102)', () => {
     const base = Date.now()
     writeSlugged('older', base + 100, [{ role: 'qa', status: 'working', task: 'Read', label: null }],

--- a/tests/serverTransportE2E.test.js
+++ b/tests/serverTransportE2E.test.js
@@ -19,7 +19,7 @@
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { spawn } from 'node:child_process'
-import { mkdtempSync, mkdirSync, existsSync, statSync } from 'node:fs'
+import { mkdtempSync, mkdirSync, existsSync, statSync, readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'node:net'
@@ -290,6 +290,36 @@ describe('AC-3 behavioral spine checks', () => {
     const devAgent = (merged?.agents ?? []).find(a => a.role === 'dev')
     expect(devAgent).toBeTruthy()
     expect(devAgent.status).toBe('idle')
+  })
+
+  it('awaiting-approval survives the real server path', async () => {
+    const res = await postStatus({
+      type: 'office-status',
+      agents: [{ role: 'qa', status: 'awaiting-approval', label: 'Waiting on user' }],
+    })
+    expect(res.status).toBe(200)
+    const merged = await getStatus()
+    const qaAgent = (merged?.agents ?? []).find(a => a.role === 'qa')
+    expect(qaAgent).toBeTruthy()
+    expect(qaAgent.status).toBe('awaiting-approval')
+    expect(merged.activeCount).toBe(1)
+  })
+
+  it('production writes are project-scoped and default webhook events do not become workflow banners', async () => {
+    const statusRes = await postStatus({ dev: 'working' })
+    expect(statusRes.status).toBe(200)
+    let raw = JSON.parse(readFileSync(statusFilePath, 'utf-8'))
+    expect(raw._cwd).toBe(ROOT)
+    let merged = await getStatus()
+    expect(merged._cwd).toBeUndefined()
+
+    const eventRes = await postEvent({ event: 'test-passed' })
+    expect(eventRes.status).toBe(200)
+    raw = JSON.parse(readFileSync(statusFilePath, 'utf-8'))
+    expect(raw._cwd).toBe(ROOT)
+    expect(raw.workflow).toBeNull()
+    merged = await getStatus()
+    expect(merged.workflow).toBeNull()
   })
 
   it('_seq strictly increases across ≥4 alternating POST /api/status + POST /api/event calls', async () => {

--- a/tests/viteEventMiddlewareParity.test.js
+++ b/tests/viteEventMiddlewareParity.test.js
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import fs from 'node:fs'
+
+describe('vite /api/event middleware parity guard', () => {
+  it('keeps dev webhook activeCount and default workflow aligned with production', () => {
+    const src = fs.readFileSync('vite.config.js', 'utf8')
+
+    expect(src).toMatch(/activeCount:\s*agents\.filter\(a => a\.status === 'working' \|\| a\.status === 'blocked' \|\| a\.status === 'planning' \|\| a\.status === 'awaiting-approval'\)\.length/)
+    expect(src).toContain("workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : null")
+    expect(src).not.toContain("workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : eventName")
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -554,8 +554,8 @@ function officeStatusPlugin() {
               _cwd: process.cwd(),
               type: 'office-status',
               agents,
-              activeCount: agents.filter(a => a.status === 'working' || a.status === 'blocked').length,
-              workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : eventName,
+              activeCount: agents.filter(a => a.status === 'working' || a.status === 'blocked' || a.status === 'planning' || a.status === 'awaiting-approval').length,
+              workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : null,
               source: 'webhook',
             }
             const dir = path.dirname(statusPath)


### PR DESCRIPTION
## Summary

Strengthens the panel verifier and follows through on product-level regressions found during adversarial pre-mortem review, including two rounds of parallel subagent review.

## Why

The original verifier work made CI better, but deeper product-focused checks found real runtime risks that CI alone would not catch:

- `awaiting-approval` was rendered as a first-class UI state but rejected by the transport contract.
- Production `/api/status` and `/api/event` writes were not project-scoped like the Vite middleware path.
- Default webhook events could pollute the workflow banner.
- Multi-session merge could hide terminal/planning/approval status representatives beside active sessions.
- Movement soak exposed intermittent visible stacking when arrival nudge ignored in-flight route claims and the RAF chain could stay stale past the product stack threshold.
- Additional adversarial soak exposed occupied-home stacking: another agent could stand on an agent's home/desk, then the owner would walk back into that occupied claim.
- Final subagent review found idle representative leakage, activeCount drift, zero-sample soak false-pass, panel verifier false-positive risk, Vite dev/prod webhook drift, and unbounded/duplicate untrusted agent arrays.

## Changes

- Adds `smoke:panel` and runs it in the GitHub Actions `render-smoke` job.
- Adds a CI `Spawn soak smoke` step via `npm run soak:spawn -- --minutes 0.05` so spawned Vite/cleanup is covered remotely.
- Adds cross-platform `npm run soak:spawn` / `--spawn` to avoid local soak accidentally reusing a foreign `localhost:5173` server.
- Makes the panel verifier self-start Vite, use repo-relative screenshots, exact API route stubs, fetch timeouts, and signal cleanup.
- Scopes the cyan assertion to awaiting approval and now asserts blocked QA has zero cyan stroke/fill.
- Validates verifier/soak ports and soak minutes up front, and rejects zero-sample soak passes.
- Aligns production and Vite dev `/api/event`: activeCount includes working/blocked/planning/awaiting-approval, and default webhook events keep workflow null unless explicitly supplied.
- Aligns transport status handling so `awaiting-approval` survives POST/GET and counts as active.
- Aligns client normalized activeCount with live transport statuses.
- Bounds untrusted `office-status.agents` scanning to 50 entries and de-duplicates by sanitized role.
- Makes multi-session merge reject invalid-role representatives so corrupt files cannot create phantom workflows.
- Makes production `/api/status` and `/api/event` writes project-scoped with `_cwd`.
- Keeps webhook events out of `workflow` unless the caller explicitly supplies a workflow.
- Updates multi-session merge to keep `done`, `planning`, and `awaiting-approval` representatives, drop `idle` representatives, and keep activeCount/mood/workflow tied to live sessions.
- Restarts stale RAF walk loops before the long-freeze snap boundary and expands arrival-nudge blockers to include moving agents' current leg and journey-end claims.
- Makes home/work destinations claim-aware: exact home is preserved when clear, but side-steps if another agent currently claims that spot.

## Validation

Remote CI: all checks passed for latest head `a404db77b194138fe87fb2928737f3b347c8a63a`.

Latest local verification:

- Browser product pre-mortem: local Vite + Playwright loaded desktop and panel, POSTed full-format dev awaiting-approval / QA planning / ops done, verified DOM statuses in both views, 0 console/page errors.
- Targeted tests passed: `npm test -- tests/scanSessions.test.js tests/normalizeStatusMessage.test.js tests/viteEventMiddlewareParity.test.js tests/normalizePost.test.js tests/normalizePost.server.test.js tests/serverTransportE2E.test.js` -> 6 files / 221 tests.
- Focused re-run passed: `npm test -- tests/viteEventMiddlewareParity.test.js tests/normalizeStatusMessage.test.js tests/scanSessions.test.js` -> 3 files / 107 tests.
- `npm run smoke:panel` passed with awaiting cyan positive assertion and blocked cyan negative assertion.
- `npm run soak:spawn -- --minutes 0.05` passed: 12 samples, 0 violations.
- Negative soak validation passed: `node scripts/sim-soak.mjs --spawn --minutes 0` and `--minutes abc` fail cleanly with `--minutes must be a finite number greater than 0`.
- `npm run smoke` passed across 4 viewports, 0 page/page console errors.
- `npm test` passed: 106 files / 2233 tests.
- `npm run build` passed.
- `node scripts/bundle-budget.mjs` passed: 483622 bytes, +7.46% vs baseline, below +10% limit.
- `.agentcortex/bin/validate.ps1` passed: `pass=99 warn=15 fail=0 skip=4`.
- `git diff --check` passed, with only expected Windows LF/CRLF warnings.
- Secret sanity over changed diff found no credential-like strings.
- Additional scenario simulation passed: skill/workflow signal through `/api/status`, browser store/UI reflection, workflow clear, webhook default/explicit workflow, oversized postMessage cap/dedupe, invalid-role multi-session filter, and hook `SubagentStart -> PreToolUse -> PostToolUse -> SubagentStop` lifecycle.

Earlier validation in this review cycle also included adversarial production API probes, two parallel 3-minute spawned soaks, `npm run smoke:pack`, fixed/occupied/invalid verifier-port checks, fixed/invalid soak-port checks, and production server render/API probes.

## Subagent Review Integration

- Product runtime review: no Critical/High/Medium/Low findings; residual risk noted that short soak is not a replacement for longer observation.
- API/status review: fixed Vite `/api/event` parity, bounded/de-duplicated untrusted agent arrays, and filtered invalid multi-session representatives.
- CI/verifier review: fixed blocked/cyan false-positive gap, clarified spawned soak smoke, and added cross-platform `soak:spawn`.
- PR/governance readiness: PR remains ready, branch pushed, local governance validator passes with existing non-blocking warnings only.

## Residual Notes

- Build still reports existing Vite warnings for mixed exports in `vite.config.js` and deprecated `inlineDynamicImports`; they do not fail build or budget and are not introduced by this PR.
- CI `Spawn soak smoke` is intentionally short and verifies spawn/cleanup plus basic invariants; long soak coverage remains local/nightly-style evidence, not this PR's fast CI gate.