### PR TITLE
feat(tooling): make the office-rhythm measurement reusable, and its hermeticity real

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,17 @@ runtime*, not in any single function — so the repo ships its own observation t
 |---|---|
 | `npm run soak` | **The soak gate.** Runs the office headless for 5 min (`--minutes N` to change) and fails on world-invariant violations: teleports, sustained standing stacks, frozen walkers, characters standing inside furniture. Also runs nightly in CI (`sim-soak` workflow). |
 | `node scripts/overlap-recorder.mjs 12` | Stack forensics: when two characters sit fully overlapped ≥2s, dumps both agents' last ~12s state chains (positions, targets, behaviors) so the mechanism is visible. |
-| `node scripts/zone-audit.mjs` | Movement-rhythm audit: 3-min zone occupancy, room visits, and how often 0/1/2+ characters are walking at once. |
+| `node scripts/zone-audit.mjs` | Movement-rhythm audit: 3-min zone occupancy, room visits, and how often 0/1/2+ characters are walking at once. Its `--organic` flag isolates the run by **renaming your real `~/.claude/office-status*.json`** and restoring them on a clean exit — prefer `npm run rhythm` below, which isolates without touching your files. |
+| `npm run rhythm` | **Is the office ALIVE or merely BUSY?** Hermetic by construction (spawns its own dev server pointed at an empty `OFFICE_STATUS_DIR`, and refuses to report numbers if any external status arrived). Reports stillness against an exact Poisson-binomial *independent model* — the gap says whether motion **clusters** (bursts and real quiet = rhythm) or **spreads** (someone always walking = churn), which no rate metric can distinguish. Also flags stale behaviour labels (AVO-195). Reports, never gates. |
 
-All three reuse a running `npm run dev` server on :5173, or start their own. If you see a
+All of these reuse a running `npm run dev` server on :5173, or start their own. If you see a
 visual glitch, run the matching recorder *before* theorizing — every overlap/rhythm fix in
 v1.4.0 started from one of these captures.
+
+> **Reading rhythm numbers.** Quote the stillness **gap** from a single run; the stillness
+> **level** is not reproducible from one. Two 8-minute runs on identical code measured 1.4% and
+> 11.8% while the gap held at −12.3 and −10.5 points. Any claim about the level needs a paired
+> control run on the unchanged build.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "smoke:pack": "node scripts/pack-smoke.mjs",
     "soak": "node scripts/sim-soak.mjs",
     "soak:spawn": "node scripts/sim-soak.mjs --spawn",
+    "rhythm": "node scripts/office-rhythm.mjs",
     "test": "vitest run",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/scripts/office-rhythm.mjs
