### PR TITLE
chore(release): v1.6.4 — product action strip Phase-1

### DIFF
--- a/.agentcortex/context/current_state.md
+++ b/.agentcortex/context/current_state.md
@@ -12,8 +12,8 @@
   - Task Isolation: `.agentcortex/context/work/<worklog-key>.md`
   - Active Work Log Path: derive <worklog-key> from the raw branch name using filesystem-safe normalization before any gate checks.
   - Workflows & Policies: `.agent/workflows/*.md`, `.agent/rules/*.md`
-- **Last Updated**: 2026-07-04T13:20:00+08:00
-- **Update Sequence**: 102
+- **Last Updated**: 2026-07-04T14:05:00+08:00
+- **Update Sequence**: 103
 - **ADR Index**:
   - docs/adr/ADR-001-vnext-self-managed-architecture.md — vNext self-managed AI architecture
   - docs/adr/ADR-002-multi-worktree-session-design.md — multi-worktree session isolation design
@@ -165,6 +165,12 @@
 - **Verification reality**: behavioral correctness = the **test suite** (vitest = real modules, no dup). Pixel/visual correctness = **owner only**. `preview_screenshot` must NOT be relied on (hangs).
 
 ## Ship History
+
+### Ship-chore-release-v1.6.4-2026-07-04 (product action strip Phase-1) · release v1.6.4
+
+- Release cutting the merged Phase-1 product-action-strip polish (PR #196, squash `dacb682`) as **v1.6.4**: `package.json` 1.6.3→1.6.4 + CHANGELOG narrative ("Clearer signals, plainer words"). No further app change. Lockfile root version left stale per convention. Git tag performed manually by owner.
+- Scope note: this branch's Phase-2 in-repo portable-core layer (34-subpath package API + `.mjs` mirrors) was PARKED not merged per **ADR-009** (owner Option A — AVO stays a local, unpublished app; the reusable core is deferred to a clean-room copy-out into a NEW repo if a second consumer firms up). PR #195 closed as the parked reference; self-review findings F1–F9 preserved in ADR-009 (F1/F4 honesty-critical).
+- Tests: Pass (full suite 2251, from #196; CI 7/7 green — Semgrep / render-smoke / test 22+24 / pack-smoke / npm audit / TruffleHog)
 
 ### Ship-codex-product-action-strip-2026-07-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ live in `docs/specs/_shipped-log.md`; this file is the high-level story.
 
 Format loosely follows [Keep a Changelog](https://keepachangelog.com).
 
+## v1.6.4 — 2026-07-04 — Clearer signals, plainer words
+
+### Added
+
+- **Action strip** — the control panel now surfaces actionable blockers up front, so a stuck agent is
+  visible at a glance without opening anything.
+
+### Changed
+
+- **The activity feed speaks plainer** — implementation-shaped entries (raw filenames, hook artifacts)
+  are translated into product-readable copy, with the raw text kept in the tooltip. The bottom rail now
+  shows agents that have a live signal and folds the quiet ones into a tidy count.
+- **Fewer interruptions** — the settings popover closes itself after you switch major views, and the
+  most meme-like high-frequency Chinese speech bubbles were removed. The first-run setup hint is easier
+  to read.
+
+### Fixed
+
+- **Honest rail status** — the rail status dot and its accessibility label now read from the normalized
+  external status, so they can't drift from what the agent is actually doing.
+
+### Documentation
+
+- **ADR-009** — recorded the decision to keep the speculative "portable status-core" package layer out
+  of AVO; it is deferred to a clean-room copy-out into a new repo if a real second consumer ever firms
+  up. No user-facing effect.
+
 ## v1.6.3 — 2026-06-27 — Fuller corners, honest windows
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-virtual-office",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Pixel-art virtual office that visualizes your AI coding agents in real time — Claude Code, Codex, Gemini CLI, or any tool that can POST status. Pure SVG, zero backend, runs locally.",
   "main": "bin/cli.js",
   "bin": {


### PR DESCRIPTION
## Release v1.6.4 — product action strip Phase-1

Cuts the merged Phase-1 UI polish (PR #196, `dacb682`) as **v1.6.4**.

- `package.json` 1.6.3 → 1.6.4
- CHANGELOG narrative — *"Clearer signals, plainer words"* (action strip surfaces actionable blockers; activity feed speaks plainer; bottom rail declutter; honest rail status; copy polish)
- SSoT Ship History entry

No app-code change — the Phase-1 work is already on `main` and CI-green (#196). Lockfile root version left stale per convention. **Git tag is the manual owner step.**

**Scope note**: this line's Phase-2 in-repo portable-core layer was **parked** per **ADR-009** (PR #195 closed as the reference); self-review findings F1–F9 (F1/F4 honesty-critical) preserved for a future clean-room copy-out into a new repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
