### PR TITLE
fix(hook-io): match sessions against the invoking project root, not the package dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,8 @@ v1.4.0 started from one of these captures.
 
 **Office is blank — no agents appear**
 1. No hooks installed? Run `npx agent-virtual-office setup`.
-2. Wrong directory? The office filters by `process.cwd()` — run it in the same directory as your session.
+2. Wrong directory? The office only shows sessions from the directory you launched it in — run it from
+   your project root, or point it somewhere else with `OFFICE_PROJECT_ROOT=/path/to/project`.
 3. Stale status? Status expires after 5 minutes of inactivity — start a new session.
 4. Not using Claude Code? Push status with `curl` (see [Connect Your Agent](#connect-your-agent)).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -151,7 +151,8 @@ window.__office_config__ = {
 
 **辦公室一片空白 — 沒有小人**
 1. 沒裝 hook？跑 `npx agent-virtual-office setup`。
-2. 目錄不對？辦公室以 `process.cwd()` 過濾 —— 請在和 session 相同的目錄跑它。
+2. 目錄不對？辦公室只顯示「啟動它的那個目錄」的 session —— 請在專案根目錄執行，或用
+   `OFFICE_PROJECT_ROOT=/path/to/project` 指到別處。
 3. 狀態過期？閒置 5 分鐘後狀態會過期 —— 開一個新 session。
 4. 沒在用 Claude Code？用 `curl` 推狀態（見[接上你的 Agent](#接上你的-agent)）。
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,18 @@ const root = path.resolve(__dirname, '..')
 const args = process.argv.slice(2)
 const command = args[0]
 
+// Both servers are spawned with `cwd: root` so Vite can resolve its own config and sources.
+// That makes their process.cwd() the package directory — under `npx` the npx cache — while
+// the hooks stamp each session file with the real project directory. Without forwarding the
+// invoking cwd, every hook file looks foreign and is filtered out, leaving only file-watcher
+// fallback data (`source: 'file-watcher'`, `_hint: 'no-hooks'`). This process is never
+// chdir'd, so its cwd is still the directory the user launched us from. An explicitly set
+// OFFICE_PROJECT_ROOT wins, so multi-worktree setups can point the office at one root.
+// Reported by @whoffmandesign (#201).
+function childEnv() {
+  return { ...process.env, OFFICE_PROJECT_ROOT: process.env.OFFICE_PROJECT_ROOT || process.cwd() }
+}
+
 // ─── setup: one-click Claude Code hook installation ───
 if (command === 'setup') {
   const claudeDir = path.join(os.homedir(), '.claude')
@@ -188,6 +200,7 @@ if (command === 'serve') {
   const serverArgs = process.argv.slice(3)
   const child = spawn(process.execPath, [serverScript, ...serverArgs], {
     cwd: root,
+    env: childEnv(),
     stdio: 'inherit',
     shell: false,
   })
@@ -338,6 +351,7 @@ const viteFlags = ['--port', port]
 if (host) viteFlags.push('--host')
 const vite = spawn(process.execPath, [viteBinJs, ...viteFlags], {
   cwd: root,
+  env: childEnv(),
   stdio: 'inherit',
   shell: false,
 })

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -373,6 +373,12 @@ session 文件
   └── 其他 → 納入合併
 ```
 
+`projectRoot` 由 `resolveProjectRoot()`（`src/server/scanSessions.mjs`）決定：`OFFICE_PROJECT_ROOT`
+優先，否則用 `process.cwd()`。兩個 server 都由 `bin/cli.js` 以 `cwd: <套件目錄>` spawn（Vite 需要在那裡
+解析自己的設定），所以在 `npx` 下 `process.cwd()` 是 npx cache 而非使用者的專案 —— `bin/cli.js` 會把呼叫
+當下的 cwd 以 `OFFICE_PROJECT_ROOT` 傳進子行程。**讀（`scanAndMerge`/`getSessionStats`）與寫（POST
+handler 蓋 `_cwd`）兩邊必須用同一個 root**，否則 server 會過濾掉自己寫入的狀態（#201）。
+
 ### GET /api/status 多 Session 合併流程
 
 ```

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -128,7 +128,7 @@ Register it in `~/.claude/settings.json` (the hook reads events from stdin, no a
 }
 ```
 
-The hook auto-detects the current git branch slug, writes `~/.claude/office-status-{slug}.json`, and the office filters by `process.cwd()` so sessions from other projects never appear.
+The hook auto-detects the current git branch slug, writes `~/.claude/office-status-{slug}.json`, and the office filters by the directory it was launched in so sessions from other projects never appear. Set `OFFICE_PROJECT_ROOT` to match against a different project root (e.g. a multi-worktree setup).
 
 ---
 

--- a/docs/adr/ADR-002-multi-worktree-session-design.md
+++ b/docs/adr/ADR-002-multi-worktree-session-design.md
@@ -46,7 +46,7 @@ Every session file written by the hook includes the project root:
 ```
 
 The GET `/api/status` handler filters:
-- If `_cwd` is set and does not resolve to `process.cwd()` → **skip** (other project)
+- If `_cwd` is set and does not resolve to the project root → **skip** (other project). The project root is `OFFICE_PROJECT_ROOT` when set, otherwise the launching directory — `process.cwd()` alone is wrong under `npx` (#201).
 - If `_cwd` is absent and filename is NOT `office-status.json` → **skip** (slugged file from old hookless run)
 - If `_cwd` is absent and filename IS `office-status.json` → **allow** (legacy fallback)
 

--- a/docs/adr/ADR-007-dialogue-channel-separation-and-honesty-gate.md
+++ b/docs/adr/ADR-007-dialogue-channel-separation-and-honesty-gate.md
@@ -3,7 +3,7 @@ title: "ADR-007 — Dialogue channel separation + dialogue honesty gate"
 date: 2026-06-15
 status: accepted
 applies_to:
-  - "src/systems/banter.js"
+  - "src/systems/roleArchetype.js"
   - "src/systems/behaviorEngine.js"
   - "src/systems/officeLife.js"
   - "src/systems/contextBubble.js"

--- a/docs/deployment/DEPLOYMENT.md
+++ b/docs/deployment/DEPLOYMENT.md
@@ -168,6 +168,7 @@ docker compose up -d --build             # rebuild image and recreate container
 | --- | --- | --- |
 | `OFFICE_API_TOKEN` | No | If set, all API **write** endpoints (POST) require this token via the `X-Office-Token` header or `Authorization: Bearer <token>`. GET `/api/status` is always readable (status data only, no secrets). Leave unset for trusted local networks. |
 | `OFFICE_API_ALLOWED_ORIGINS` | No | Comma-separated list of allowed CORS origins (e.g. `https://office.example.com`). If unset, only loopback and the server's own IPs are accepted. |
+| `OFFICE_PROJECT_ROOT` | No | Project directory that session files are matched against (each file carries the `_cwd` the hook ran in). Defaults to the directory the office was launched from — `bin/cli.js` forwards it, since both servers are spawned with their cwd set to the package directory. Set it explicitly to watch a different project root, e.g. a shared worktree. |
 
 ## Hook integration note
 

--- a/server.mjs
+++ b/server.mjs
@@ -19,7 +19,7 @@ import os from 'node:os'
 import { createHash, timingSafeEqual } from 'node:crypto'
 import { fileURLToPath } from 'node:url'
 import { execSync } from 'node:child_process'
-import { scanAndMerge, getSessionStats } from './src/server/scanSessions.mjs'
+import { scanAndMerge, getSessionStats, resolveProjectRoot } from './src/server/scanSessions.mjs'
 // AVO-146: replaced inline normalizePost copy with the canonical src module.
 // This also fixes the #52 divergence: the old inline copy dropped agents with
 // invalid status; the canonical src module coerces them to 'idle' instead.
@@ -66,6 +66,11 @@ if (!fs.existsSync(path.join(dist, 'index.html'))) {
 
 // ─── Shared paths ────────────────────────────────────────────────────────────
 const STATUS_PATH = path.join(os.homedir(), '.claude', 'office-status.json')
+
+// The project directory session files are matched against. This process is spawned with its
+// cwd set to the package root by bin/cli.js (and therefore by npx), so process.cwd() cannot
+// be used here — see resolveProjectRoot() in src/server/scanSessions.mjs.
+const PROJECT_ROOT = resolveProjectRoot()
 
 // Fail fast if the state directory is not writable (catches Docker bind-mount misconfiguration).
 try {
@@ -219,7 +224,7 @@ function handleStatus(req, res) {
   if (req.method === 'GET') {
     try {
       const clientEtag = req.headers['if-none-match']
-      const merged = scanAndMerge(path.dirname(STATUS_PATH), process.cwd())
+      const merged = scanAndMerge(path.dirname(STATUS_PATH), PROJECT_ROOT)
       if (!merged) return res.end('null')
       const data = JSON.stringify(merged)
       const etag = '"' + createHash('md5').update(data).digest('hex').slice(0, 12) + '"'
@@ -247,7 +252,7 @@ function handleStatus(req, res) {
       let normalized
       try {
         normalized = normalizePost(JSON.parse(body))
-        normalized._cwd = process.cwd()
+        normalized._cwd = PROJECT_ROOT
         if (!atomicWrite(STATUS_PATH, JSON.stringify(normalized, null, 2))) {
           res.statusCode = 500; return res.end(JSON.stringify({ ok: false, error: 'Write failed' }))
         }
@@ -260,7 +265,7 @@ function handleStatus(req, res) {
       // scanAndMerge re-reads and re-parses every status file in ~/.claude/.
       if (sseClients.size > 0) {
         try {
-          const ssePayload = scanAndMerge(path.dirname(STATUS_PATH), process.cwd())
+          const ssePayload = scanAndMerge(path.dirname(STATUS_PATH), PROJECT_ROOT)
           if (ssePayload) broadcastSSE(ssePayload)
         } catch {}
       }
@@ -370,7 +375,7 @@ function handleEvent(req, res) {
         activeCount: countActive(agents),
         workflow: typeof parsed.workflow === 'string' ? parsed.workflow.slice(0, 200) : null,
         source: 'webhook',
-        _cwd: process.cwd(),
+        _cwd: PROJECT_ROOT,
       }
       if (!atomicWrite(STATUS_PATH, JSON.stringify(output, null, 2))) {
         res.statusCode = 500; return res.end(JSON.stringify({ ok: false, error: 'Write failed' }))
@@ -382,7 +387,7 @@ function handleEvent(req, res) {
     // Skip the broadcast scan when no SSE clients are connected (see /api/status POST).
     if (sseClients.size > 0) {
       try {
-        const ssePayload = scanAndMerge(path.dirname(STATUS_PATH), process.cwd())
+        const ssePayload = scanAndMerge(path.dirname(STATUS_PATH), PROJECT_ROOT)
         if (ssePayload) broadcastSSE(ssePayload)
       } catch {}
     }
@@ -466,7 +471,7 @@ const server = http.createServer((req, res) => {
     // try/catch: an uncaught scanAndMerge throw in this request handler would crash the
     // server (req/res 'error' listeners don't catch synchronous handler-body throws).
     let snapshot = null
-    try { snapshot = scanAndMerge(path.dirname(STATUS_PATH), process.cwd()) } catch {}
+    try { snapshot = scanAndMerge(path.dirname(STATUS_PATH), PROJECT_ROOT) } catch {}
     if (snapshot) {
       try { res.write(`event: status\ndata: ${JSON.stringify(snapshot)}\n\n`) }
       catch { sseClients.delete(res) }
@@ -481,7 +486,7 @@ const server = http.createServer((req, res) => {
     setCors(res, req.headers.origin, 'GET, OPTIONS')
     if (req.method === 'OPTIONS') return handlePreflight(req, res)
     if (req.method !== 'GET' && req.method !== 'HEAD') { res.setHeader('Allow', 'GET, HEAD, OPTIONS'); res.statusCode = 405; return res.end() }
-    const stats = getSessionStats(path.dirname(STATUS_PATH), process.cwd())
+    const stats = getSessionStats(path.dirname(STATUS_PATH), PROJECT_ROOT)
     return res.end(JSON.stringify({ ok: true, uptime: Math.floor(process.uptime()), ...stats }))
   }
   return serveStatic(req, res)
@@ -557,7 +562,7 @@ let _watchDebounce = null
         // (e.g. a malformed session file reaching scanAndMerge) would crash the whole server
         // process. Mirrors the POST-broadcast caller's guard above.
         try {
-          const merged = scanAndMerge(watchDir, process.cwd())
+          const merged = scanAndMerge(watchDir, PROJECT_ROOT)
           if (merged) broadcastSSE(merged)
         } catch {}
       }, 80)  // debounce: atomic rename fires two events on some platforms

--- a/src/server/scanSessions.mjs
+++ b/src/server/scanSessions.mjs
@@ -36,6 +36,28 @@ function pathsEqual(a, b) {
   return isWin ? a.toLowerCase() === b.toLowerCase() : a === b
 }
 
+/**
+ * The project directory that session files are matched against.
+ *
+ * Both servers are spawned by `bin/cli.js` with `cwd` set to the PACKAGE root (Vite must
+ * resolve its own config and sources from there), so under `npx agent-virtual-office` the
+ * process cwd is the npx cache directory — not the project the user launched us from.
+ * Hooks stamp `_cwd` with the real project, so every hook file then looks foreign and is
+ * filtered out, leaving only file-watcher fallback data. `bin/cli.js` forwards the invoking
+ * cwd as OFFICE_PROJECT_ROOT; an explicitly set value wins (useful for multi-worktree
+ * setups), and the process.cwd() default keeps `npm run dev` unchanged.
+ *
+ * MUST be used for BOTH the read sites (scanAndMerge/getSessionStats) and the write sites
+ * that stamp `_cwd` on POSTed payloads — a root that differs between the two makes the
+ * server filter out its own writes.
+ */
+export function resolveProjectRoot(env = process.env, cwd = process.cwd()) {
+  const override = env.OFFICE_PROJECT_ROOT
+  return typeof override === 'string' && override.trim() !== ''
+    ? path.resolve(override)
+    : cwd
+}
+
 function hasValidBaseRole(role) {
   if (typeof role !== 'string' || role.length === 0) return false
   const sep = role.lastIndexOf('~')

--- a/tests/agentInspector.test.js
+++ b/tests/agentInspector.test.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// Timestamps here MUST be built with the local-time constructor `new Date(y, m, d, …)`.
+// The ledger derives `dayKey` from the LOCAL date, so a fixed-offset ISO literal
+// (`…T12:00:00+08:00`) only lands on the hardcoded '2026-04-08' dayKey on machines whose
+// TZ is UTC+8 — elsewhere it silently rolls the ledger to the previous/next day and the
+// day-rollover and replay-guard cases fail. Reported from a UTC-7 host in #201.
+
 const { countAgentDoneToday, inspectorTaskLabel, stateDurationLabel } = await import('../src/components/agentInspectorModel.js')
 const { useOfficeStore } = await import('../src/systems/store.js')
 
@@ -134,19 +140,19 @@ describe('AgentInspector', () => {
   })
 
   it('counts only same-day done events for the selected agent', () => {
-    const now = new Date('2026-04-08T18:00:00+08:00').getTime()
+    const now = new Date(2026, 3, 8, 18, 0, 0).getTime()
 
     expect(countAgentDoneToday([
       { agentId: 'dev', type: 'status', status: 'done', timestamp: now - 1_000, message: 'Finished step' },
       { agentId: 'dev', type: 'status', status: 'done', timestamp: now - 3_600_000, message: 'Another done' },
       { agentId: 'dev', type: 'status', status: 'working', timestamp: now - 2_000, message: 'Still working' },
       { agentId: 'qa', type: 'status', status: 'done', timestamp: now - 2_000, message: 'Other agent' },
-      { agentId: 'dev', type: 'status', status: 'done', timestamp: new Date('2026-04-07T23:00:00+08:00').getTime(), message: 'Yesterday' },
+      { agentId: 'dev', type: 'status', status: 'done', timestamp: new Date(2026, 3, 7, 23, 0, 0).getTime(), message: 'Yesterday' },
     ], 'dev', now)).toBe(2)
   })
 
   it('reads same-day done counts from the durable ledger when available', () => {
-    const now = new Date('2026-04-08T18:00:00+08:00').getTime()
+    const now = new Date(2026, 3, 8, 18, 0, 0).getTime()
 
     expect(countAgentDoneToday({
       dayKey: '2026-04-08',
@@ -185,7 +191,7 @@ describe('AgentInspector', () => {
     ], {
       source: 'claude-cli',
       seq: '9001',
-      now: new Date('2026-04-08T18:00:00+08:00').getTime(),
+      now: new Date(2026, 3, 8, 18, 0, 0).getTime(),
     })
 
     expect(useOfficeStore.getState().dailyDoneLedger).toMatchObject({
@@ -198,7 +204,7 @@ describe('AgentInspector', () => {
     ], {
       source: 'claude-cli',
       seq: '9002',
-      now: new Date('2026-04-08T18:05:00+08:00').getTime(),
+      now: new Date(2026, 3, 8, 18, 5, 0).getTime(),
     })
 
     expect(useOfficeStore.getState().dailyDoneLedger).toMatchObject({
@@ -217,7 +223,7 @@ describe('AgentInspector', () => {
     ], {
       source: 'claude-cli',
       seq: '9002',
-      now: new Date('2026-04-08T18:10:00+08:00').getTime(),
+      now: new Date(2026, 3, 8, 18, 10, 0).getTime(),
     })
 
     expect(useOfficeStore.getState().dailyDoneLedger).toMatchObject({
@@ -239,7 +245,7 @@ describe('AgentInspector', () => {
       externalStatus: {},
       dailyDoneLedger: { dayKey: '2026-04-08', counts: {}, seenEventKeys: [] },
     })
-    const now = new Date('2026-04-08T12:00:00+08:00').getTime()
+    const now = new Date(2026, 3, 8, 12, 0, 0).getTime()
 
     useOfficeStore.getState().applyExternalStatus(
       [{ agentId: 'dev', status: 'done', task: 'Edit', label: 'fix' }],
@@ -268,7 +274,7 @@ describe('AgentInspector', () => {
       },
       dailyDoneLedger: { dayKey: '2026-04-08', counts: { dev: 5 }, seenEventKeys: ['claude-cli:seen:dev'] },
     })
-    const now = new Date('2026-04-08T12:00:00+08:00').getTime()
+    const now = new Date(2026, 3, 8, 12, 0, 0).getTime()
 
     // Same eventKey as already-seen → shouldCount is false → no growth.
     useOfficeStore.getState().applyExternalStatus(
@@ -283,7 +289,7 @@ describe('AgentInspector', () => {
       externalStatus: {},
       dailyDoneLedger: { dayKey: '2026-04-08', counts: {}, seenEventKeys: [] },
     })
-    const now = new Date('2026-04-08T12:00:00+08:00').getTime()
+    const now = new Date(2026, 3, 8, 12, 0, 0).getTime()
 
     useOfficeStore.getState().applyExternalStatus(
       [{ agentId: 'feat-x~dev', status: 'done', task: 'Edit', label: 'fix', session: 'feat-x' }],
@@ -433,7 +439,7 @@ describe('store — dailyDoneLedger day rollover via applyExternalStatus', () =>
       dailyDoneLedger: { dayKey: '2026-04-08', counts: { dev: 4 }, seenEventKeys: ['claude-cli:x:dev'] },
     })
 
-    const nextDayNow = new Date('2026-04-09T09:00:00+08:00').getTime()
+    const nextDayNow = new Date(2026, 3, 9, 9, 0, 0).getTime()
     useOfficeStore.getState().applyExternalStatus(
       [{ agentId: 'dev', status: 'done', task: 'Edit', label: 'New day work' }],
       { source: 'claude-cli', seq: 'nd1', now: nextDayNow },

--- a/tests/projectRoot.test.js
+++ b/tests/projectRoot.test.js
@@ -1,0 +1,113 @@
+/**
+ * Project-root resolution (#201 — npx hook filtering)
+ *
+ * Both servers are spawned by bin/cli.js with `cwd` set to the PACKAGE root, so under
+ * `npx agent-virtual-office` their process.cwd() is the npx cache directory. Session files
+ * are matched against that root, so every hook-written file looked foreign and was filtered
+ * out — the office fell back to file-watcher data and the documented install path showed
+ * no agent signal at all.
+ *
+ * Covers:
+ *   - resolveProjectRoot() precedence (env override > cwd) and path resolution.
+ *   - The read path honours the override (the reported bug).
+ *   - The WRITE path uses the same root — a server that stamps `_cwd` with its own cwd
+ *     while reading against the override filters out its own POSTs (the gap left by the
+ *     original patch: vite.config.js/server.mjs stamp `_cwd` in the POST handlers too).
+ *
+ * The real-server end-to-end proof lives in tests/serverProjectRootE2E.test.js.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import os from 'node:os'
+import { scanAndMerge, resolveProjectRoot } from '../src/server/scanSessions.mjs'
+
+function tmpDir(prefix = 'projectRoot-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function writeSession(dir, file, data) {
+  fs.writeFileSync(path.join(dir, file), JSON.stringify(data))
+}
+
+function hookSession(cwd) {
+  return {
+    type: 'office-status',
+    _seq: String(Date.now()),
+    _cwd: cwd,
+    source: 'claude-cli',
+    agents: [{ role: 'dev', status: 'working', task: 'Edit', label: null }],
+  }
+}
+
+describe('resolveProjectRoot', () => {
+  it('defaults to the process cwd when no override is set', () => {
+    expect(resolveProjectRoot({}, '/some/project')).toBe('/some/project')
+  })
+
+  it('prefers an explicit OFFICE_PROJECT_ROOT over the cwd', () => {
+    const root = path.resolve('/explicit/root')
+    expect(resolveProjectRoot({ OFFICE_PROJECT_ROOT: root }, '/package/dir')).toBe(root)
+  })
+
+  it('resolves a relative override to an absolute path', () => {
+    const resolved = resolveProjectRoot({ OFFICE_PROJECT_ROOT: 'sub/dir' }, '/package/dir')
+    expect(path.isAbsolute(resolved)).toBe(true)
+    expect(resolved).toBe(path.resolve('sub/dir'))
+  })
+
+  it('ignores an empty or whitespace-only override', () => {
+    expect(resolveProjectRoot({ OFFICE_PROJECT_ROOT: '' }, '/package/dir')).toBe('/package/dir')
+    expect(resolveProjectRoot({ OFFICE_PROJECT_ROOT: '   ' }, '/package/dir')).toBe('/package/dir')
+  })
+})
+
+describe('session matching under an npx-style cwd split', () => {
+  let statusDir, projectRoot, packageRoot
+  beforeEach(() => {
+    statusDir = tmpDir('projectRoot-status-')
+    projectRoot = tmpDir('projectRoot-project-')
+    packageRoot = tmpDir('projectRoot-package-')
+  })
+  afterEach(() => {
+    for (const d of [statusDir, projectRoot, packageRoot]) {
+      fs.rmSync(d, { recursive: true, force: true })
+    }
+  })
+
+  // Test-the-test: this is the reported failure. If this ever starts passing, the
+  // _cwd filter has changed and the override below no longer proves anything.
+  it('drops hook sessions when the root is the package dir (the #201 bug)', () => {
+    writeSession(statusDir, 'office-status-abc.json', hookSession(projectRoot))
+    expect(scanAndMerge(statusDir, packageRoot)).toBeNull()
+  })
+
+  it('keeps hook sessions when the root is the invoking project dir', () => {
+    writeSession(statusDir, 'office-status-abc.json', hookSession(projectRoot))
+    const merged = scanAndMerge(statusDir, resolveProjectRoot(
+      { OFFICE_PROJECT_ROOT: projectRoot },
+      packageRoot,
+    ))
+    expect(merged).not.toBeNull()
+    expect(merged.source).toBe('claude-cli')
+    expect(merged.agents[0].role).toBe('dev')
+  })
+
+  // The write sites (`normalized._cwd = PROJECT_ROOT` in both POST handlers) must use the
+  // same root as the read sites. Stamping process.cwd() while reading against the override
+  // makes the server filter out its own POSTed status.
+  it('keeps a POST-style payload stamped with the same resolved root', () => {
+    const root = resolveProjectRoot({ OFFICE_PROJECT_ROOT: projectRoot }, packageRoot)
+    writeSession(statusDir, 'office-status.json', { ...hookSession(root), source: 'webhook' })
+    const merged = scanAndMerge(statusDir, root)
+    expect(merged).not.toBeNull()
+    expect(merged.source).toBe('webhook')
+  })
+
+  it('drops a POST-style payload stamped with the package dir instead', () => {
+    const root = resolveProjectRoot({ OFFICE_PROJECT_ROOT: projectRoot }, packageRoot)
+    writeSession(statusDir, 'office-status.json', { ...hookSession(packageRoot), source: 'webhook' })
+    expect(scanAndMerge(statusDir, root)).toBeNull()
+  })
+})

--- a/tests/serverProjectRootE2E.test.js
+++ b/tests/serverProjectRootE2E.test.js
@@ -1,0 +1,140 @@
+/**
+ * #201 — real-server proof that OFFICE_PROJECT_ROOT reaches both the read and write paths.
+ *
+ * Reproduces the npx layout: `bin/cli.js` spawns the server with `cwd` set to the PACKAGE
+ * root, so process.cwd() is NOT the project the user launched from. Under that split the
+ * server must match session files against the forwarded project root, or every hook-written
+ * file is filtered out as foreign (the reported bug: `source: 'file-watcher'`, `_hint:
+ * 'no-hooks'`, labels degraded to raw .jsonl filenames).
+ *
+ * Isolation follows tests/serverTransportE2E.test.js: HOME/USERPROFILE point at a temp dir,
+ * so os.homedir() resolves there and the developer's real ~/.claude is never touched.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest'
+import { spawn } from 'node:child_process'
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createServer } from 'node:net'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+
+function freePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer()
+    srv.listen(0, '127.0.0.1', () => {
+      const port = srv.address().port
+      srv.close(() => resolve(port))
+    })
+    srv.on('error', reject)
+  })
+}
+
+async function waitForServer(base, deadlineMs = 25_000) {
+  const deadline = Date.now() + deadlineMs
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${base}/api/health`)
+      if (res.ok && (await res.json()).ok) return true
+    } catch {}
+    await new Promise(r => setTimeout(r, 150))
+  }
+  return false
+}
+
+let BASE_URL
+let serverProc
+let projectDir
+
+beforeAll(async () => {
+  if (!existsSync(join(ROOT, 'dist', 'index.html'))) {
+    throw new Error('dist/index.html not found — run `npm run build` before this e2e (server.mjs requires the bundle).')
+  }
+
+  const homeDir = mkdtempSync(join(tmpdir(), 'avo-201-home-'))
+  mkdirSync(join(homeDir, '.claude'), { recursive: true })
+  // The project the user "launched from" — distinct from ROOT (which stands in for the
+  // npx package directory the server is actually spawned in).
+  projectDir = mkdtempSync(join(tmpdir(), 'avo-201-project-'))
+
+  // A hook-written session, stamped with the real project dir like office-status-hook.js does.
+  writeFileSync(
+    join(homeDir, '.claude', 'office-status-e2e.json'),
+    JSON.stringify({
+      type: 'office-status',
+      _seq: String(Date.now()),
+      _cwd: projectDir,
+      source: 'claude-cli',
+      agents: [{ role: 'ops', status: 'working', task: 'Bash', label: 'deploying' }],
+    }),
+  )
+
+  const port = await freePort()
+  BASE_URL = `http://127.0.0.1:${port}`
+
+  serverProc = spawn(process.execPath, ['server.mjs', `--port=${port}`, '--no-open'], {
+    // Deliberately the package root, exactly as bin/cli.js spawns it.
+    cwd: ROOT,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      OFFICE_API_TOKEN: '',
+      // What bin/cli.js forwards from the invoking cwd.
+      OFFICE_PROJECT_ROOT: projectDir,
+    },
+  })
+
+  let stderr = ''
+  serverProc.stderr.on('data', d => { stderr += d.toString() })
+  serverProc.on('error', err => { throw new Error(`Failed to spawn server.mjs: ${err.message}`) })
+
+  if (!(await waitForServer(BASE_URL))) {
+    serverProc.kill('SIGKILL')
+    throw new Error(`server.mjs did not become ready on ${BASE_URL}.\nStderr: ${stderr.slice(-800)}`)
+  }
+}, 40_000)
+
+afterAll(() => {
+  try { serverProc?.kill('SIGTERM') } catch {}
+})
+
+describe('#201 — server honours the forwarded project root', () => {
+  it('serves hook sessions from the invoking project, not the package dir', async () => {
+    const body = await (await fetch(`${BASE_URL}/api/status`)).json()
+    expect(body).not.toBeNull()
+    // Before the fix this was 'file-watcher' with _hint: 'no-hooks' — the hook file was
+    // dropped because its _cwd did not match the package dir the server runs in.
+    expect(body.source).toBe('claude-cli')
+    expect(body._hint).toBeUndefined()
+    expect(body.agents.map(a => a.role)).toContain('ops')
+  })
+
+  it('reads back its own POSTed status (write and read roots agree)', async () => {
+    const res = await fetch(`${BASE_URL}/api/status`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dev: 'blocked', workflow: 'e2e-201' }),
+    })
+    expect(res.status).toBe(200)
+
+    const body = await (await fetch(`${BASE_URL}/api/status`)).json()
+    expect(body).not.toBeNull()
+    // The POST handler stamps _cwd itself. If it stamped process.cwd() while the reader
+    // matched OFFICE_PROJECT_ROOT, this payload would be filtered out as foreign.
+    // Multi-session merge prefixes roles with the session slug (`main~dev`).
+    const baseRole = r => r.slice(r.lastIndexOf('~') + 1)
+    expect(body.agents.some(a => baseRole(a.role) === 'dev' && a.status === 'blocked')).toBe(true)
+  })
+
+  it('counts the hook session in /api/health stats (getSessionStats root)', async () => {
+    const body = await (await fetch(`${BASE_URL}/api/health`)).json()
+    expect(body.ok).toBe(true)
+    // 0 before the fix — getSessionStats matched against the package dir too.
+    expect(body.hookSessionCount).toBeGreaterThan(0)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import os from 'node:os'
 import { normalizePost, VALID_ROLES, VALID_STATUSES } from './src/utils/normalizePost.js'
-import { scanAndMerge, getSessionStats } from './src/server/scanSessions.mjs'
+import { scanAndMerge, getSessionStats, resolveProjectRoot } from './src/server/scanSessions.mjs'
 
 // Middleware: Universal status API
 //   GET  /api/status → read current status (browser polls this)
@@ -22,6 +22,11 @@ import { scanAndMerge, getSessionStats } from './src/server/scanSessions.mjs'
 
 // Shared status file path (shared between plugins)
 const STATUS_PATH = path.join(os.homedir(), '.claude', 'office-status.json')
+
+// The project directory session files are matched against. Vite's own cwd is the package
+// root when launched via bin/cli.js (and therefore npx), so it cannot be used here —
+// see resolveProjectRoot() in src/server/scanSessions.mjs.
+const PROJECT_ROOT = resolveProjectRoot()
 
 const LOOPBACK_ORIGIN_RE = /^https?:\/\/(localhost|127(?:\.\d{1,3}){3}|\[::1\])(?::\d+)?$/i
 
@@ -184,7 +189,7 @@ function officeStatusPlugin() {
         if (req.method === 'GET') {
           try {
             const clientEtag = req.headers['if-none-match']
-            const merged = scanAndMerge(path.dirname(statusPath), process.cwd())
+            const merged = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
             if (!merged) { res.end('null'); return }
             const data = JSON.stringify(merged)
             const etag = '"' + createHash('md5').update(data).digest('hex').slice(0, 12) + '"'
@@ -236,7 +241,7 @@ function officeStatusPlugin() {
             try {
               const parsed = JSON.parse(body)
               normalized = normalizePost(parsed)
-              normalized._cwd = process.cwd()
+              normalized._cwd = PROJECT_ROOT
               const dir = path.dirname(statusPath)
               if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
               if (!atomicWrite(statusPath, JSON.stringify(normalized, null, 2))) {
@@ -258,7 +263,7 @@ function officeStatusPlugin() {
             // Running it for a broadcast that has no recipients is pure waste.
             if (sseClients.size > 0) {
               try {
-                const sseData = scanAndMerge(path.dirname(statusPath), process.cwd())
+                const sseData = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
                 if (sseData) broadcastSSE(sseData)
               } catch {}
             }
@@ -298,7 +303,7 @@ function officeStatusPlugin() {
         req.on('close', () => sseClients.delete(res))
         req.on('error', () => sseClients.delete(res))
         res.on('error', () => sseClients.delete(res))
-        const snapshot = scanAndMerge(path.dirname(statusPath), process.cwd())
+        const snapshot = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
         if (snapshot) {
           try { res.write(`event: status\ndata: ${JSON.stringify(snapshot)}\n\n`) }
           catch { sseClients.delete(res) }
@@ -321,7 +326,7 @@ function officeStatusPlugin() {
         if (sseClients.size === 0) return
         clearTimeout(watchDebounce)
         watchDebounce = setTimeout(() => {
-          const merged = scanAndMerge(path.dirname(statusPath), process.cwd())
+          const merged = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
           if (merged) broadcastSSE(merged)
         }, 80)
         if (watchDebounce.unref) watchDebounce.unref()
@@ -551,7 +556,7 @@ function officeStatusPlugin() {
 
             const output = {
               _seq: nextSeq(),
-              _cwd: process.cwd(),
+              _cwd: PROJECT_ROOT,
               type: 'office-status',
               agents,
               activeCount: agents.filter(a => a.status === 'working' || a.status === 'blocked' || a.status === 'planning' || a.status === 'awaiting-approval').length,
@@ -576,7 +581,7 @@ function officeStatusPlugin() {
           // Skip the broadcast scan when no SSE clients are connected (see POST handler).
           if (sseClients.size > 0) {
             try {
-              const sseData = scanAndMerge(path.dirname(statusPath), process.cwd())
+              const sseData = scanAndMerge(path.dirname(statusPath), PROJECT_ROOT)
               if (sseData) broadcastSSE(sseData)
             } catch {}
           }
@@ -602,7 +607,7 @@ function officeStatusPlugin() {
           res.setHeader('Allow', 'GET, HEAD, OPTIONS')
           res.statusCode = 405; res.end(JSON.stringify({ error: 'Method not allowed' })); return
         }
-        const stats = getSessionStats(path.dirname(statusPath), process.cwd())
+        const stats = getSessionStats(path.dirname(statusPath), PROJECT_ROOT)
         res.end(JSON.stringify({ ok: true, uptime: Math.floor(process.uptime()), ...stats }))
       })
 


### PR DESCRIPTION
Maintenance sweep of `main@685e767`. One real user-facing defect, one host-portability defect, and the doc drift around both.

## 1. The office was blind under `npx` — the documented install path

`bin/cli.js` spawns both servers with `cwd` set to the **package** root (Vite must resolve its own config and sources there), so their `process.cwd()` is the npx cache directory. Session files are matched against that root, and the hooks stamp `_cwd` with the real project — so every hook-written file was dropped as foreign, leaving only file-watcher fallback data:

```json
{"agents":[{"role":"ops","task":"Edit","label":"✏️ 651791b3-….jsonl"}],
 "source":"file-watcher","_hint":"no-hooks"}
```

Diagnosed and originally patched by **@whoffmandesign** in #201. The mechanism there (`OFFICE_PROJECT_ROOT`, forwarded from the CLI's own cwd) was correct and is kept as-is. Two gaps are closed here:

**(a) The write sites.** Both POST handlers stamp `_cwd` themselves. Converting only the six read sites makes the server filter out its *own* POSTed status, so the documented `POST /api/status` / `/api/event` webhook path would have gone dark under npx — a fix that trades one broken path for another. Proven, not asserted: with only the readers converted, `serverProjectRootE2E > reads back its own POSTed status` fails with `expected false to be true`.

**(b) `server.mjs`.** The `serve` / Docker path has all 8 of the identical sites and was equally broken.

`resolveProjectRoot()` now lives in `src/server/scanSessions.mjs` — the module that owns the `_cwd` matching contract and is already imported by both servers — so the two cannot drift again.

## 2. The suite failed on any host outside UTC+8

`tests/agentInspector.test.js` mixed fixed `+08:00` ISO literals with a `dayKey` the ledger derives in **local** time. On a UTC-7 host `new Date('2026-04-09T09:00:00+08:00')` is still 2026-04-08 locally, so the ledger rolled to the wrong day and two cases failed — which is why the contributor saw them red on a clean checkout. The same class of bug was already fixed once in this file for CI/UTC (`countAgentDoneToday` block, with a comment explaining the local-time constructor); the remaining 10 literals just were not swept. They are now.

Green from **UTC-11 to UTC+14**: UTC, America/Los_Angeles, Pacific/Kiritimati, Pacific/Midway, Europe/Berlin.

## 3. Doc drift

| File | Was | Now |
|---|---|---|
| `README.md` / `README.zh-TW.md` | "filters by `process.cwd()`" | filters by the launching directory; names `OFFICE_PROJECT_ROOT` |
| `docs/ARCHITECTURE.md` | no note on how `projectRoot` resolves | documents the resolution + the read/write symmetry requirement |
| `docs/INTEGRATIONS.md` | "filters by `process.cwd()`" | corrected |
| `docs/deployment/DEPLOYMENT.md` | env table missing the var | `OFFICE_PROJECT_ROOT` documented |
| `docs/adr/ADR-002` | filter rule stated as `process.cwd()` | project root, with the npx caveat |
| `docs/adr/ADR-007` | `applies_to: src/systems/banter.js` | `roleArchetype.js` — `banter.js` never existed |

## Evidence

- Defect reproduced on pre-fix source: `GET /api/status` → `expected null not to be null` (a valid hook session on disk, office sees nothing).
- Partial-fix regression reproduced: read-only variant fails the POST-readback case.
- `npx vitest run` → **114 files / 2306 tests pass** (+11: 8 unit, 3 real-server e2e).
- `npm run build` → PASS, `496.50 kB` — unchanged, no bundled source touched.
- Agentic OS validator → `pass=112 warn=8 fail=0 skip=4` (identical to baseline).

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