+++ b/scripts/office-rhythm.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * office-rhythm.mjs — measure whether the office reads ALIVE or merely BUSY.
+ *
+ * Samples the running office for N minutes and hands the timeline to `officeRhythm.mjs`, which
+ * answers the two questions `sim-soak` structurally cannot: is motion CLUSTERED (bursts and real
+ * quiet — rhythm) or SPREAD (someone always walking — churn), and is the office narrating an
+ * activity an agent left minutes ago (backlog AVO-195).
+ *
+ * HERMETIC BY DEFAULT, via TWO independent isolations — one alone is not enough:
+ *   OFFICE_STATUS_DIR=<empty temp>   the default `~/.claude` is where the operator's own live
+ *                                    Claude Code hook traffic lands every few seconds.
+ *   OFFICE_DISABLE_FILE_WATCHER=1    the dev server otherwise manufactures agent status from edits
+ *                                    to the PROJECT ITSELF, and writes it into whatever status dir
+ *                                    it was given — isolated or not.
+ * The second one is not theoretical: the first real run of this tool aborted with
+ * `external agent status arrived (dev, res)` because tests and docs were being edited beside it.
+ * The run ASSERTS no external status arrived and WITHHOLDS the numbers if any did, because a
+ * contaminated run reported as a measurement is worse than no measurement.
+ *
+ * USAGE
+ *   node scripts/office-rhythm.mjs                    # 8-minute hermetic run
+ *   node scripts/office-rhythm.mjs --minutes 3
+ *   RHYTHM_REPORT=rhythm.json node scripts/office-rhythm.mjs
+ *
+ * READING THE OUTPUT — the caveat that cost a control run to learn: quote the stillness GAP from
+ * a single run, never the stillness LEVEL. Two 8-minute runs on identical code measured 1.4% and
+ * 11.8%, while the gap to independence held at -12.3 and -10.5. Any claim about the level needs a
+ * paired control run on the unchanged build.
+ *
+ * EXIT: 0 = measured and reported; 1 = could not measure (never a verdict on the office itself —
+ * this tool reports, it does not gate).
+ */
+import { createRequire } from 'node:module'
+import { spawn } from 'node:child_process'
+import { existsSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { analyzeRhythm, formatRhythm } from './officeRhythm.mjs'
+import { formatTargetIdentityError, inspectAvoViteTarget } from './soakTarget.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+const require = createRequire(path.join(ROOT, 'package.json'))
+const argIdx = process.argv.indexOf('--minutes')
+const MINUTES = argIdx > -1 ? Number(process.argv[argIdx + 1]) : 8
+const SAMPLE_INTERVAL_MS = 250
+const PORT = Number(process.env.RHYTHM_PORT || 5197)
+
+if (!Number.isFinite(MINUTES) || MINUTES <= 0) {
+  console.error('office-rhythm ERROR: --minutes must be a positive number')
+  process.exit(1)
+}
+
+const viteBin = path.join(ROOT, 'node_modules', 'vite', 'bin', 'vite.js')
+if (!existsSync(viteBin)) {
+  console.error('office-rhythm ERROR: Vite binary not found. Run `npm ci` first.')
+  process.exit(1)
+}
+
+let statusDir = null
+let serverProc = null
+let browser = null
+let cleanupPromise = null
+
+async function cleanup() {
+  if (cleanupPromise) return cleanupPromise
+  cleanupPromise = (async () => {
+    try { await browser?.close() } catch {}
+    if (serverProc?.pid) {
+      if (process.platform === 'win32') {
+        await new Promise((resolve) => {
+          const killer = spawn('taskkill.exe', ['/pid', String(serverProc.pid), '/t', '/f'], { stdio: 'ignore' })
+          killer.on('error', resolve)
+          killer.on('exit', resolve)
+        })
+      } else {
+        try { process.kill(-serverProc.pid, 'SIGTERM') } catch {}
+      }
+    }
+    // Only ever the mkdtemp directory this process created, never an operator-supplied path.
+    if (statusDir) { try { rmSync(statusDir, { recursive: true, force: true }) } catch {} }
+  })()
+  return cleanupPromise
+}
+process.once('SIGINT', () => cleanup().then(() => process.exit(130)))
+process.once('SIGTERM', () => cleanup().then(() => process.exit(143)))
+
+const urlUp = async (url) => {
+  try { return (await fetch(url, { signal: AbortSignal.timeout(1000) })).ok } catch { return false }
+}
+
+let exitCode = 0
+try {
+  statusDir = mkdtempSync(path.join(os.tmpdir(), 'avo-rhythm-status-'))
+  serverProc = spawn(
+    process.execPath,
+    [viteBin, '--host', '127.0.0.1', '--port', String(PORT), '--strictPort'],
+    {
+      cwd: ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+      // BOTH are required. OFFICE_STATUS_DIR alone leaves the dev server's file-watcher
+      // fallback manufacturing agent status from edits to the project itself -- which aborted the
+      // first real run of this tool with `external agent status arrived (dev, res)` while tests
+      // and docs were being edited alongside it.
+      env: { ...process.env, OFFICE_STATUS_DIR: statusDir, OFFICE_DISABLE_FILE_WATCHER: '1' },
+    },
+  )
+  serverProc.stdout.on('error', () => {})
+  serverProc.stderr.on('error', () => {})
+
+  const baseUrl = `http://localhost:${PORT}`
+  const deadline = Date.now() + 40000
+  while (Date.now() < deadline && !(await urlUp(`${baseUrl}/`))) {
+    await new Promise((r) => setTimeout(r, 300))
+  }
+  if (!(await urlUp(`${baseUrl}/`))) throw new Error('vite dev server did not become ready')
+
+  const identity = await inspectAvoViteTarget(baseUrl, { timeoutMs: 5000 })
+  if (identity.status !== 'match') throw new Error(formatTargetIdentityError(baseUrl, identity))
+
+  const { chromium } = require('playwright')
+  try {
+    browser = await chromium.launch({ headless: true })
+  } catch {
+    const systemChrome = 'C:/Program Files/Google/Chrome/Application/chrome.exe'
+    if (!existsSync(systemChrome)) throw new Error('No Chromium. Run: npx playwright install --with-deps chromium')
+    browser = await chromium.launch({ headless: true, executablePath: systemChrome })
+  }
+
+  const page = await browser.newPage({ viewport: { width: 1400, height: 900 } })
+  await page.addInitScript(() => { try { localStorage.setItem('office-onboarded', '1') } catch {} })
+  await page.goto(`${baseUrl}/?lang=en`, { waitUntil: 'domcontentloaded' })
+  await page.waitForSelector('svg [data-agent-id]', { timeout: 20000 })
+  await page.waitForTimeout(1500)
+
+  console.log(`office-rhythm: sampling ${MINUTES} min @${SAMPLE_INTERVAL_MS}ms against ${baseUrl} (hermetic)`)
+  const out = await page.evaluate(async ({ minutes, interval }) => {
+    const store = (await import('/src/systems/store.js')).useOfficeStore
+    const parse = (g) => {
+      const m = /translate\(([-\d.]+)[, ]+([-\d.]+)\)/.exec(g.getAttribute('transform') || '')
+      return m ? { x: +m[1], y: +m[2] } : null
+    }
+    const samples = []
+    const t0 = Date.now()
+    while (Date.now() - t0 < minutes * 60000) {
+      const st = store.getState()
+      const agents = {}
+      for (const el of document.querySelectorAll('[data-agent-id]')) {
+        const id = el.getAttribute('data-agent-id')
+        const p = parse(el)
+        const a = st.agents[id]
+        // x/y are the RENDERED position — the layer the user's eyes see. `moving` is carried for
+        // completeness but the analysis never reads it; a store flag is intent, not truth.
+        if (p && a) agents[id] = { x: p.x, y: p.y, moving: !!a.isMoving, group: !!a.inGroupEvent, beh: a.behavior || null, bub: a.bubble ? 1 : 0 }
+      }
+      samples.push({ t: Date.now() - t0, agents })
+      await new Promise((r) => setTimeout(r, interval))
+    }
+    return { samples, externalStatusKeys: Object.keys(store.getState().externalStatus || {}) }
+  }, { minutes: MINUTES, interval: SAMPLE_INTERVAL_MS })
+
+  // Assume-failure: a contaminated run must not be reported as a measurement of the office.
+  if (out.externalStatusKeys.length > 0) {
+    throw new Error(
+      `run was NOT hermetic — external agent status arrived during sampling (${out.externalStatusKeys.join(', ')}). `
+      + 'Numbers withheld: live hook traffic drives agents into working/blocked and relocates them.',
+    )
+  }
+
+  const report = analyzeRhythm(out.samples)
+  console.log(formatRhythm(report))
+  if (process.env.RHYTHM_REPORT) {
+    writeFileSync(process.env.RHYTHM_REPORT, JSON.stringify({ minutes: MINUTES, ...report }, null, 1))
+    console.log(`office-rhythm: report written to ${process.env.RHYTHM_REPORT}`)
+  }
+} catch (err) {
+  process.stderr.write(`office-rhythm ERROR: ${err.message}\n`)
+  exitCode = 1
+} finally {
+  await cleanup()
+}
+process.exit(exitCode)

--- a/scripts/officeRhythm.mjs
+++ b/scripts/officeRhythm.mjs
@@ -1,0 +1,207 @@
+/**
+ * officeRhythm.mjs — does the office read as ALIVE, or merely BUSY? (pure)
+ *
+ * `soakInvariants` answers "is the office BROKEN" — teleports, stacks, frozen walkers, furniture
+ * clipping. It cannot answer the two judgements the owner actually makes at a glance:
+ * *一直很多人在走動* and *畫面活起來了嗎*. Those live in the DISTRIBUTION of motion over minutes,
+ * not in any single frame, so nothing frame-local can see them.
+ *
+ * Pure and dependency-injected like its siblings (soakInvariants / soakCoverage / soakTarget), so
+ * the analysis itself is unit-testable rather than only observable through a 10-minute browser run.
+ *
+ * samples: [{ t, agents: { [id]: { x, y, moving, group, beh? } } }]   — the sim-soak sample shape.
+ *   x, y  RENDERED position. Motion is measured from these, NEVER from the `moving` store flag:
+ *         a store field is INTENT, and the two disagree (an agent can be nudged while `moving`
+ *         is false, and can claim `moving` while parked). Every number here is what the eye sees.
+ *   beh   optional. Present → stale-label detection runs; absent → that section reports null.
+ *
+ * ── WHY THE INDEPENDENT MODEL MATTERS ────────────────────────────────────────────────────────
+ * A raw stillness percentage cannot be interpreted on its own, because it moves with how much
+ * each agent happens to walk. The useful quantity is stillness RELATIVE to what uncorrelated
+ * agents would produce: an exact Poisson-binomial over each agent's OWN measured motion share.
+ *   observed >> independent  → trips CLUSTER (bursts, then real quiet — reads as rhythm)
+ *   observed << independent  → trips are SPREAD (someone always walking — reads as churn)
+ * Measured on this office 2026-09-02: stillness ran 10.5 and 12.3 points BELOW independence
+ * across two runs, i.e. the concurrency cap defers blocked trips into the gaps that would
+ * otherwise have been quiet. That gap-to-independence is the stable signal; see the caveat below.
+ *
+ * ── THE CAVEAT THAT COST A CONTROL RUN TO LEARN ──────────────────────────────────────────────
+ * The stillness LEVEL is not reproducible from a single run. Two 8-minute runs on identical code
+ * gave 1.4% and 11.8%. The gap to independence was stable (-12.3 / -10.5) while the level was not.
+ * So: quote the GAP from one run; never quote the LEVEL without a paired control run.
+ */
+
+/** Rendered-motion threshold, shared with soakInvariants' REST_STEP_PX so both agree on "at rest". */
+export const REST_STEP_PX = 0.5
+
+/**
+ * A behaviour label that never changes while the agent is NOT in a group event.
+ * Bound empirically rather than guessed: on healthy `main`, event-set behaviours are overwritten
+ * within 2–27s and the longest unchanged label observed across two runs was 74s and 78s —
+ * consistent with the 65s behaviour-duration ceiling plus walk time. A rejected prototype produced
+ * 254s. 90s therefore separates the two populations without flagging anything `main` produces.
+ * Reported, never thrown: this module measures, the caller decides. (backlog AVO-195)
+ */
+export const STALE_LABEL_MS = 90000
+
+const clampId = (agents) => Object.keys(agents || {})
+
+/** Exact Poisson-binomial P(k successes) for independent trials with per-trial probabilities. */
+export function poissonBinomial(probabilities) {
+  let dp = [1]
+  for (const p of probabilities) {
+    const next = new Array(dp.length + 1).fill(0)
+    for (let k = 0; k < dp.length; k++) {
+      next[k] += dp[k] * (1 - p)
+      next[k + 1] += dp[k] * p
+    }
+    dp = next
+  }
+  return dp
+}
+
+/**
+ * @param {Array} samples  sim-soak sample timeline
+ * @param {object} opts    { restPx, staleMs, ids }
+ * @returns {object} rhythm report — all shares are 0..1, all durations in ms
+ */
+export function analyzeRhythm(samples, opts = {}) {
+  const restPx = opts.restPx ?? REST_STEP_PX
+  const staleMs = opts.staleMs ?? STALE_LABEL_MS
+  const ids = opts.ids ?? (samples.length ? clampId(samples[0].agents) : [])
+  const intervals = Math.max(0, samples.length - 1)
+
+  if (intervals === 0 || ids.length === 0) {
+    return {
+      intervals: 0, agents: ids.length, usable: false,
+      motionShare: {}, meanMotionShare: null, motionCV: null,
+      moverHistogram: [], stillness: null, independentStillness: null,
+      stillnessGap: null, crowdShare: null, independentCrowdShare: null,
+      deadFrameShare: null, staleLabels: null,
+    }
+  }
+
+  const moved = (i, id) => {
+    const a = samples[i].agents?.[id]
+    const p = samples[i - 1].agents?.[id]
+    if (!a || !p) return false
+    return Math.hypot(a.x - p.x, a.y - p.y) > restPx
+  }
+
+  // ── per-agent motion share (rendered truth) ──────────────────────────────────────────────
+  const motionShare = {}
+  for (const id of ids) {
+    let m = 0, t = 0
+    for (let i = 1; i < samples.length; i++) {
+      if (!samples[i].agents?.[id] || !samples[i - 1].agents?.[id]) continue
+      t++
+      if (moved(i, id)) m++
+    }
+    motionShare[id] = t > 0 ? m / t : 0
+  }
+  const shares = ids.map((id) => motionShare[id])
+  const mean = shares.reduce((a, b) => a + b, 0) / shares.length
+  const sd = Math.sqrt(shares.reduce((a, b) => a + (b - mean) ** 2, 0) / shares.length)
+  // Concentration: a office where the same two characters do all the walking reads worse than
+  // one where the same total motion rotates around the room, even at identical total motion.
+  const motionCV = mean > 0 ? sd / mean : 0
+
+  // ── concurrent-mover distribution, observed vs independent ───────────────────────────────
+  const hist = new Array(ids.length + 1).fill(0)
+  for (let i = 1; i < samples.length; i++) hist[ids.filter((id) => moved(i, id)).length]++
+  const observed = hist.map((n) => n / intervals)
+  const independent = poissonBinomial(shares)
+  const sumFrom = (arr, k) => arr.slice(k).reduce((a, b) => a + b, 0)
+
+  // ── dead frames: nothing moving, nobody in an event, no bubble, no label change ───────────
+  let dead = 0
+  for (let i = 1; i < samples.length; i++) {
+    let alive = false
+    for (const id of ids) {
+      const a = samples[i].agents?.[id]
+      const p = samples[i - 1].agents?.[id]
+      if (!a) continue
+      if (moved(i, id) || a.group || a.bub || (p && a.beh !== undefined && a.beh !== p.beh)) { alive = true; break }
+    }
+    if (!alive) dead++
+  }
+
+  // ── stale labels (AVO-195): the office narrating an activity the agent left long ago ──────
+  const hasBeh = samples.some((s) => ids.some((id) => s.agents?.[id]?.beh !== undefined))
+  let staleLabels = null
+  if (hasBeh) {
+    staleLabels = []
+    for (const id of ids) {
+      let start = null, prev = null, movedIn = 0
+      const close = (endIdx) => {
+        if (start === null) return
+        const ms = samples[endIdx].t - samples[start].t
+        if (ms >= staleMs) staleLabels.push({ id, behavior: prev, ms, movedSamples: movedIn })
+        start = null; movedIn = 0
+      }
+      for (let i = 1; i < samples.length; i++) {
+        const a = samples[i].agents?.[id]
+        if (!a) { close(i - 1); prev = null; continue }
+        // A group event legitimately owns behaviour for its duration — only ambient time counts.
+        if (a.beh === prev && !a.group) {
+          if (start === null) start = i - 1
+          if (moved(i, id)) movedIn++
+        } else {
+          close(i - 1)
+        }
+        prev = a.beh
+      }
+      close(samples.length - 1)
+    }
+    staleLabels.sort((a, b) => b.ms - a.ms)
+  }
+
+  return {
+    intervals,
+    agents: ids.length,
+    usable: true,
+    motionShare,
+    meanMotionShare: mean,
+    motionCV,
+    moverHistogram: observed,
+    independentHistogram: independent,
+    stillness: observed[0],
+    independentStillness: independent[0],
+    // The headline. Negative = trips spread into the quiet gaps (churn); positive = they cluster.
+    stillnessGap: observed[0] - independent[0],
+    crowdShare: sumFrom(observed, 3),
+    independentCrowdShare: sumFrom(independent, 3),
+    deadFrameShare: dead / intervals,
+    staleLabels,
+  }
+}
+
+const pct = (n) => (n === null || n === undefined ? '  n/a' : `${(100 * n).toFixed(1)}%`)
+
+/** Human-readable report. Deliberately leads with the GAP, not the level — see the caveat above. */
+export function formatRhythm(r) {
+  if (!r.usable) return 'office-rhythm: not enough samples to analyse'
+  const lines = [
+    `office-rhythm: ${r.intervals} intervals, ${r.agents} agents`,
+    `  stillness        ${pct(r.stillness)}  vs independent ${pct(r.independentStillness)}`
+      + `  -> gap ${r.stillnessGap >= 0 ? '+' : ''}${(100 * r.stillnessGap).toFixed(1)} pts`
+      + ` (${r.stillnessGap < -0.03 ? 'trips SPREAD into the quiet gaps' : r.stillnessGap > 0.03 ? 'trips CLUSTER' : 'near-independent'})`,
+    `  >=1 moving       ${pct(1 - r.stillness)}      >=3 moving ${pct(r.crowdShare)} vs independent ${pct(r.independentCrowdShare)}`,
+    `  motion share     mean ${pct(r.meanMotionShare)}   concentration CV ${r.motionCV.toFixed(2)}`,
+    `  dead frames      ${pct(r.deadFrameShare)}`,
+  ]
+  if (r.staleLabels === null) {
+    lines.push('  stale labels     not sampled (no `beh` field in the timeline)')
+  } else if (r.staleLabels.length === 0) {
+    lines.push(`  stale labels     none over ${STALE_LABEL_MS / 1000}s`)
+  } else {
+    lines.push(`  stale labels     ${r.staleLabels.length} over ${STALE_LABEL_MS / 1000}s:`)
+    for (const s of r.staleLabels.slice(0, 5)) {
+      lines.push(`      ${s.id} held '${s.behavior}' for ${(s.ms / 1000).toFixed(0)}s outside any event`
+        + ` (visibly moving in ${s.movedSamples} samples of it)`)
+    }
+  }
+  lines.push('  NOTE: quote the GAP from a single run; the stillness LEVEL needs a paired control run')
+  lines.push('        (two runs on identical code measured 1.4% and 11.8%).')
+  return lines.join('\n')
+}

--- a/scripts/zone-audit.mjs
+++ b/scripts/zone-audit.mjs
@@ -4,6 +4,14 @@
 // Measures per-agent: zone occupancy %, room-visit events (zone change away from home
 // held >=2s), walk events (contiguous moving runs), simultaneous-walker screen share.
 // Pass --organic to shelve the live status files (untracked idle office) first.
+//
+// WARNING on --organic: it isolates the run by RENAMING the operator's real
+// ~/.claude/office-status*.json to *.za-bak and restoring them in an exit handler. A hard kill
+// (taskkill /f, a crash, a closed terminal) skips that handler and leaves the operator's office
+// status silently shelved. `npm run rhythm` (scripts/office-rhythm.mjs) isolates the SAFE way
+// instead -- it spawns its own dev server pointed at an empty OFFICE_STATUS_DIR and touches
+// nothing of yours -- and additionally reports the independent-model gap and stale-label
+// detection this script does not. Prefer it; --organic is kept only for reusing a live :5173.
 import { chromium } from 'playwright-core'
 import { readdirSync, renameSync, existsSync } from 'node:fs'
 import os from 'node:os'
@@ -12,6 +20,9 @@ import path from 'node:path'
 const ORGANIC = process.argv.includes('--organic')
 const moved = []
 if (ORGANIC) {
+  console.warn('zone-audit WARNING: --organic renames your real ~/.claude/office-status*.json and'
+    + ' restores them only on a clean exit. A hard kill leaves them shelved as *.za-bak.'
+    + ' `npm run rhythm` isolates without touching your files.')
   const claudeDir = path.join(os.homedir(), '.claude')
   for (const f of readdirSync(claudeDir)) {
     if (/^office-status(-[^.]+)?\.json$/.test(f)) {

--- a/tests/officeRhythm.test.js
+++ b/tests/officeRhythm.test.js
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeRhythm, poissonBinomial, formatRhythm,
+  REST_STEP_PX, STALE_LABEL_MS,
+} from '../scripts/officeRhythm.mjs'
+
+const INTERVAL = 250
+
+/**
+ * Build a timeline from a per-agent motion PATTERN string: '#' = moved this interval, '.' = still.
+ * Position is the only motion source (the module must never read the `moving` store flag), so the
+ * pattern is realised as real pixel deltas.
+ */
+function timeline(patterns, { beh = {}, group = {} } = {}) {
+  const ids = Object.keys(patterns)
+  const len = patterns[ids[0]].length
+  const x = Object.fromEntries(ids.map((id) => [id, 100]))
+  const samples = [{ t: 0, agents: Object.fromEntries(ids.map((id) => [id, { x: x[id], y: 50, moving: false, group: false, ...(beh[id] ? { beh: beh[id][0] } : {}) }])) }]
+  for (let i = 0; i < len; i++) {
+    const agents = {}
+    for (const id of ids) {
+      if (patterns[id][i] === '#') x[id] += 10
+      agents[id] = {
+        x: x[id], y: 50,
+        moving: false,                       // deliberately WRONG — nothing may read it
+        group: !!(group[id] && group[id][i] === 'G'),
+        ...(beh[id] ? { beh: beh[id][i + 1] ?? beh[id][beh[id].length - 1] } : {}),
+      }
+    }
+    samples.push({ t: (i + 1) * INTERVAL, agents })
+  }
+  return samples
+}
+
+describe('poissonBinomial', () => {
+  it('reduces to the binomial when every probability is equal', () => {
+    // n=3, p=0.5 -> 1/8, 3/8, 3/8, 1/8
+    const d = poissonBinomial([0.5, 0.5, 0.5])
+    expect(d.map((v) => +v.toFixed(6))).toEqual([0.125, 0.375, 0.375, 0.125])
+  })
+
+  it('handles unequal probabilities and always sums to 1', () => {
+    const d = poissonBinomial([0.1, 0.9, 0.35, 0.6])
+    expect(d.reduce((a, b) => a + b, 0)).toBeCloseTo(1, 10)
+    expect(d).toHaveLength(5)
+  })
+
+  it('is exact for the degenerate cases', () => {
+    expect(poissonBinomial([])).toEqual([1])
+    expect(poissonBinomial([0, 0])).toEqual([1, 0, 0])
+    expect(poissonBinomial([1, 1])).toEqual([0, 0, 1])
+  })
+})
+
+describe('analyzeRhythm — motion is read from rendered position, never the store flag', () => {
+  it('measures motion from pixel deltas even when `moving` says otherwise', () => {
+    // Every sample carries moving:false. If the module ever trusted it, this would read 0%.
+    const r = analyzeRhythm(timeline({ a: '####....', b: '........' }))
+    expect(r.motionShare.a).toBeCloseTo(0.5, 6)
+    expect(r.motionShare.b).toBe(0)
+  })
+
+  it('ignores sub-threshold jitter', () => {
+    const samples = [
+      { t: 0, agents: { a: { x: 100, y: 50 } } },
+      { t: 250, agents: { a: { x: 100 + REST_STEP_PX * 0.5, y: 50 } } },
+    ]
+    expect(analyzeRhythm(samples).motionShare.a).toBe(0)
+  })
+})
+
+describe('analyzeRhythm — the stillness gap is the point', () => {
+  it('reports a NEGATIVE gap when trips are spread so someone is always walking', () => {
+    // Perfectly anti-correlated: exactly one of the two always moves. Never still, though two
+    // independent agents at 50% each would be still 25% of the time.
+    const r = analyzeRhythm(timeline({ a: '#.#.#.#.', b: '.#.#.#.#' }))
+    expect(r.stillness).toBe(0)
+    expect(r.independentStillness).toBeCloseTo(0.25, 6)
+    expect(r.stillnessGap).toBeCloseTo(-0.25, 6)
+    expect(formatRhythm(r)).toContain('trips SPREAD into the quiet gaps')
+  })
+
+  it('reports a POSITIVE gap when trips cluster into bursts', () => {
+    // Perfectly correlated: both move together, then both rest. Same per-agent share as above.
+    const r = analyzeRhythm(timeline({ a: '##..##..', b: '##..##..' }))
+    expect(r.stillness).toBeCloseTo(0.5, 6)
+    expect(r.independentStillness).toBeCloseTo(0.25, 6)
+    expect(r.stillnessGap).toBeCloseTo(0.25, 6)
+    expect(formatRhythm(r)).toContain('trips CLUSTER')
+  })
+
+  it('the two cases above have IDENTICAL per-agent motion — only the distribution differs', () => {
+    const spread = analyzeRhythm(timeline({ a: '#.#.#.#.', b: '.#.#.#.#' }))
+    const burst = analyzeRhythm(timeline({ a: '##..##..', b: '##..##..' }))
+    expect(spread.meanMotionShare).toBeCloseTo(burst.meanMotionShare, 6)
+    // ...which is exactly why a rate metric cannot tell churn from rhythm and this one can.
+    expect(spread.stillnessGap).toBeLessThan(burst.stillnessGap)
+  })
+})
+
+describe('analyzeRhythm — motion concentration', () => {
+  it('CV is 0 when every agent walks the same amount', () => {
+    expect(analyzeRhythm(timeline({ a: '##..', b: '##..', c: '##..' })).motionCV).toBeCloseTo(0, 6)
+  })
+
+  it('CV rises when the same character does all the walking', () => {
+    const even = analyzeRhythm(timeline({ a: '##..', b: '##..', c: '##..' }))
+    const concentrated = analyzeRhythm(timeline({ a: '####', b: '....', c: '....' }))
+    expect(concentrated.motionCV).toBeGreaterThan(even.motionCV)
+  })
+})
+
+describe('analyzeRhythm — stale behaviour labels (AVO-195)', () => {
+  const longPattern = '.'.repeat(600)          // 600 intervals = 150s at 250ms
+
+  it('flags a label held past the threshold outside any group event', () => {
+    const r = analyzeRhythm(timeline({ a: longPattern }, { beh: { a: 'x'.repeat(601).split('').map(() => 'eat-snack') } }))
+    expect(r.staleLabels).toHaveLength(1)
+    expect(r.staleLabels[0]).toMatchObject({ id: 'a', behavior: 'eat-snack' })
+    expect(r.staleLabels[0].ms).toBeGreaterThanOrEqual(STALE_LABEL_MS)
+  })
+
+  it('does NOT flag the same duration while the agent is in a group event', () => {
+    // officeLife legitimately owns behaviour for an event's whole duration.
+    const r = analyzeRhythm(timeline(
+      { a: longPattern },
+      { beh: { a: Array(601).fill('meeting') }, group: { a: 'G'.repeat(600) } },
+    ))
+    expect(r.staleLabels).toHaveLength(0)
+  })
+
+  it('does not flag a healthy cycle that changes well inside the threshold', () => {
+    // 74-78s was the worst observed on healthy main; 60s must stay clean.
+    const half = Array(120).fill('typing')     // 30s
+    const other = Array(120).fill('reading-screen')
+    const beh = { a: [...half, ...other, ...half, ...other] }
+    const r = analyzeRhythm(timeline({ a: '.'.repeat(beh.a.length - 1) }, { beh }))
+    expect(r.staleLabels).toHaveLength(0)
+  })
+
+  it('records how much the agent VISIBLY MOVED while the label sat still', () => {
+    // This is what separated "the scheduler froze" from "the label is stale" during the
+    // investigation: the frozen reading was refuted by 260-551px of movement.
+    const beh = { a: Array(601).fill('eat-snack') }
+    const r = analyzeRhythm(timeline({ a: '#'.repeat(600) }, { beh }))
+    expect(r.staleLabels[0].movedSamples).toBeGreaterThan(0)
+  })
+
+  it('reports null rather than zero when the timeline carries no behaviour field', () => {
+    // "No stale labels found" and "I never looked" must not render identically.
+    const r = analyzeRhythm(timeline({ a: '##..' }))
+    expect(r.staleLabels).toBeNull()
+    expect(formatRhythm(r)).toContain('not sampled')
+  })
+})
+
+describe('analyzeRhythm — degenerate input', () => {
+  it('reports unusable rather than dividing by zero', () => {
+    expect(analyzeRhythm([]).usable).toBe(false)
+    expect(analyzeRhythm([{ t: 0, agents: {} }]).usable).toBe(false)
+    expect(formatRhythm(analyzeRhythm([]))).toContain('not enough samples')
+  })
+})
+
+describe('formatRhythm', () => {
+  it('always carries the control-run caveat, because the level is not reproducible', () => {
+    const out = formatRhythm(analyzeRhythm(timeline({ a: '##..', b: '..##' })))
+    expect(out).toContain('paired control run')
+    expect(out).toContain('1.4% and 11.8%')
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -33,6 +33,19 @@ import { scanAndMerge, getSessionStats, resolveProjectRoot } from './src/server/
 // `configureServer` ONLY, so it does not run for `vite build` / `vite preview` / the packaged
 // serve path, and this file is Node build tooling that is never bundled into the browser payload.
 const STATUS_DIR = process.env.OFFICE_STATUS_DIR || path.join(os.homedir(), '.claude')
+
+// OFFICE_DISABLE_FILE_WATCHER=1 turns off the file-watcher fallback below. OFFICE_STATUS_DIR alone
+// does NOT make a measurement run hermetic: the watcher manufactures agent status from edits to the
+// PROJECT ITSELF and writes it into whatever STATUS_DIR is pointed at, isolated or not. So a soak or
+// rhythm run measured while anyone edits a served file is reading its own operator back. Caught for
+// real: a hermetic-by-OFFICE_STATUS_DIR rhythm run aborted with `external agent status arrived
+// (dev, res)` because tests and docs were being edited while it sampled.
+//
+// Same blast radius as OFFICE_STATUS_DIR: this file is Node build tooling that is never bundled,
+// and the watcher is registered under `configureServer` ONLY, so it cannot reach `vite build` /
+// `vite preview` / the packaged serve path. It adds no fabrication capability -- it only removes a
+// source of it.
+const FILE_WATCHER_DISABLED = process.env.OFFICE_DISABLE_FILE_WATCHER === '1'
 const STATUS_PATH = path.join(STATUS_DIR, 'office-status.json')
 
 // The project directory session files are matched against. Vite's own cwd is the package
@@ -723,6 +736,8 @@ function fileWatcherFallbackPlugin() {
   return {
     name: 'office-file-watcher-fallback',
     configureServer(server) {
+      // Measurement runs opt out entirely: see OFFICE_DISABLE_FILE_WATCHER above.
+      if (FILE_WATCHER_DISABLED) return
       // Watch project source files for changes (Vite's watcher covers src/)
       const onFallbackChange = (file) => {
         // Skip node_modules, dist, .git, and the status file itself


### PR DESCRIPTION
Everything that made this session's rhythm conclusions possible lived in a **scratch directory**: the independent model, the stale-label detector, the hermetic sampling. Only the soak's `OFFICE_STATUS_DIR` fix ([#221](https://github.com/KbWen/agent-virtual-office/pull/221)) had reached the repo. The analysis — the half that is actually hard — would have been lost. This graduates it.

## Prior art was checked before anything was added

`zone-audit.mjs` already samples rendered transforms and reports simultaneous-walker share, so this does **not** duplicate it. What is new:

**1. The exact Poisson-binomial independent model.** A stillness percentage cannot be interpreted on its own, because it moves with how much each agent happens to walk. The useful quantity is stillness *relative to uncorrelated agents*:

| | reading |
|---|---|
| observed **below** independent | trips are **SPREAD** — someone is always walking → churn |
| observed **above** independent | trips **CLUSTER** — bursts and real quiet → rhythm |

Two timelines with *identical* per-agent motion can sit at opposite ends. That is why no rate metric can tell the two apart and this one can — there is a test on exactly that pair.

**2. Stale-label detection** (backlog AVO-195): the office narrating an activity an agent left minutes ago. Threshold bound empirically rather than guessed — healthy `main` clears event-set behaviours in 2–27s with a 74–78s worst case, a rejected prototype produced 254s, so **90s** separates the populations.

**3. Isolation that does not touch your files.** `zone-audit --organic` isolates by **renaming your real `~/.claude/office-status*.json`** and restoring them in an exit handler; a hard kill strands them. That hazard is now warned at runtime and in the README, pointing at the safe path rather than silently competing with it.

## The hermeticity claim was wrong, and the tool caught it on its first real run

`OFFICE_STATUS_DIR` alone is **not enough**. `vite.config.js` registers a file-watcher fallback that manufactures agent status from edits to the **project itself** and writes it into whatever status dir it was given — isolated or not.

Run 1 aborted with `external agent status arrived during sampling (dev, res)` because tests and docs were being edited beside it.

`OFFICE_DISABLE_FILE_WATCHER=1` is added with the same blast radius as its `OFFICE_STATUS_DIR` precedent — `configureServer` only, so it can never reach a built or packaged office — and it *removes* a source of fabrication rather than adding one.

> This makes **#221's isolation claim incomplete**. It is corrected on that branch rather than left to ship as written.

## Reports, never gates

A rhythm threshold is a product judgement, not a correctness one, and the level is not reproducible enough to gate on. `sim-soak` remains the correctness gate. Exit 1 means *"could not measure"*, never a verdict on the office.

## Tests

- `npx vitest run` — **2336 passed / 117 files / 0 failed** (baseline 2319, +17).
- **Mutation-verified in two directions**: swapping the pixel-delta motion test for the `moving` store flag fails **six** tests, so the rendered-truth discipline is *enforced* rather than merely commented; removing the group-event guard from stale detection fails its exemption test.
- `npm run build` PASS; `bundle-budget` PASS at 495983 vs baseline 496504 (**-0.10%**).

Run 2 — clean, both isolations, nothing edited during sampling:

```
office-rhythm: 705 intervals, 8 agents
  stillness        13.8%  vs independent 24.2%  -> gap -10.4 pts (trips SPREAD into the quiet gaps)
  >=1 moving       86.2%      >=3 moving 0.4% vs independent 10.4%
  motion share     mean 15.5%   concentration CV 0.68
  dead frames       0.3%
  stale labels     none over 90s
```

That is a **third independent reproduction** of this session's core finding. Across three hermetic runs on unmodified `main`:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| stillness **gap** | −10.5 | −12.3 | −10.4 |
| stillness **level** | 11.8% | 1.4% | 13.8% |

The gap reproduces and the level does not — precisely the caveat the tool prints, now demonstrated rather than asserted, and pinned by a test so it cannot be quietly dropped from the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
