### PR TITLE
fix: forward invoking cwd so hook status files aren't filtered out under npx

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -336,8 +336,14 @@ if (host) {
 // shell-quoting dance — `process.execPath` + the resolved JS path is portable.
 const viteFlags = ['--port', port]
 if (host) viteFlags.push('--host')
+// Vite must run from `root` to resolve its own config and sources, so its cwd is the
+// package directory rather than the project the user launched us from. scanAndMerge
+// matches each session file's `_cwd` against the server's project root, so without
+// this the hook-written files all look foreign and get filtered out — leaving only
+// file-watcher fallback data. Forward the invoking cwd explicitly.
 const vite = spawn(process.execPath, [viteBinJs, ...viteFlags], {
   cwd: root,
+  env: { ...process.env, OFFICE_PROJECT_ROOT: process.env.OFFICE_PROJECT_ROOT || process.cwd() },
   stdio: 'inherit',
   shell: false,
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,14 @@ import os from 'node:os'
 import { normalizePost, VALID_ROLES, VALID_STATUSES } from './src/utils/normalizePost.js'
 import { scanAndMerge, getSessionStats } from './src/server/scanSessions.mjs'
 
+// Session status files are matched against this root. When launched via `bin/cli.js`
+// (and therefore `npx`), Vite's cwd is the package directory, not the project Claude
+// Code is running in, so every hook-written status file is filtered out as foreign.
+// Set OFFICE_PROJECT_ROOT to the project directory to make the match work.
+const PROJECT_ROOT = process.env.OFFICE_PROJECT_ROOT
+  ? path.resolve(process.env.OFFICE_PROJECT_ROOT)
+  : process.cwd()
+
 // Middleware: Universal status API
 //   GET  /api/status → read current status (browser polls this)
 //   POST /api/status → update status (any tool can curl this)
@@ -184,7 +192,7 @@ function officeStatusPlugin() {
         if (req.method === 'GET') {
           try {
             const clientEtag = req.headers['if-none-match']
-            const merged = scanAndMerge(path.dirname(statusPath), process.cwd())
+            const merged = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
             if (!merged) { res.end('null'); return }
             const data = JSON.stringify(merged)
             const etag = '"' + createHash('md5').update(data).digest('hex').slice(0, 12) + '"'
@@ -258,7 +266,7 @@ function officeStatusPlugin() {
             // Running it for a broadcast that has no recipients is pure waste.
             if (sseClients.size > 0) {
               try {
-                const sseData = scanAndMerge(path.dirname(statusPath), process.cwd())
+                const sseData = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
                 if (sseData) broadcastSSE(sseData)
               } catch {}
             }
@@ -298,7 +306,7 @@ function officeStatusPlugin() {
         req.on('close', () => sseClients.delete(res))
         req.on('error', () => sseClients.delete(res))
         res.on('error', () => sseClients.delete(res))
-        const snapshot = scanAndMerge(path.dirname(statusPath), process.cwd())
+        const snapshot = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
         if (snapshot) {
           try { res.write(`event: status\ndata: ${JSON.stringify(snapshot)}\n\n`) }
           catch { sseClients.delete(res) }
@@ -321,7 +329,7 @@ function officeStatusPlugin() {
         if (sseClients.size === 0) return
         clearTimeout(watchDebounce)
         watchDebounce = setTimeout(() => {
-          const merged = scanAndMerge(path.dirname(statusPath), process.cwd())
+          const merged = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
           if (merged) broadcastSSE(merged)
         }, 80)
         if (watchDebounce.unref) watchDebounce.unref()
@@ -576,7 +584,7 @@ function officeStatusPlugin() {
           // Skip the broadcast scan when no SSE clients are connected (see POST handler).
           if (sseClients.size > 0) {
             try {
-              const sseData = scanAndMerge(path.dirname(statusPath), process.cwd())
+              const sseData = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
               if (sseData) broadcastSSE(sseData)
             } catch {}
           }
@@ -602,7 +610,7 @@ function officeStatusPlugin() {
           res.setHeader('Allow', 'GET, HEAD, OPTIONS')
           res.statusCode = 405; res.end(JSON.stringify({ error: 'Method not allowed' })); return
         }
-        const stats = getSessionStats(path.dirname(statusPath), process.cwd())
+        const stats = getSessionStats(path.dirname(statusPath), PROJECT_ROOT)
         res.end(JSON.stringify({ ok: true, uptime: Math.floor(process.uptime()), ...stats }))
       })
 


### PR DESCRIPTION
## The bug

When launched via `npx agent-virtual-office` — the documented install path — the office never picks up hook data. The banner stays on **"No agent signal yet — Run: npx agent-virtual-office setup"** even with the hook correctly installed and writing valid payloads, and agent labels degrade to raw `.jsonl` filenames.

`GET /api/status` shows it:

```json
{"agents":[{"role":"ops","task":"Edit","label":"✏️ 651791b3-….jsonl"}],
 "source":"file-watcher","_hint":"no-hooks"}
```

## Root cause

`bin/cli.js` spawns Vite with `cwd: root` (the package dir) so Vite can resolve its own config and sources:

```js
const root = path.resolve(__dirname, '..')
const vite = spawn(process.execPath, [viteBinJs, ...viteFlags], { cwd: root, … })
```

`vite.config.js` then passes `process.cwd()` to `scanAndMerge` as the project root — but that's now the package directory, not the project the user launched from:

```
/Users/<user>/.npm/_npx/<hash>/node_modules/agent-virtual-office
```

`scanAndMerge` filters session files by comparing `_cwd` to that root, in **both** the strict and fallback passes:

```js
if (parsed._cwd && !pathsEqual(path.resolve(parsed._cwd), resolvedRoot)) continue
```

The hook writes `_cwd` as the real project directory, so every hook file is treated as foreign and dropped. Only the file-watcher entry (which has no `_cwd`) survives — hence `source: 'file-watcher'` and `_hint: 'no-hooks'`.

This doesn't reproduce under `npm run dev`, where Vite's cwd is the repo and coincides with the project root — which is likely why it's gone unnoticed.

## The fix

Add an `OFFICE_PROJECT_ROOT` env var that overrides the project root, and have `bin/cli.js` set it to its own `process.cwd()`. The CLI process itself is never chdir'd — only the Vite spawn is — so it still knows where the user invoked it from.

An explicitly set `OFFICE_PROJECT_ROOT` is respected (useful for multi-worktree setups), and the `process.cwd()` default is kept, so `npm run dev` is unaffected. No user action required; npx works out of the box.

## Verification

Same hook files, same moment, two servers:

| | `source` | `_hint` | roles |
|---|---|---|---|
| before | `file-watcher` | `no-hooks` | raw `.jsonl` filename |
| after | `claude-cli` | — | `gate`, `res`, `pm`, `dev`, `ops` |

Also confirmed zero-config: plain `node bin/cli.js` from a project dir with no env var set reports `source: 'claude-cli'`.

Test suite: `2228 passed | 22 skipped`. Two files fail (`agentInspector.test.js` — a date-rollover assertion expecting `2026-04-09`, got `2026-04-08`), but they fail identically on a clean checkout — pre-existing and unrelated to this change.

Found on v1.6.4, macOS, Node v22.